### PR TITLE
Add c3.medium and c3.small firstdisk for VMware

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -396,6 +396,9 @@ func determineDisk(j job.Job) string {
 		"n2.xlarge.google",
 		"x2.xlarge.x86":
 		return "--firstdisk=lsi_mr3,lsi_msgpt3,vmw_ahci"
+	case "c3.medium.x86",
+		"c3.small.x86",
+		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "m1.xlarge.x86":
 		if j.PlanVersionSlug() == "baremetal_2_04" {
 			return "--firstdisk=vmw_ahci"

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -397,7 +397,7 @@ func determineDisk(j job.Job) string {
 		"x2.xlarge.x86":
 		return "--firstdisk=lsi_mr3,lsi_msgpt3,vmw_ahci"
 	case "c3.medium.x86",
-		"c3.small.x86",
+		"c3.small.x86":
 		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "m1.xlarge.x86":
 		if j.PlanVersionSlug() == "baremetal_2_04" {


### PR DESCRIPTION
This is to add better VMware support for both the c3.medium and c3.small server types. The storage driver which sets the installation disk is handled by the --firstdisk config directive.