### PR TITLE
Updated git-lfs instructions link for Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This services handles DHCP, PXE, tftp, and iPXE for provisions.
 
 ### Local Setup
 
-First, you need to make sure you have [git-lfs](https://git-lfs.github.com/) installed:
+First, you need to make sure you have [git-lfs](https://github.com/git-lfs/git-lfs/wiki/Installation) installed:
 
 ```
 git lfs install


### PR DESCRIPTION
I have updated the `git-lfs` link. However, we will probably be moving away from `git-lfs` to AWS S3 or something similar.

Signed-off-by: Gaurav Gahlot <gaurav.gahlot19@gmail.com>