### PR TITLE
Add ECLYPSIUM_TOKEN environment variable | ENG-5336

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -27,6 +27,9 @@ var (
 	ignoredGIs  = getIgnoredGIs()
 
 	TrustedProxies = parseTrustedProxies()
+
+	// Eclypsium registration token, passed into osie
+	EclypsiumToken = env.Get("ECLYPSIUM_TOKEN")
 )
 
 func mustPublicIPv4() net.IP {

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -3,6 +3,7 @@ package osie
 import (
 	"strings"
 
+	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
 )
@@ -63,6 +64,11 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 	s.Args("parch=${parch}")
 	s.Args("packet_action=${action}")
 	s.Args("packet_state=${state}")
+
+	// Don't bother including eclypsium_token if none is provided
+	if conf.EclypsiumToken != "" {
+		s.Args("eclypsium_token=" + conf.EclypsiumToken)
+	}
 
 	if isCustomOsie(j) {
 		s.Args("packet_base_url=" + osieBaseUrl(j))


### PR DESCRIPTION
To enable eclypsium scanning/registration during deprovision but not expose the
token in git we allow the token to be set during run time via an environment
variable and then pass the token into osie during boot.

* add ECLYPSIUM_TOKEN environment variable
* supply eclypsium_token kernel param during osie if defined