### PR TITLE
Prioritize vmw_ahci on firstdisk for c2med, g2, n2, m2

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -395,7 +395,7 @@ func determineDisk(j job.Job) string {
 		"n2.xlarge.x86",
 		"n2.xlarge.google",
 		"x2.xlarge.x86":
-		return "--firstdisk=lsi_mr3,lsi_msgpt3,vmw_ahci"
+		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "c3.medium.x86",
 		"c3.small.x86",
 		"s3.xlarge.x86":


### PR DESCRIPTION
This modifies the firstdisk option used for determining the installation disk. The vmw_ahci driver will enable installs to go on to the smaller disks across specific hardware plans.