### PR TITLE
Support for workflow mode

### DIFF
--- a/dhcp.go
+++ b/dhcp.go
@@ -3,10 +3,10 @@ package main
 import (
 	"flag"
 
-	"github.com/tinkerbell/boots/env"
-	"github.com/tinkerbell/boots/job"
 	dhcp4 "github.com/packethost/dhcp4-go"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/env"
+	"github.com/tinkerbell/boots/job"
 
 	"github.com/avast/retry-go"
 )
@@ -71,8 +71,6 @@ func getCircuitID(req *dhcp4.Packet) (string, error) {
 		} else {
 			return circuitID, errors.New("option82 option1 out of bounds (check eightytwo[1])")
 		}
-	} else {
-		return circuitID, errors.New("option82 information not available for this mac")
 	}
 	return circuitID, nil
 }

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -3,7 +3,6 @@ package osie
 import (
 	"strings"
 
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
 )
@@ -12,8 +11,6 @@ func init() {
 	job.RegisterDefaultInstaller(bootScripts["install"])
 	job.RegisterDistro("alpine", bootScripts["rescue"])
 }
-
-var logger log.Logger
 
 var bootScripts = map[string]func(job.Job, *ipxe.Script){
 	"rescue": func(j job.Job, s *ipxe.Script) {
@@ -39,7 +36,6 @@ var bootScripts = map[string]func(job.Job, *ipxe.Script){
 }
 
 func bootScript(action string, j job.Job, s *ipxe.Script) {
-	logger = j.Logger
 	s.Set("arch", j.Arch())
 	s.Set("parch", j.PArch())
 	s.Set("bootdevmac", j.PrimaryNIC().String())

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -25,7 +25,11 @@ var bootScripts = map[string]func(job.Job, *ipxe.Script){
 			typ = "deprovisioning.304.1"
 		}
 		s.PhoneHome(typ)
-		s.Set("action", "install")
+		if canWorkflow(j) {
+			s.Set("action", "workflow")
+		} else {
+			s.Set("action", "install")
+		}
 		s.Set("state", j.HardwareState())
 		bootScript("install", j, s)
 	},
@@ -59,9 +63,23 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 	s.Args("parch=${parch}")
 	s.Args("packet_action=${action}")
 	s.Args("packet_state=${state}")
+
 	if isCustomOsie(j) {
 		s.Args("packet_base_url=" + osieBaseUrl(j))
 	}
+
+	if canWorkflow(j) {
+		buildWorkerParams()
+		s.Args("docker_registry=" + dockerRegistry)
+		s.Args("grpc_authority=" + grpcAuthority)
+		s.Args("grpc_cert_url=" + grpcCertURL)
+		s.Args("registry_username=" + registryUsername)
+		s.Args("registry_password=" + registryPassword)
+		s.Args("elastic_search_url=" + elasticSearchURL)
+		s.Args("packet_base_url=" + workflowBaseURL())
+		s.Args("worker_id=" + j.HardwareID())
+	}
+
 	s.Args("packet_bootdev_mac=${bootdevmac}")
 	s.Args("facility=" + j.FacilityCode())
 
@@ -136,4 +154,12 @@ func osieBaseUrl(j job.Job) string {
 		return osieURL + "/" + j.ServicesVersion().Osie
 	}
 	return osieURL + "/current"
+}
+
+func workflowBaseURL() string {
+	return mirrorBaseURL + "/workflow"
+}
+
+func canWorkflow(j job.Job) bool {
+	return j.CanWorkflow()
 }

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/env"
+	"github.com/tinkerbell/boots/installers"
 )
 
 const (
@@ -60,7 +61,7 @@ func buildWorkerParams() {
 func getParam(key string) string {
 	value := os.Getenv(key)
 	if value == "" {
-		logger.Fatal(errors.New("invalid" + key))
+		installers.Logger("osie").Fatal(errors.New("invalid" + key))
 	}
 	return value
 }

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -1,7 +1,6 @@
 package osie
 
 import (
-	"log"
 	"net/url"
 	"os"
 
@@ -61,7 +60,7 @@ func buildWorkerParams() {
 func getParam(key string) string {
 	value := os.Getenv(key)
 	if value == "" {
-		log.Fatal(errors.New("invalid" + key))
+		logger.Fatal(errors.New("invalid" + key))
 	}
 	return value
 }

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -1,11 +1,12 @@
 package osie
 
 import (
+	"log"
 	"net/url"
 	"os"
 
-	"github.com/tinkerbell/boots/env"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/env"
 )
 
 const (
@@ -13,7 +14,12 @@ const (
 )
 
 var (
-	osieURL = mustBuildOsieURL().String()
+	osieURL                            = mustBuildOsieURL().String()
+	mirrorBaseURL                      = env.MirrorBaseUrl
+	dockerRegistry                     string
+	grpcAuthority, grpcCertURL         string
+	registryUsername, registryPassword string
+	elasticSearchURL                   string
 )
 
 func buildOsieURL() (*url.URL, error) {
@@ -41,4 +47,21 @@ func mustBuildOsieURL() *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+func buildWorkerParams() {
+	dockerRegistry = getParam("DOCKER_REGISTRY")
+	grpcAuthority = getParam("TINKERBELL_GRPC_AUTHORITY")
+	grpcCertURL = getParam("TINKERBELL_CERT_URL")
+	registryUsername = getParam("REGISTRY_USERNAME")
+	registryPassword = getParam("REGISTRY_PASSWORD")
+	elasticSearchURL = getParam("ELASTIC_SEARCH_URL")
+}
+
+func getParam(key string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		log.Fatal(errors.New("invalid" + key))
+	}
+	return value
 }

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -61,7 +61,7 @@ func buildWorkerParams() {
 func getParam(key string) string {
 	value := os.Getenv(key)
 	if value == "" {
-		installers.Logger("osie").Fatal(errors.New("invalid" + key))
+		installers.Logger("osie").With("key", key).Fatal(errors.New("invalid key"))
 	}
 	return value
 }

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -191,3 +191,8 @@ func (j Job) ServicesVersion() packet.ServicesVersion {
 	}
 	return packet.ServicesVersion{}
 }
+
+// CanWorkflow checks if workflow is allowed
+func (j Job) CanWorkflow() bool {
+	return j.hardware.AllowWorkflow
+}

--- a/packet/models.go
+++ b/packet/models.go
@@ -249,6 +249,7 @@ type Hardware struct {
 	PrivateSubnets  []string        `json:"private_subnets,omitempty"`
 	UEFI            bool            `json:"efi_boot"`
 	AllowPXE        bool            `json:"allow_pxe"`
+	AllowWorkflow   bool            `json:"allow_workflow"`
 	ServicesVersion ServicesVersion `json:"services"`
 
 	Instance *Instance `json:"instance"`


### PR DESCRIPTION
At present, the default action is `install`. Therefore, for the time being, a user must set the `allow_workflow: true` to bootstrap a worker in workflow mode.

In the near future, this will not be required as every worker will by default boot into a workflow.