### PR TITLE
Only pass eclypsium_token to osie during deprovisioning | ENG-4970

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -66,7 +66,7 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 	s.Args("packet_state=${state}")
 
 	// Don't bother including eclypsium_token if none is provided
-	if conf.EclypsiumToken != "" {
+	if conf.EclypsiumToken != "" && j.HardwareState() == "deprovisioning" {
 		s.Args("eclypsium_token=" + conf.EclypsiumToken)
 	}
 


### PR DESCRIPTION
No need to pass the token into osie, and risk possible exposure, when it's not needed.   Since it's only needed during deprovision, we only pass it then.