### PR TITLE
Fix imports sort order

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,7 @@ pipeline:
     image: golang:1.13-alpine
     commands:
       - apk add --update --upgrade --no-cache git
+      - go get golang.org/x/tools/cmd/goimports
       - goimports -d . | (! grep .)
 
   test:

--- a/files/ignition/networkd.go
+++ b/files/ignition/networkd.go
@@ -3,8 +3,8 @@ package ignition
 import (
 	"encoding/json"
 
-	"github.com/tinkerbell/boots/files/unit"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/files/unit"
 )
 
 type NetworkUnits []*unit.Unit

--- a/files/ignition/systemd.go
+++ b/files/ignition/systemd.go
@@ -3,8 +3,8 @@ package ignition
 import (
 	"encoding/json"
 
-	"github.com/tinkerbell/boots/files/unit"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/files/unit"
 )
 
 type SystemdUnit struct {

--- a/http.go
+++ b/http.go
@@ -12,12 +12,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tinkerbell/boots/env"
-	"github.com/tinkerbell/boots/httplog"
-	"github.com/tinkerbell/boots/job"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sebest/xff"
+	"github.com/tinkerbell/boots/env"
+	"github.com/tinkerbell/boots/httplog"
+	"github.com/tinkerbell/boots/job"
 )
 
 var (

--- a/installers/coreos/installer_test.go
+++ b/installers/coreos/installer_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/tinkerbell/boots/files/ignition"
 	"github.com/tinkerbell/boots/job"
-	"github.com/stretchr/testify/require"
 )
 
 func assertLines(t *testing.T, m job.Mock, execLines []string) {

--- a/installers/coreos/main_test.go
+++ b/installers/coreos/main_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
+	l "github.com/packethost/pkg/log"
 	"github.com/tinkerbell/boots/installers"
 	"github.com/tinkerbell/boots/job"
-	l "github.com/packethost/pkg/log"
 )
 
 func TestMain(m *testing.M) {

--- a/installers/custom_ipxe/main_test.go
+++ b/installers/custom_ipxe/main_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tinkerbell/boots/job"
 	l "github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/job"
 )
 
 func TestMain(m *testing.M) {

--- a/installers/nixos/main.go
+++ b/installers/nixos/main.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
-	"github.com/pkg/errors"
 )
 
 func buildInitPaths() map[string]string {

--- a/installers/nixos/main_test.go
+++ b/installers/nixos/main_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tinkerbell/boots/job"
 	l "github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/job"
 )
 
 func TestMain(m *testing.M) {

--- a/installers/osie/main_test.go
+++ b/installers/osie/main_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tinkerbell/boots/job"
 	l "github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/job"
 )
 
 func TestMain(m *testing.M) {

--- a/installers/rancher/main_test.go
+++ b/installers/rancher/main_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/tinkerbell/boots/job"
 	l "github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/job"
 )
 
 func TestMain(m *testing.M) {

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"text/template"
 
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/installers"
 	"github.com/tinkerbell/boots/job"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
+	"github.com/stretchr/testify/require"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/job"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDetermineDisk(t *testing.T) {

--- a/installers/vmware/main_test.go
+++ b/installers/vmware/main_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
+	l "github.com/packethost/pkg/log"
 	"github.com/tinkerbell/boots/installers"
 	"github.com/tinkerbell/boots/job"
-	l "github.com/packethost/pkg/log"
 )
 
 func TestMain(m *testing.M) {

--- a/ipxe/dhcp_options.go
+++ b/ipxe/dhcp_options.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/tinkerbell/boots/env"
 	dhcp4 "github.com/packethost/dhcp4-go"
+	"github.com/tinkerbell/boots/env"
 )
 
 const (

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -3,12 +3,12 @@ package job
 import (
 	"strings"
 
+	dhcp4 "github.com/packethost/dhcp4-go"
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/dhcp"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/packet"
-	dhcp4 "github.com/packethost/dhcp4-go"
-	"github.com/pkg/errors"
 )
 
 func IsSpecialOS(i *packet.Instance) bool {

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
+	dhcp4 "github.com/packethost/dhcp4-go"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/packet"
-	dhcp4 "github.com/packethost/dhcp4-go"
 )
 
 func TestSetPXEFilename(t *testing.T) {

--- a/job/events.go
+++ b/job/events.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/tinkerbell/boots/packet"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/packet"
 )
 
 func (j Job) CustomPXEDone() {

--- a/job/ipxe.go
+++ b/job/ipxe.go
@@ -3,9 +3,9 @@ package job
 import (
 	"net/http"
 
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/ipxe"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/job/job.go
+++ b/job/job.go
@@ -4,11 +4,11 @@ import (
 	"net"
 	"time"
 
+	"github.com/packethost/pkg/log"
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/dhcp"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/packet"
-	"github.com/packethost/pkg/log"
-	"github.com/pkg/errors"
 )
 
 var client *packet.Client

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/boots/httplog"
 	"github.com/tinkerbell/boots/packet"
-	"github.com/packethost/pkg/log"
 )
 
 func TestMain(m *testing.M) {

--- a/job/mock.go
+++ b/job/mock.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/tinkerbell/boots/packet"
 	"github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/packet"
 	"go.uber.org/zap/zaptest"
 )
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"time"
 
+	"github.com/packethost/pkg/log"
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/dhcp"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/httplog"
@@ -12,8 +14,6 @@ import (
 	"github.com/tinkerbell/boots/packet"
 	"github.com/tinkerbell/boots/syslog"
 	"github.com/tinkerbell/boots/tftp"
-	"github.com/packethost/pkg/log"
-	"github.com/pkg/errors"
 
 	_ "github.com/tinkerbell/boots/installers/coreos"
 	_ "github.com/tinkerbell/boots/installers/custom_ipxe"

--- a/packet/client.go
+++ b/packet/client.go
@@ -9,10 +9,10 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/tinkerbell/boots/httplog"
 	"github.com/packethost/cacher/client"
 	"github.com/packethost/cacher/protos/cacher"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/httplog"
 	"google.golang.org/grpc"
 )
 

--- a/syslog/receiver.go
+++ b/syslog/receiver.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tinkerbell/boots/env"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/env"
 )
 
 var (

--- a/tftp.go
+++ b/tftp.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/avast/retry-go"
 	tftp "github.com/betawaffle/tftp-go"
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/env"
 	"github.com/tinkerbell/boots/job"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -7,9 +7,9 @@ import (
 	"path"
 	"time"
 
-	"github.com/tinkerbell/boots/ipxe"
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/ipxe"
 )
 
 var tftpFiles = map[string][]byte{


### PR DESCRIPTION
And fix CI test for it. goimports is no longer installed by default, we
didn't catch it because of the `|` and not having `set -u pipefail`