### PR TITLE
Add VMware ESXi 7.0

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -380,7 +380,7 @@ func rootpw(j job.Job) string {
 	return j.CryptedPassword()
 }
 
-// We do not support anything other than ESXi 6.5 and above (os slug "vmware_esxi_6_5", "vmware_esxi_6_7", etc)
+// We do not support anything other than ESXi 6.5 and above (os slug "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0" etc)
 // full list of drive settings is listed https://packet.atlassian.net/browse/SWE-2385
 func determineDisk(j job.Job) string {
 	switch j.PlanSlug() {

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -26,7 +26,7 @@ func TestDetermineDisk(t *testing.T) {
 
 func TestScriptKickstart(t *testing.T) {
 	manufacturers := []string{"supermicro", "dell"}
-	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7"}
+	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0"}
 	assert := require.New(t)
 	conf.MirrorBaseIP = "http://127.0.0.1"
 	conf.PublicIPv4 = net.ParseIP("127.0.0.1")

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -40,7 +40,7 @@ func bootScriptVmwareEsxi67(j job.Job, s *ipxe.Script) {
 }
 
 func bootScriptVmwareEsxi70(j job.Job, s *ipxe.Script) {
-        bootScriptVmwareEsxi(j, s, "/vmware/esxi-7.0.0")
+	bootScriptVmwareEsxi(j, s, "/vmware/esxi-7.0.0")
 }
 
 func bootScriptVmwareEsxi(j job.Job, s *ipxe.Script, basePath string) {

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -39,7 +39,7 @@ func bootScriptVmwareEsxi67(j job.Job, s *ipxe.Script) {
 	bootScriptVmwareEsxi(j, s, "/vmware/esxi-6.7.0")
 }
 
-func bootScriptVmwareEsxi67(j job.Job, s *ipxe.Script) {
+func bootScriptVmwareEsxi70(j job.Job, s *ipxe.Script) {
         bootScriptVmwareEsxi(j, s, "/vmware/esxi-7.0.0")
 }
 

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -11,6 +11,7 @@ func init() {
 	job.RegisterSlug("vmware_esxi_6_0", bootScriptVmwareEsxi60)
 	job.RegisterSlug("vmware_esxi_6_5", bootScriptVmwareEsxi65)
 	job.RegisterSlug("vmware_esxi_6_7", bootScriptVmwareEsxi67)
+	job.RegisterSlug("vmware_esxi_7_0", bootScriptVmwareEsxi70)
 	job.RegisterDistro("vmware", bootScriptDefault)
 }
 
@@ -36,6 +37,10 @@ func bootScriptVmwareEsxi65(j job.Job, s *ipxe.Script) {
 
 func bootScriptVmwareEsxi67(j job.Job, s *ipxe.Script) {
 	bootScriptVmwareEsxi(j, s, "/vmware/esxi-6.7.0")
+}
+
+func bootScriptVmwareEsxi67(j job.Job, s *ipxe.Script) {
+        bootScriptVmwareEsxi(j, s, "/vmware/esxi-7.0.0")
 }
 
 func bootScriptVmwareEsxi(j job.Job, s *ipxe.Script, basePath string) {


### PR DESCRIPTION
The purpose of this pull request is to add initial supportfor ESXi 7.0 in the boots vmware installer.