### PR TITLE
Support for new hardware data model

### DIFF
--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -69,7 +69,7 @@ func (j Job) configureDHCP(rep, req *dhcp4.Packet) bool {
 }
 
 func (j Job) isPXEAllowed() bool {
-	if j.hardware.AllowPXE {
+	if (*j.hardware).HardwareAllowPXE() {
 		return true
 	}
 	if j.InstanceID() == "" {

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -51,19 +51,21 @@ func TestSetPXEFilename(t *testing.T) {
 	}
 
 	for i, tt := range setPXEFilenameTests {
-		t.Logf("index=%d hStahe=%q id=%q iState=%q slug=%q plan=%q allowPXE=%v packet=%v arm=%v uefi=%v filename=%q",
+		t.Logf("index=%d hState=%q id=%q iState=%q slug=%q plan=%q allowPXE=%v packet=%v arm=%v uefi=%v filename=%q",
 			i, tt.hState, tt.id, tt.iState, tt.slug, tt.plan, tt.allowPXE, tt.packet, tt.arm, tt.uefi, tt.filename)
 
 		if tt.plan == "" {
 			tt.plan = "0"
 		}
+
+		var hardware packet.Hardware = &packet.HardwareCacher{
+			ID:       "$hardware_id",
+			State:    packet.HardwareState(tt.hState),
+			PlanSlug: "baremetal_" + tt.plan,
+		}
 		j := Job{
-			Logger: joblog.With("index", i, "hStahe", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
-			hardware: &packet.Hardware{
-				ID:       "$hardware_id",
-				State:    packet.HardwareState(tt.hState),
-				PlanSlug: "baremetal_" + tt.plan,
-			},
+			Logger:   joblog.With("index", i, "hStahe", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
+			hardware: &hardware,
 			instance: &packet.Instance{
 				ID:       tt.id,
 				State:    packet.InstanceState(tt.iState),
@@ -97,10 +99,11 @@ func TestAllowPXE(t *testing.T) {
 	} {
 		t.Logf("want=%t, hardware=%t, instance=%t, instance_id=%s",
 			tt.want, tt.hw, tt.instance, tt.iid)
+		var hardware packet.Hardware = packet.HardwareCacher{
+			AllowPXE: tt.hw,
+		}
 		j := Job{
-			hardware: &packet.Hardware{
-				AllowPXE: tt.hw,
-			},
+			hardware: &hardware,
 			instance: &packet.Instance{
 				ID:       tt.iid,
 				AllowPXE: tt.instance,

--- a/job/events.go
+++ b/job/events.go
@@ -54,7 +54,7 @@ func (j Job) PostHardwareProblem(slug string) bool {
 		j.With("problem", slug).Error(errors.WithMessage(err, "encoding hardware problem request"))
 		return false
 	}
-	if _, err := client.PostHardwareProblem(j.hardware.ID, bytes.NewReader(b)); err != nil {
+	if _, err := client.PostHardwareProblem((*j.hardware).HardwareID(), bytes.NewReader(b)); err != nil {
 		j.With("problem", slug).Error(errors.WithMessage(err, "posting hardware problem"))
 		return false
 	}
@@ -94,7 +94,7 @@ func (j Job) phoneHome(body []byte) bool {
 			j.With("state", j.HardwareState()).Info("ignoring hardware phone-home when state is not preinstalling")
 			return false
 		}
-		id = j.hardware.ID
+		id = (*j.hardware).HardwareID()
 		typ = "hardware"
 		post = p.postHardware
 	}
@@ -138,25 +138,24 @@ func (j Job) postEvent(kind, body string, private bool) bool {
 	return true
 }
 
-// golangci-lint: unused
-//func (j Job) postFailure(reason string) bool {
-//	f := failure{
-//		Reason: reason,
-//	}
-//
-//	if j.InstanceID() != "" {
-//		if err := f.postInstance(j.instance.ID); err != nil {
-//			j.Error(errors.WithMessage(err, "posting instance failure"))
-//			return false
-//		}
-//	} else {
-//		if err := f.postHardware(j.hardware.ID); err != nil {
-//			j.Error(errors.WithMessage(err, "posting hardware failure"))
-//			return false
-//		}
-//	}
-//	return true
-//}
+func (j Job) postFailure(reason string) bool {
+	f := failure{
+		Reason: reason,
+	}
+
+	if j.InstanceID() != "" {
+		if err := f.postInstance(j.instance.ID); err != nil {
+			j.Error(errors.WithMessage(err, "posting instance failure"))
+			return false
+		}
+	} else {
+		if err := f.postHardware((*j.hardware).HardwareID()); err != nil {
+			j.Error(errors.WithMessage(err, "posting hardware failure"))
+			return false
+		}
+	}
+	return true
+}
 
 func posterFromJSON(b []byte) (poster, error) {
 	if len(b) == 0 {

--- a/job/events.go
+++ b/job/events.go
@@ -138,24 +138,25 @@ func (j Job) postEvent(kind, body string, private bool) bool {
 	return true
 }
 
-func (j Job) postFailure(reason string) bool {
-	f := failure{
-		Reason: reason,
-	}
+// unused, but keeping for now
+// func (j Job) postFailure(reason string) bool {
+// 	f := failure{
+// 		Reason: reason,
+// 	}
 
-	if j.InstanceID() != "" {
-		if err := f.postInstance(j.instance.ID); err != nil {
-			j.Error(errors.WithMessage(err, "posting instance failure"))
-			return false
-		}
-	} else {
-		if err := f.postHardware((*j.hardware).HardwareID()); err != nil {
-			j.Error(errors.WithMessage(err, "posting hardware failure"))
-			return false
-		}
-	}
-	return true
-}
+// 	if j.InstanceID() != "" {
+// 		if err := f.postInstance(j.instance.ID); err != nil {
+// 			j.Error(errors.WithMessage(err, "posting instance failure"))
+// 			return false
+// 		}
+// 	} else {
+// 		if err := f.postHardware((*j.hardware).HardwareID()); err != nil {
+// 			j.Error(errors.WithMessage(err, "posting hardware failure"))
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
 
 func posterFromJSON(b []byte) (poster, error) {
 	if len(b) == 0 {

--- a/job/events_test.go
+++ b/job/events_test.go
@@ -42,14 +42,14 @@ func TestPhoneHome(t *testing.T) {
 		fmt.Println("test:", name)
 		t.Log("test:", name)
 		reqs = nil
-
+		var hardware packet.Hardware = packet.HardwareCacher{
+			ID:    "$hardware_id",
+			State: packet.HardwareState(test.state),
+		}
 		j := Job{
-			Logger: joblog.With("test", name),
-			mode:   modeInstance,
-			hardware: &packet.Hardware{
-				ID:    "$hardware_id",
-				State: packet.HardwareState(test.state),
-			},
+			Logger:   joblog.With("test", name),
+			mode:     modeInstance,
+			hardware: &hardware,
 			instance: &packet.Instance{
 				ID: test.id,
 				OS: packet.OperatingSystem{

--- a/job/hardware.go
+++ b/job/hardware.go
@@ -47,7 +47,7 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if _, err := client.PostHardwareComponent(j.hardware.ID, bytes.NewReader(jsonBody)); err != nil {
+	if _, err := client.PostHardwareComponent((*j.hardware).HardwareID(), bytes.NewReader(jsonBody)); err != nil {
 		joblog.Error(errors.Wrap(err, "posting componenents"))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"bytes"
 	"net"
 
 	"github.com/tinkerbell/boots/packet"
@@ -18,14 +19,14 @@ func (j Job) IsARM() bool {
 
 func (j Job) IsUEFI() bool {
 	if h := j.hardware; h != nil {
-		return h.UEFI
+		return (*h).HardwareUEFI()
 	}
 	return false
 }
 
 func (j Job) Arch() string {
 	if h := j.hardware; h != nil {
-		return h.Arch
+		return (*h).HardwareArch()
 	}
 	return ""
 }
@@ -49,7 +50,6 @@ func (j Job) PArch() string {
 	if parch != "" {
 		return parch
 	}
-
 	return j.Arch()
 }
 
@@ -83,13 +83,6 @@ func (j Job) InstanceIPs() []packet.IP {
 	return nil
 }
 
-func (j Job) PrivateSubnets() []string {
-	if h := j.hardware; h != nil {
-		return h.PrivateSubnets
-	}
-	return nil
-}
-
 func (j Job) CryptedPassword() string {
 	if j.instance != nil {
 		return j.instance.CryptedRootPassword
@@ -113,7 +106,7 @@ func (j Job) ID() string {
 
 func (j Job) Interfaces() []packet.Port {
 	if h := j.hardware; h != nil {
-		return h.Interfaces()
+		return (*h).Interfaces()
 	}
 	return nil
 }
@@ -134,35 +127,35 @@ func (j Job) InterfaceMAC(i int) net.HardwareAddr {
 
 func (j Job) HardwareID() string {
 	if h := j.hardware; h != nil {
-		return h.ID
+		return (*h).HardwareID()
 	}
 	return ""
 }
 
 func (j Job) FacilityCode() string {
 	if h := j.hardware; h != nil {
-		return h.FacilityCode
+		return (*h).HardwareFacilityCode()
 	}
 	return ""
 }
 
 func (j Job) PlanSlug() string {
 	if h := j.hardware; h != nil {
-		return h.PlanSlug
+		return (*h).HardwarePlanSlug()
 	}
 	return ""
 }
 
 func (j Job) PlanVersionSlug() string {
 	if h := j.hardware; h != nil {
-		return h.PlanVersionSlug
+		return (*h).HardwarePlanVersionSlug()
 	}
 	return ""
 }
 
 func (j Job) Manufacturer() string {
 	if h := j.hardware; h != nil {
-		return h.Manufacturer.Slug
+		return (*h).HardwareManufacturer()
 	}
 	return ""
 }
@@ -172,27 +165,27 @@ func (j Job) PrimaryNIC() net.HardwareAddr {
 	return j.mac
 }
 
-// golangci-lint: unused
-//func (j Job) isPrimaryNIC(mac net.HardwareAddr) bool {
-//	return bytes.Equal(mac, j.PrimaryNIC())
-//}
+func (j Job) isPrimaryNIC(mac net.HardwareAddr) bool {
+	return bytes.Equal(mac, j.PrimaryNIC())
+}
 
 // HardwareState will return (enrolled burn_in preinstallable preinstalling failed_preinstall provisionable provisioning deprovisioning in_use)
 func (j Job) HardwareState() string {
-	if h := j.hardware; h != nil && h.ID != "" {
-		return string(h.State)
+	if h := j.hardware; h != nil && (*h).HardwareID() != "" {
+		return string((*h).HardwareState())
 	}
 	return ""
 }
 
 func (j Job) ServicesVersion() packet.ServicesVersion {
-	if h := j.hardware; h != nil && h.ID != "" {
-		return h.ServicesVersion
+	if h := j.hardware; h != nil && (*h).HardwareID() != "" {
+		sv := (*h).HardwareServicesVersion()
+		return sv.(packet.ServicesVersion) // asserting for now
 	}
 	return packet.ServicesVersion{}
 }
 
 // CanWorkflow checks if workflow is allowed
 func (j Job) CanWorkflow() bool {
-	return j.hardware.AllowWorkflow
+	return (*j.hardware).HardwareAllowWorkflow()
 }

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"bytes"
 	"net"
 
 	"github.com/tinkerbell/boots/packet"
@@ -165,9 +164,10 @@ func (j Job) PrimaryNIC() net.HardwareAddr {
 	return j.mac
 }
 
-func (j Job) isPrimaryNIC(mac net.HardwareAddr) bool {
-	return bytes.Equal(mac, j.PrimaryNIC())
-}
+// unused, but keeping for now
+// func (j Job) isPrimaryNIC(mac net.HardwareAddr) bool {
+// 	return bytes.Equal(mac, j.PrimaryNIC())
+// }
 
 // HardwareState will return (enrolled burn_in preinstallable preinstalling failed_preinstall provisionable provisioning deprovisioning in_use)
 func (j Job) HardwareState() string {

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1,13 +1,10 @@
 package job
 
 import (
-	"fmt"
 	"net"
 	"os"
-	"reflect"
 	"testing"
 
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/boots/httplog"
 	"github.com/tinkerbell/boots/packet"
@@ -24,24 +21,10 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestSetupNil(t *testing.T) {
-	d := &packet.Discovery{Hardware: &packet.Hardware{}}
-	j1 := &Job{}
-	j2 := &Job{}
-
-	j1.setup(d)
-	j1.Logger = log.Logger{}
-	j2.Logger = j1.Logger
-	if !reflect.DeepEqual(j1, j2) {
-		fmt.Println(pretty.Compare(j1, j2))
-		t.Fatal("jobs do not match")
-	}
-}
-
 func TestSetupDiscover(t *testing.T) {
 	macIPMI := packet.MACAddr([6]byte{0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00})
-	d := &packet.Discovery{
-		Hardware: &packet.Hardware{
+	var d packet.Discovery = &packet.DiscoveryCacher{
+		HardwareCacher: &packet.HardwareCacher{
 			Name:     "TestSetupDiscover",
 			Instance: nil,
 			NetworkPorts: []packet.Port{
@@ -64,14 +47,20 @@ func TestSetupDiscover(t *testing.T) {
 	}
 
 	j := &Job{mac: macIPMI.HardwareAddr()}
-	j.setup(d)
+	j.setup(&d)
 
-	wantMode := modeManagement
-	if j.mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, j.mode)
+	dh := *d.Hardware()
+	h := dh.(*packet.HardwareCacher)
+
+	mode := d.Mode()
+
+	wantMode := "management"
+	if mode != wantMode {
+		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
 	}
 
-	netConfig := d.IPMI
+	dc := d.(*packet.DiscoveryCacher)
+	netConfig := dc.HardwareIPMI()
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
 		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
 	}
@@ -81,16 +70,16 @@ func TestSetupDiscover(t *testing.T) {
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
 		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
 	}
-	if d.Hardware.Name != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", d.Hardware.Name, j.dhcp.Hostname())
+	if h.Name != j.dhcp.Hostname() {
+		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", h.Name, j.dhcp.Hostname())
 	}
 }
 
 // The easy way to differentiate between discovered hardware and enrolled/not-active hardware is by existence of PlanSLug
 func TestSetupManagement(t *testing.T) {
 	macIPMI := packet.MACAddr([6]byte{0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00})
-	d := &packet.Discovery{
-		Hardware: &packet.Hardware{
+	var d packet.Discovery = &packet.DiscoveryCacher{
+		HardwareCacher: &packet.HardwareCacher{
 			Name:     "TestSetupManagement",
 			Instance: &packet.Instance{},
 			PlanSlug: "f1.fake.x86",
@@ -113,15 +102,22 @@ func TestSetupManagement(t *testing.T) {
 		},
 	}
 
-	j := &Job{mac: macIPMI.HardwareAddr()}
-	j.setup(d)
+	dh := *d.Hardware()
+	h := dh.(*packet.HardwareCacher)
 
-	wantMode := modeManagement
-	if j.mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, j.mode)
+	j := &Job{mac: macIPMI.HardwareAddr()}
+	j.setup(&d)
+
+	mode := d.Mode()
+
+	wantMode := "management"
+	if mode != wantMode {
+		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
 	}
 
-	netConfig := d.IPMI
+	dc := d.(*packet.DiscoveryCacher)
+	netConfig := dc.HardwareIPMI()
+
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
 		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
 	}
@@ -131,23 +127,27 @@ func TestSetupManagement(t *testing.T) {
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
 		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
 	}
-	if d.Hardware.Name != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", d.Name, j.dhcp.Hostname())
+	if h.Name != j.dhcp.Hostname() {
+		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", h.Name, j.dhcp.Hostname())
 	}
 }
 
 func TestSetupInstance(t *testing.T) {
-	d, macs, _ := MakeHardwareWithInstance()
+	var d packet.Discovery
+	var macs []packet.MACAddr
+	d, macs, _ = MakeHardwareWithInstance()
 
 	j := &Job{mac: macs[1].HardwareAddr()}
-	j.setup(d)
+	j.setup(&d)
 
-	wantMode := modeInstance
-	if j.mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, j.mode)
+	mode := d.Mode()
+
+	wantMode := "instance"
+	if mode != wantMode {
+		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
 	}
 
-	netConfig := d.NetConfig(macs[1].HardwareAddr())
+	netConfig := d.Ip(macs[1].HardwareAddr())
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
 		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
 	}
@@ -157,16 +157,15 @@ func TestSetupInstance(t *testing.T) {
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
 		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
 	}
-	if d.Instance.Hostname != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", d.Instance.Hostname, j.dhcp.Hostname())
+	if d.Instance().Hostname != j.dhcp.Hostname() {
+		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", d.Instance().Hostname, j.dhcp.Hostname())
 	}
 }
-
 func TestSetupFails(t *testing.T) {
-	d := &packet.Discovery{Hardware: &packet.Hardware{}}
+	var d packet.Discovery = &packet.DiscoveryCacher{HardwareCacher: &packet.HardwareCacher{}}
 	j := &Job{}
 
-	err := j.setup(d)
+	err := j.setup(&d)
 	if err == nil {
 		t.Fatal("expected an error but got nil")
 	}

--- a/job/network.go
+++ b/job/network.go
@@ -3,5 +3,5 @@ package job
 import "github.com/tinkerbell/boots/packet"
 
 func (j Job) BondingMode() packet.BondingMode {
-	return j.hardware.BondingMode
+	return (*j.hardware).HardwareBondingMode()
 }

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -120,10 +120,10 @@ func (c *Client) GetInstanceIDFromIP(dip net.IP) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if d.Instance == nil {
+	if (*d).Instance() == nil {
 		return "", nil
 	}
-	return d.Instance.ID, nil
+	return (*d).Instance().ID, nil
 }
 
 // PostHardwareComponent - POSTs a HardwareComponent to the API

--- a/packet/models.go
+++ b/packet/models.go
@@ -1,11 +1,9 @@
 package packet
 
 import (
-	"bytes"
 	"encoding/json"
 	"net"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -214,22 +212,23 @@ type NetworkPorts struct {
 	IPMI Port   `json:"ipmi"`
 }
 
-func (p *NetworkPorts) addMain(port Port) {
-	var (
-		mac   = port.MAC()
-		ports = p.Main
-	)
-	n := len(ports)
-	i := sort.Search(n, func(i int) bool {
-		return bytes.Compare(mac, ports[i].MAC()) < 0
-	})
-	if i < n {
-		ports = append(append(ports[:i], port), ports[i:]...)
-	} else {
-		ports = append(ports, port)
-	}
-	p.Main = ports
-}
+// unused, but keeping for now
+// func (p *NetworkPorts) addMain(port Port) {
+// 	var (
+// 		mac   = port.MAC()
+// 		ports = p.Main
+// 	)
+// 	n := len(ports)
+// 	i := sort.Search(n, func(i int) bool {
+// 		return bytes.Compare(mac, ports[i].MAC()) < 0
+// 	})
+// 	if i < n {
+// 		ports = append(append(ports[:i], port), ports[i:]...)
+// 	} else {
+// 		ports = append(ports, port)
+// 	}
+// 	p.Main = ports
+// }
 
 type OperatingSystem struct {
 	Slug     string `json:"slug"`

--- a/packet/models.go
+++ b/packet/models.go
@@ -15,10 +15,12 @@ const (
 	discoveryTypeTinkerbell = "tinkerbell"
 )
 
+// BondingMode is the hardware bonding mode
 type BondingMode int
 
+// Discovery interface is the base for cacher and tinkerbell hardware discovery
 type Discovery interface {
-	Instance() *Instance // temporary
+	Instance() *Instance
 	Mac() net.HardwareAddr
 	Mode() string
 	Ip(addr net.HardwareAddr) IP
@@ -29,11 +31,13 @@ type Discovery interface {
 	SetMac(mac net.HardwareAddr)
 }
 
+// DiscoveryCacher presents the structure for old data model
 type DiscoveryCacher struct {
 	*HardwareCacher
 	mac net.HardwareAddr
 }
 
+// DiscoveryTinkerbell presents the structure for tinkerbell's new data model
 type DiscoveryTinkerbell struct {
 	*HardwareTinkerbell
 	mac net.HardwareAddr
@@ -63,6 +67,7 @@ type OsieTinkerbell struct {
 	*Bootstrapper
 }
 
+// Hardware interface holds primary hardware methods
 type Hardware interface {
 	HardwareAllowPXE() bool
 	HardwareAllowWorkflow() bool
@@ -80,6 +85,7 @@ type Hardware interface {
 	HardwareUEFI() bool
 }
 
+// HardwareCacher represents the old hardware data model for backward compatibility
 type HardwareCacher struct {
 	ID    string        `json:"id"`
 	Name  string        `json:"name"`
@@ -103,6 +109,7 @@ type HardwareCacher struct {
 	Instance        *Instance       `json:"instance"`
 }
 
+// HardwareTinkerbell represents the new hardware data model for tinkerbell
 type HardwareTinkerbell struct {
 	ID       string    `json:"id"`
 	DHCP     DHCP      `json:"dhcp"`
@@ -111,7 +118,7 @@ type HardwareTinkerbell struct {
 	Metadata Metadata  `json:"metadata"`
 }
 
-// New instantiates a Discovery struct from the json argument
+// NewDiscovery instantiates a Discovery struct from the json argument
 func NewDiscovery(j string) (*Discovery, error) {
 	var res Discovery
 
@@ -161,6 +168,7 @@ type Device struct {
 	ID string `json:"id"`
 }
 
+// FindIP returns IP for an instance, nil otherwise
 func (i *Instance) FindIP(pred func(IP) bool) *IP {
 	for _, ip := range i.IPs {
 		if pred(ip) {
@@ -178,6 +186,7 @@ func managementPrivateIPv4IP(ip IP) bool {
 	return !ip.Public && ip.Management && ip.Family == 4
 }
 
+// InstanceState represents the state of an instance (e.g. active)
 type InstanceState string
 
 type Event struct {
@@ -196,8 +205,10 @@ type ServicesVersion struct {
 	Osie string `json:"osie"`
 }
 
+// HardwareState is the hardware state (e.g. provisioning)
 type HardwareState string
 
+// IP represents IP address for a hardware
 type IP struct {
 	Address    net.IP `json:"address"`
 	Netmask    net.IP `json:"netmask"`
@@ -207,10 +218,10 @@ type IP struct {
 	Management bool   `json:"management"`
 }
 
-type NetworkPorts struct {
-	Main []Port `json:"main"`
-	IPMI Port   `json:"ipmi"`
-}
+// type NetworkPorts struct {
+// 	Main []Port `json:"main"`
+// 	IPMI Port   `json:"ipmi"`
+// }
 
 // unused, but keeping for now
 // func (p *NetworkPorts) addMain(port Port) {
@@ -230,6 +241,7 @@ type NetworkPorts struct {
 // 	p.Main = ports
 // }
 
+// OperatingSystem holds details for the operating system
 type OperatingSystem struct {
 	Slug     string `json:"slug"`
 	Distro   string `json:"distro"`
@@ -238,6 +250,7 @@ type OperatingSystem struct {
 	OsSlug   string `json:"os_slug"`
 }
 
+// Port represents a network port
 type Port struct {
 	ID   string   `json:"id"`
 	Type PortType `json:"type"`
@@ -248,6 +261,7 @@ type Port struct {
 	} `json:"data"`
 }
 
+// MAC returns the physical hardware address, nil otherwise
 func (p *Port) MAC() net.HardwareAddr {
 	if p.Data.MAC != nil && *p.Data.MAC != ZeroMAC {
 		return p.Data.MAC.HardwareAddr()
@@ -255,13 +269,16 @@ func (p *Port) MAC() net.HardwareAddr {
 	return nil
 }
 
+// PortType is type for a network port
 type PortType string
 
+// Manufacturer holds data for hardware manufacturer
 type Manufacturer struct {
 	ID   string `json:"id"`
 	Slug string `json:"slug"`
 }
 
+// DHCP holds details for DHCP connection
 type DHCP struct {
 	MAC         *MACAddr      `json:"mac"`
 	IP          string        `json:"ip"`
@@ -275,6 +292,7 @@ type DHCP struct {
 	IfaceName   string        `json:"iface_name"`
 }
 
+// Netboot holds details for a hardware to boot over network
 type Netboot struct {
 	AllowPXE      bool `json:"allow_pxe"`
 	AllowWorkflow bool `json:"allow_workflow"`
@@ -285,17 +303,20 @@ type Netboot struct {
 	Bootstrapper Bootstrapper `json:"bootstrapper"`
 }
 
+// Bootstrapper is the bootstrapper to be used during netboot
 type Bootstrapper struct {
 	Kernel string `json:"kernel"`
 	Initrd string `json:"initrd"`
 	OS     string `json:"os"`
 }
 
+// Network holds hardware network details
 type Network struct {
 	DHCP    DHCP    `json:"dhcp,omitempty"`
 	Netboot Netboot `json:"netboot,omitempty"`
 }
 
+// Metadata holds the hardware metadata
 type Metadata struct {
 	State        HardwareState `json:"state"`
 	BondingMode  BondingMode   `json:"bonding_mode"`
@@ -308,6 +329,7 @@ type Metadata struct {
 	Facility Facility `json:"facility"`
 }
 
+// Facility represents the facilty in use
 type Facility struct {
 	PlanSlug        string `json:"plan_slug"`
 	PlanVersionSlug string `json:"plan_version_slug"`

--- a/packet/models.go
+++ b/packet/models.go
@@ -1,176 +1,136 @@
 package packet
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
+	"os"
+	"sort"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/files/ignition"
+)
+
+const (
+	discoveryTypeCacher     = "cacher"
+	discoveryTypeTinkerbell = "tinkerbell"
 )
 
 type BondingMode int
 
-type Discovery struct {
-	*Hardware
+type Discovery interface {
+	Instance() *Instance // temporary
+	Mac() net.HardwareAddr
+	Mode() string
+	Ip(addr net.HardwareAddr) IP
+	DnsServers() []net.IP
+	LeaseTime() time.Duration
+	Hostname() (string, error)
+	Hardware() *Hardware
+	SetMac(mac net.HardwareAddr)
 }
 
-func (d *Discovery) macType(mac string) string {
-	for _, port := range d.NetworkPorts {
-		if port.MAC().String() == mac {
-			return string(port.Type)
-		}
-	}
-	return "NOTFOUND"
+type DiscoveryCacher struct {
+	*HardwareCacher
+	mac net.HardwareAddr
 }
 
-func (d *Discovery) macIsType(mac string, portType string) bool {
-	for _, port := range d.NetworkPorts {
-		if port.MAC().String() != mac {
-			continue
-		}
-		return string(port.Type) == portType
-	}
-	return false
+type DiscoveryTinkerbell struct {
+	*HardwareTinkerbell
+	mac net.HardwareAddr
+}
+
+type Interface interface {
+	Name() string
+}
+
+type InterfaceCacher struct {
+	*Port
+}
+
+type InterfaceTinkerbell struct {
+	*DHCP
+}
+
+type Osie interface { // temp name
+
+}
+
+type OsieCacher struct {
+	*ServicesVersion
+}
+
+type OsieTinkerbell struct {
+	*Bootstrapper
+}
+
+type Hardware interface {
+	HardwareAllowPXE() bool
+	HardwareAllowWorkflow() bool
+	HardwareArch() string
+	HardwareBondingMode() BondingMode
+	HardwareFacilityCode() string
+	HardwareID() string
+	HardwareIPs() []IP
+	Interfaces() []Port
+	HardwareManufacturer() string
+	HardwarePlanSlug() string
+	HardwarePlanVersionSlug() string
+	HardwareState() HardwareState
+	HardwareServicesVersion() Osie
+	HardwareUEFI() bool
+}
+
+type HardwareCacher struct {
+	ID    string        `json:"id"`
+	Name  string        `json:"name"`
+	State HardwareState `json:"state"`
+
+	BondingMode     BondingMode     `json:"bonding_mode"`
+	NetworkPorts    []Port          `json:"network_ports"`
+	Manufacturer    Manufacturer    `json:"manufacturer"`
+	PlanSlug        string          `json:"plan_slug"`
+	PlanVersionSlug string          `json:"plan_version_slug"`
+	Arch            string          `json:"arch"`
+	FacilityCode    string          `json:"facility_code"`
+	IPMI            IP              `json:"management"`
+	IPs             []IP            `json:"ip_addresses"`
+	PreinstallOS    OperatingSystem `json:"preinstalled_operating_system_version"`
+	PrivateSubnets  []string        `json:"private_subnets,omitempty"`
+	UEFI            bool            `json:"efi_boot"`
+	AllowPXE        bool            `json:"allow_pxe"`
+	AllowWorkflow   bool            `json:"allow_workflow"`
+	ServicesVersion ServicesVersion `json:"services"`
+	Instance        *Instance       `json:"instance"`
+}
+
+type HardwareTinkerbell struct {
+	ID       string    `json:"id"`
+	DHCP     DHCP      `json:"dhcp"`
+	Netboot  Netboot   `json:"netboot"`
+	Network  []Network `json:"network"`
+	Metadata Metadata  `json:"metadata"`
 }
 
 // New instantiates a Discovery struct from the json argument
 func NewDiscovery(j string) (*Discovery, error) {
 	var res Discovery
+
+	discoveryType := os.Getenv("DISCOVERY_TYPE")
+	switch discoveryType {
+	case discoveryTypeCacher:
+		res = &DiscoveryCacher{}
+	case discoveryTypeTinkerbell:
+		res = &DiscoveryTinkerbell{}
+	default:
+		return nil, errors.New("invalid discovery type")
+	}
 	err := json.Unmarshal([]byte(j), &res)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal json for discovery")
 	}
 	return &res, err
-}
-
-// Mode returns whether the mac belongs to the instance, hardware, bmc, discovered, or unknown
-func (d Discovery) Mode(mac net.HardwareAddr) string {
-	if d.InstanceIP(mac.String()) != nil {
-		return "instance"
-	}
-	if d.ManagementIP(mac.String()) != nil {
-		return "management"
-	}
-	if d.HardwareIP(mac.String()) != nil {
-		return "hardware"
-	}
-	if d.DiscoveredIP(mac.String()) != nil {
-		return "discovered"
-	}
-	return ""
-}
-
-// NetConfig returns the network configuration that corresponds to the interface whose MAC address is mac.
-func (d Discovery) NetConfig(mac net.HardwareAddr) IP {
-	ip := d.InstanceIP(mac.String())
-	if ip != nil {
-		return *ip
-	}
-	ip = d.ManagementIP(mac.String())
-	if ip != nil {
-		return *ip
-	}
-	ip = d.HardwareIP(mac.String())
-	if ip != nil {
-		return *ip
-	}
-	ip = d.DiscoveredIP(mac.String())
-	if ip != nil {
-		return *ip
-	}
-	return IP{}
-}
-
-// InstanceIP returns the IP configuration that should be Offered to the instance if there is one; if it's prov/deprov'ing, it's the hardware IP
-func (d Discovery) InstanceIP(mac string) *IP {
-	if d.Instance == nil || d.Instance.ID == "" || !d.macIsType(mac, "data") || d.PrimaryDataMAC().HardwareAddr().String() != mac {
-		return nil
-	}
-	if ip := d.Instance.FindIP(managementPublicIPv4IP); ip != nil {
-		return ip
-	}
-	if ip := d.Instance.FindIP(managementPrivateIPv4IP); ip != nil {
-		return ip
-	}
-	if d.Instance.State == "provisioning" || d.Instance.State == "deprovisioning" {
-		ip := d.hardwareIP()
-		if ip != nil {
-			return ip
-		}
-	}
-	return nil
-}
-
-// HardwareIP returns the IP configuration that should be offered to the hardware if there is no instance
-func (d Discovery) HardwareIP(mac string) *IP {
-	if !d.macIsType(mac, "data") {
-		return nil
-	}
-	if d.PrimaryDataMAC().HardwareAddr().String() != mac {
-		return nil
-	}
-	return d.hardwareIP()
-}
-
-// hardwareIP returns the IP configuration that should be offered to the hardware (not exported)
-func (d Discovery) hardwareIP() *IP {
-	for _, ip := range d.Hardware.IPs {
-		if ip.Family != 4 {
-			continue
-		}
-		if ip.Public {
-			continue
-		}
-		return &ip
-	}
-	return nil
-}
-
-// ManagementIP returns the IP configuration that should be Offered to the BMC, if the MAC is a BMC MAC
-func (d Discovery) ManagementIP(mac string) *IP {
-	if d.macIsType(mac, "ipmi") && d.Name != "" {
-		return &d.IPMI
-	}
-	return nil
-}
-
-// DiscoveredIP returns the IP configuration that should be offered to a newly discovered BMC, if the MAC is a BMC MAC
-func (d Discovery) DiscoveredIP(mac string) *IP {
-	if d.macIsType(mac, "ipmi") && d.Name == "" {
-		return &d.IPMI
-	}
-	return nil
-}
-
-// PrimaryDataMAC returns the mac associated with eth0, or as a fallback the lowest numbered non-bmc MAC address
-func (d Discovery) PrimaryDataMAC() MACAddr {
-	mac := OnesMAC
-	for _, port := range d.NetworkPorts {
-		if port.Type != "data" {
-			continue
-		}
-		if port.Name == "eth0" {
-			mac = *port.Data.MAC
-			break
-		}
-		if port.MAC().String() < mac.String() {
-			mac = *port.Data.MAC
-		}
-	}
-
-	if mac.IsOnes() {
-		return ZeroMAC
-	}
-	return mac
-}
-
-// ManagementMAC returns the mac address of the BMC interface
-func (d Discovery) ManagementMAC() MACAddr {
-	for _, port := range d.NetworkPorts {
-		if port.Type == "ipmi" {
-			return *port.Data.MAC
-		}
-	}
-	return ZeroMAC
 }
 
 // Instance models the instance data as returned by the API
@@ -189,6 +149,13 @@ type Instance struct {
 
 	// Only returned in the first 24 hours
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`
+
+	Tags []string `json:"tags,omitempty"`
+	// Project
+	Storage ignition.Storage `json:"storage,omitempty"`
+	SSHKeys []string         `json:"ssh_keys,omitempty"`
+	// CustomData
+	NetworkReady bool `json:"network_ready,omitempty"`
 }
 
 // Device Full device result from /devices endpoint
@@ -231,49 +198,6 @@ type ServicesVersion struct {
 	Osie string `json:"osie"`
 }
 
-type Hardware struct {
-	ID    string        `json:"id"`
-	Name  string        `json:"name"`
-	State HardwareState `json:"state"`
-
-	BondingMode     BondingMode     `json:"bonding_mode"`
-	NetworkPorts    []Port          `json:"network_ports"`
-	Manufacturer    Manufacturer    `json:"manufacturer"`
-	PlanSlug        string          `json:"plan_slug"`
-	PlanVersionSlug string          `json:"plan_version_slug"`
-	Arch            string          `json:"arch"`
-	FacilityCode    string          `json:"facility_code"`
-	IPMI            IP              `json:"management"`
-	IPs             []IP            `json:"ip_addresses"`
-	PreinstallOS    OperatingSystem `json:"preinstalled_operating_system_version"`
-	PrivateSubnets  []string        `json:"private_subnets,omitempty"`
-	UEFI            bool            `json:"efi_boot"`
-	AllowPXE        bool            `json:"allow_pxe"`
-	AllowWorkflow   bool            `json:"allow_workflow"`
-	ServicesVersion ServicesVersion `json:"services"`
-
-	Instance *Instance `json:"instance"`
-}
-
-func (h *Hardware) Management() (address, netmask, gateway net.IP) {
-	ip := h.IPMI
-	return ip.Address, ip.Netmask, ip.Gateway
-}
-
-func (h *Hardware) Interfaces() []Port {
-	ports := make([]Port, 0, len(h.NetworkPorts)-1)
-	for _, p := range h.NetworkPorts {
-		if p.Type == "ipmi" {
-			continue
-		}
-		ports = append(ports, p)
-	}
-	if len(ports) == 0 {
-		return nil
-	}
-	return ports
-}
-
 type HardwareState string
 
 type IP struct {
@@ -290,23 +214,22 @@ type NetworkPorts struct {
 	IPMI Port   `json:"ipmi"`
 }
 
-// golangci-lint: unused
-//func (p *NetworkPorts) addMain(port Port) {
-//	var (
-//		mac   = port.MAC()
-//		ports = p.Main
-//	)
-//	n := len(ports)
-//	i := sort.Search(n, func(i int) bool {
-//		return bytes.Compare(mac, ports[i].MAC()) < 0
-//	})
-//	if i < n {
-//		ports = append(append(ports[:i], port), ports[i:]...)
-//	} else {
-//		ports = append(ports, port)
-//	}
-//	p.Main = ports
-//}
+func (p *NetworkPorts) addMain(port Port) {
+	var (
+		mac   = port.MAC()
+		ports = p.Main
+	)
+	n := len(ports)
+	i := sort.Search(n, func(i int) bool {
+		return bytes.Compare(mac, ports[i].MAC()) < 0
+	})
+	if i < n {
+		ports = append(append(ports[:i], port), ports[i:]...)
+	} else {
+		ports = append(ports, port)
+	}
+	p.Main = ports
+}
 
 type OperatingSystem struct {
 	Slug     string `json:"slug"`
@@ -338,4 +261,56 @@ type PortType string
 type Manufacturer struct {
 	ID   string `json:"id"`
 	Slug string `json:"slug"`
+}
+
+type DHCP struct {
+	MAC         *MACAddr      `json:"mac"`
+	IP          string        `json:"ip"`
+	Hostname    string        `json:"hostname"`
+	LeaseTime   time.Duration `json:"lease_time"`
+	NameServers []string      `json:"name_servers"`
+	TimeServers []string      `json:"time_servers"`
+	Gateway     net.IP        `json:"gateway"`
+	Arch        string        `json:"arch"`
+	UEFI        bool          `json:"uefi"`
+	IfaceName   string        `json:"iface_name"`
+}
+
+type Netboot struct {
+	AllowPXE      bool `json:"allow_pxe"`
+	AllowWorkflow bool `json:"allow_workflow"`
+	IPXE          struct {
+		URL      string `json:"url"`
+		Contents string `json:"contents"`
+	} `json:"ipxe"`
+	Bootstrapper Bootstrapper `json:"bootstrapper"`
+}
+
+type Bootstrapper struct {
+	Kernel string `json:"kernel"`
+	Initrd string `json:"initrd"`
+	OS     string `json:"os"`
+}
+
+type Network struct {
+	DHCP    DHCP    `json:"dhcp,omitempty"`
+	Netboot Netboot `json:"netboot,omitempty"`
+}
+
+type Metadata struct {
+	State        HardwareState `json:"state"`
+	BondingMode  BondingMode   `json:"bonding_mode"`
+	Manufacturer Manufacturer  `json:"manufacturer"`
+	Instance     *Instance     `json:"instance"`
+	Custom       struct {
+		PreinstalledOS OperatingSystem `json:"preinstalled_operating_system_version"`
+		PrivateSubnets []string        `json:"private_subnets"`
+	}
+	Facility Facility `json:"facility"`
+}
+
+type Facility struct {
+	PlanSlug        string `json:"plan_slug"`
+	PlanVersionSlug string `json:"plan_version_slug"`
+	FacilityCode    string `json:"facility_code"`
 }

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -1,0 +1,297 @@
+package packet
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/conf"
+)
+
+func (d DiscoveryCacher) Hardware() *Hardware {
+	var h Hardware = d.HardwareCacher
+	return &h
+}
+
+func (d DiscoveryCacher) DnsServers() []net.IP {
+	return conf.DNSServers
+}
+
+func (d DiscoveryCacher) Instance() *Instance {
+	return d.HardwareCacher.Instance
+}
+
+func (d DiscoveryCacher) LeaseTime() time.Duration {
+	return conf.DHCPLeaseTime
+}
+
+func (d DiscoveryCacher) Mac() net.HardwareAddr {
+	fmt.Println("d.mac", d.mac)
+	if d.mac == nil {
+		mac := d.PrimaryDataMAC()
+		fmt.Println("d.PrimaryDataMAC", mac)
+		fmt.Println()
+		return mac.HardwareAddr()
+	}
+	fmt.Println()
+	return d.mac
+}
+
+func (d DiscoveryCacher) MacType(mac string) string {
+	for _, port := range d.NetworkPorts {
+		if port.MAC().String() == mac {
+			return string(port.Type)
+		}
+	}
+	return "NOTFOUND"
+}
+
+func (d DiscoveryCacher) MacIsType(mac string, portType string) bool {
+	for _, port := range d.NetworkPorts {
+		if port.MAC().String() != mac {
+			continue
+		}
+		return string(port.Type) == portType
+	}
+	return false
+}
+
+// Mode returns whether the mac belongs to the instance, hardware, bmc, discovered, or unknown
+func (d DiscoveryCacher) Mode() string {
+	mac := d.mac
+	if d.InstanceIP(mac.String()) != nil {
+		return "instance"
+	}
+	if d.ManagementIP(mac.String()) != nil {
+		return "management"
+	}
+	if d.HardwareIP(mac.String()) != nil {
+		return "hardware"
+	}
+	if d.DiscoveredIP(mac.String()) != nil {
+		return "discovered"
+	}
+	return ""
+}
+
+// NetConfig returns the network configuration that corresponds to the interface whose MAC address is mac.
+func (d DiscoveryCacher) Ip(mac net.HardwareAddr) IP {
+	ip := d.InstanceIP(mac.String())
+	if ip != nil {
+		return *ip
+	}
+	ip = d.ManagementIP(mac.String())
+	if ip != nil {
+		return *ip
+	}
+	ip = d.HardwareIP(mac.String())
+	if ip != nil {
+		return *ip
+	}
+	ip = d.DiscoveredIP(mac.String())
+	if ip != nil {
+		return *ip
+	}
+	return IP{}
+}
+
+// InstanceIP returns the IP configuration that should be Offered to the instance if there is one; if it's prov/deprov'ing, it's the hardware IP
+func (d DiscoveryCacher) InstanceIP(mac string) *IP {
+	if d.Instance() == nil || d.Instance().ID == "" || !d.MacIsType(mac, "data") || d.PrimaryDataMAC().HardwareAddr().String() != mac {
+		return nil
+	}
+	if ip := d.Instance().FindIP(managementPublicIPv4IP); ip != nil {
+		return ip
+	}
+	if ip := d.Instance().FindIP(managementPrivateIPv4IP); ip != nil {
+		return ip
+	}
+	if d.Instance().State == "provisioning" || d.Instance().State == "deprovisioning" {
+		ip := d.hardwareIP()
+		if ip != nil {
+			return ip
+		}
+	}
+	return nil
+}
+
+// HardwareIP returns the IP configuration that should be offered to the hardware if there is no instance
+func (d DiscoveryCacher) HardwareIP(mac string) *IP {
+	if !d.MacIsType(mac, "data") {
+		return nil
+	}
+	if d.PrimaryDataMAC().HardwareAddr().String() != mac {
+		return nil
+	}
+	return d.hardwareIP()
+}
+
+// hardwareIP returns the IP configuration that should be offered to the hardware (not exported)
+func (d DiscoveryCacher) hardwareIP() *IP {
+	h := *d.Hardware()
+	for _, ip := range h.HardwareIPs() {
+		if ip.Family != 4 {
+			continue
+		}
+		if ip.Public {
+			continue
+		}
+		return &ip
+	}
+	return nil
+}
+
+// ManagementIP returns the IP configuration that should be Offered to the BMC, if the MAC is a BMC MAC
+func (d DiscoveryCacher) ManagementIP(mac string) *IP {
+	if d.MacIsType(mac, "ipmi") && d.Name != "" {
+		return &d.IPMI
+	}
+	return nil
+}
+
+// DiscoveredIP returns the IP configuration that should be offered to a newly discovered BMC, if the MAC is a BMC MAC
+func (d DiscoveryCacher) DiscoveredIP(mac string) *IP {
+	if d.MacIsType(mac, "ipmi") && d.Name == "" {
+		return &d.IPMI
+	}
+	return nil
+}
+
+// PrimaryDataMAC returns the mac associated with eth0, or as a fallback the lowest numbered non-bmc MAC address
+func (d DiscoveryCacher) PrimaryDataMAC() MACAddr {
+	mac := OnesMAC
+	for _, port := range d.NetworkPorts {
+		if port.Type != "data" {
+			continue
+		}
+		if port.Name == "eth0" {
+			mac = *port.Data.MAC
+			break
+		}
+		if port.MAC().String() < mac.String() {
+			mac = *port.Data.MAC
+		}
+	}
+
+	if mac.IsOnes() {
+		return ZeroMAC
+	}
+	return mac
+}
+
+// ManagementMAC returns the mac address of the BMC interface
+func (d DiscoveryCacher) ManagementMAC() MACAddr {
+	for _, port := range d.NetworkPorts {
+		if port.Type == "ipmi" {
+			return *port.Data.MAC
+		}
+	}
+	return ZeroMAC
+}
+
+func (d DiscoveryCacher) Hostname() (string, error) {
+	var hostname string
+
+	mode := d.Mode()
+	switch mode {
+	case "discovered", "management":
+		hostname = d.Name
+	case "instance":
+		hostname = d.Instance().Hostname
+		switch d.State {
+		case "deprovisioning":
+			hostname = d.Name
+		case "provisioning":
+		}
+	case "hardware":
+		hostname = d.Name
+	default:
+		return "", errors.Errorf("unknown mode: %s", mode)
+	}
+
+	return hostname, nil
+}
+
+func (d *DiscoveryCacher) SetMac(mac net.HardwareAddr) {
+	d.mac = mac
+}
+
+func (h *HardwareCacher) Management() (address, netmask, gateway net.IP) {
+	ip := h.IPMI
+	return ip.Address, ip.Netmask, ip.Gateway
+}
+
+func (h HardwareCacher) Interfaces() []Port {
+	ports := make([]Port, 0, len(h.NetworkPorts)-1)
+	for _, p := range h.NetworkPorts {
+		if p.Type == "ipmi" {
+			continue
+		}
+		ports = append(ports, p)
+	}
+	if len(ports) == 0 {
+		return nil
+	}
+	return ports
+}
+
+func (i InterfaceCacher) Name() string {
+	return i.Port.Name
+}
+
+func (h HardwareCacher) HardwareAllowPXE() bool {
+	return h.AllowPXE
+}
+
+func (h HardwareCacher) HardwareAllowWorkflow() bool {
+	return h.AllowWorkflow
+}
+
+func (h HardwareCacher) HardwareArch() string {
+	return h.Arch
+}
+
+func (h HardwareCacher) HardwareBondingMode() BondingMode {
+	return h.BondingMode
+}
+
+func (h HardwareCacher) HardwareFacilityCode() string {
+	return h.FacilityCode
+}
+
+func (h HardwareCacher) HardwareID() string {
+	return h.ID
+}
+
+func (h HardwareCacher) HardwareIPs() []IP {
+	return h.IPs
+}
+
+func (h HardwareCacher) HardwareIPMI() IP {
+	return h.IPMI
+}
+
+func (h HardwareCacher) HardwareManufacturer() string {
+	return h.Manufacturer.Slug
+}
+
+func (h HardwareCacher) HardwarePlanSlug() string {
+	return h.PlanSlug
+}
+
+func (h HardwareCacher) HardwarePlanVersionSlug() string {
+	return h.PlanVersionSlug
+}
+
+func (h HardwareCacher) HardwareServicesVersion() Osie {
+	return h.ServicesVersion
+}
+
+func (h HardwareCacher) HardwareState() HardwareState {
+	return h.State
+}
+
+func (h HardwareCacher) HardwareUEFI() bool {
+	return h.UEFI
+}

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -1,0 +1,122 @@
+package packet
+
+import (
+	"net"
+	"time"
+
+	"github.com/tinkerbell/boots/conf"
+)
+
+func (i InterfaceTinkerbell) Name() string {
+	return i.IfaceName
+}
+
+func (d DiscoveryTinkerbell) LeaseTime() time.Duration {
+	return d.DHCP.LeaseTime
+}
+
+func (d DiscoveryTinkerbell) Hardware() *Hardware {
+	var h Hardware = d.HardwareTinkerbell
+	return &h
+}
+
+func (d DiscoveryTinkerbell) DnsServers() []net.IP {
+	var servers = conf.DNSServers
+	// change to new way
+
+	return servers
+}
+
+func (d DiscoveryTinkerbell) Instance() *Instance {
+	return d.Metadata.Instance
+}
+
+func (d DiscoveryTinkerbell) Mac() net.HardwareAddr {
+	return d.mac
+}
+
+func (d DiscoveryTinkerbell) Mode() string {
+	return "hardware"
+}
+
+func (d DiscoveryTinkerbell) Ip(mac net.HardwareAddr) IP {
+	// TODO
+	return IP{}
+}
+
+func (dt *DiscoveryTinkerbell) PrimaryDataMAC() MACAddr {
+	mac := OnesMAC
+	// TODO
+	return mac
+}
+
+func (d *DiscoveryTinkerbell) Hostname() (string, error) {
+	return d.Instance().Hostname, nil // temp
+}
+
+func (d *DiscoveryTinkerbell) SetMac(mac net.HardwareAddr) {
+	d.mac = mac
+}
+
+func (h HardwareTinkerbell) HardwareAllowPXE() bool {
+	return h.Netboot.AllowPXE
+}
+
+func (h HardwareTinkerbell) HardwareAllowWorkflow() bool {
+	return h.Netboot.AllowWorkflow
+}
+
+func (h HardwareTinkerbell) HardwareArch() string {
+	return h.DHCP.Arch
+}
+
+func (h HardwareTinkerbell) HardwareBondingMode() BondingMode {
+	return h.Metadata.BondingMode
+}
+
+func (h HardwareTinkerbell) HardwareFacilityCode() string {
+	return h.Metadata.Facility.FacilityCode
+}
+
+func (h HardwareTinkerbell) HardwareID() string {
+	return h.ID
+}
+
+func (h HardwareTinkerbell) HardwareIPs() []IP {
+	var hips []IP
+	// TODO
+	return hips
+}
+
+//func (h HardwareTinkerbell) HardwareIPMI() net.IP {
+//	return h.DHCP.IP // is this correct?
+//}
+
+func (h HardwareTinkerbell) HardwareManufacturer() string {
+	return h.Metadata.Manufacturer.Slug
+}
+
+func (h HardwareTinkerbell) HardwarePlanSlug() string {
+	return h.Metadata.Facility.PlanSlug
+}
+
+func (h HardwareTinkerbell) HardwarePlanVersionSlug() string {
+	return h.Metadata.Facility.PlanVersionSlug
+}
+
+func (h HardwareTinkerbell) HardwareState() HardwareState {
+	return h.Metadata.State
+}
+
+func (h HardwareTinkerbell) HardwareServicesVersion() Osie {
+	return h.Netboot.Bootstrapper
+}
+
+func (h HardwareTinkerbell) HardwareUEFI() bool {
+	return h.DHCP.UEFI
+}
+
+func (h *HardwareTinkerbell) Interfaces() []Port {
+	var ports []Port
+	return ports
+}


### PR DESCRIPTION
Ref: [RFC #2 New Hardware data model](https://github.com/tinkerbell/tink/wiki/RFC-%232-New-Hardware-data-model)

Abstracting type Discovery into an interface to settle the differences between the new and old hardware data models.


Signed-off-by: Gaurav Gahlot <gaurav.gahlot19@gmail.com>