### PR TITLE
Custom osie via userdata

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -147,16 +147,13 @@ func initrdPath(j job.Job) string {
 }
 
 func isCustomOSIE(j job.Job) bool {
-	if version := j.ServicesVersion(); version.OSIE != "" {
-		return true
-	}
-	return false
+	return j.OSIEVersion() != ""
 }
 
 // osieBaseUrl returns the value of Custom OSIE Service Version or just /current
 func osieBaseUrl(j job.Job) string {
 	if isCustomOSIE(j) {
-		return osieURL + "/" + j.ServicesVersion().OSIE
+		return osieURL + "/" + j.OSIEVersion()
 	}
 	return osieURL + "/current"
 }

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -70,7 +70,7 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("eclypsium_token=" + conf.EclypsiumToken)
 	}
 
-	if isCustomOsie(j) {
+	if isCustomOSIE(j) {
 		s.Args("packet_base_url=" + osieBaseUrl(j))
 	}
 
@@ -146,17 +146,17 @@ func initrdPath(j job.Job) string {
 	return "initramfs-${parch}"
 }
 
-func isCustomOsie(j job.Job) bool {
-	if version := j.ServicesVersion(); version.Osie != "" {
+func isCustomOSIE(j job.Job) bool {
+	if version := j.ServicesVersion(); version.OSIE != "" {
 		return true
 	}
 	return false
 }
 
-// OsieBaseUrl returns the value of Osie Custom Service Version, or boots/osie
+// osieBaseUrl returns the value of Custom OSIE Service Version or just /current
 func osieBaseUrl(j job.Job) string {
-	if isCustomOsie(j) {
-		return osieURL + "/" + j.ServicesVersion().Osie
+	if isCustomOSIE(j) {
+		return osieURL + "/" + j.ServicesVersion().OSIE
 	}
 	return osieURL + "/current"
 }

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -185,11 +185,12 @@ func (j Job) HardwareState() string {
 	return ""
 }
 
-func (j Job) ServicesVersion() packet.ServicesVersion {
-	if h := j.hardware; h != nil && h.ID != "" {
-		return h.ServicesVersion
+// OSIEVersion returns any non-standard osie versions specified in the underlying hardware
+func (j Job) OSIEVersion() string {
+	if h := j.hardware; h != nil && h.ServicesVersion.OSIE != "" {
+		return h.ServicesVersion.OSIE
 	}
-	return packet.ServicesVersion{}
+	return ""
 }
 
 // CanWorkflow checks if workflow is allowed

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -185,8 +185,14 @@ func (j Job) HardwareState() string {
 	return ""
 }
 
-// OSIEVersion returns any non-standard osie versions specified in the underlying hardware
+// OSIEVersion returns any non-standard osie versions specified in either the instance proper or in userdata or attached to underlying hardware
 func (j Job) OSIEVersion() string {
+	if i := j.instance; i != nil {
+		ov := i.ServicesVersion().OSIE
+		if ov != "" {
+			return ov
+		}
+	}
 	if h := j.hardware; h != nil && h.ServicesVersion.OSIE != "" {
 		return h.ServicesVersion.OSIE
 	}

--- a/job/mock.go
+++ b/job/mock.go
@@ -33,7 +33,7 @@ func NewMock(t zaptest.TestingT, slug, facility string) Mock {
 
 	servicesVersion := packet.ServicesVersion{}
 	if strings.Contains(slug, "custom-osie") {
-		servicesVersion.Osie = "osie-v18.08.13.00"
+		servicesVersion.OSIE = "osie-v18.08.13.00"
 	}
 
 	mockLog := log.Test(t, "job.Mock")

--- a/packet/models.go
+++ b/packet/models.go
@@ -228,7 +228,7 @@ type UserEvent struct {
 }
 
 type ServicesVersion struct {
-	Osie string `json:"osie"`
+	OSIE string `json:"osie"`
 }
 
 type Hardware struct {

--- a/packet/models.go
+++ b/packet/models.go
@@ -181,11 +181,12 @@ type Instance struct {
 	AllowPXE bool          `json:"allow_pxe"`
 	Rescue   bool          `json:"rescue"`
 
-	OS            OperatingSystem `json:"operating_system_version"`
-	AlwaysPXE     bool            `json:"always_pxe,omitempty"`
-	IPXEScriptURL string          `json:"ipxe_script_url,omitempty"`
-	IPs           []IP            `json:"ip_addresses"`
-	UserData      string          `json:"userdata,omitempty"`
+	OS              OperatingSystem `json:"operating_system_version"`
+	AlwaysPXE       bool            `json:"always_pxe,omitempty"`
+	IPXEScriptURL   string          `json:"ipxe_script_url,omitempty"`
+	IPs             []IP            `json:"ip_addresses"`
+	UserData        string          `json:"userdata,omitempty"`
+	servicesVersion ServicesVersion
 
 	// Only returned in the first 24 hours
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -56,7 +56,7 @@ func TestDiscovery(t *testing.T) {
 			t.Fatalf("unexpected address, want: %s, got: %s\n", test.conf.Gateway, conf.Gateway)
 		}
 
-		osie := d.ServicesVersion.Osie
+		osie := d.ServicesVersion.OSIE
 		if osie != test.osie {
 			t.Fatalf("unexpected osie version, want: %s, got: %s\n", test.osie, osie)
 		}

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -160,758 +160,763 @@ var tests = map[string]struct {
 
 const (
 	discovered = `
-	{
-	  "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
-	  "management": {
-	    "address": "10.250.142.74",
-	    "gateway": "10.250.142.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "network_ports": [
-	    {
-	      "data": {
-		    "mac": "84:b5:9c:cf:17:01"
-	      },
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ]
-	}
+{
+  "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
+  "management": {
+    "address": "10.250.142.74",
+    "gateway": "10.250.142.1",
+    "netmask": "255.255.255.0"
+  },
+  "network_ports": [
+    {
+      "data": {
+        "mac": "84:b5:9c:cf:17:01"
+      },
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ]
+}
 `
 
 	noInstance = `
-	{
-	  "arch": "x86_64",
-	  "bonding_mode": 4,
-	  "efi_boot": true,
-	  "facility_code": "lab1",
-	  "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
-	  "instance": {},
-	  "management": {
-	    "address": "10.255.252.16",
-	    "gateway": "10.255.252.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "ip_addresses": [
-	    {
-		  "address": "172.16.0.3",
-	      "address_family": 4,
-		  "enabled": true,
-		  "gateway": "172.16.0.2",
-		  "management": true,
-		  "netmask": "255.255.255.252",
-		  "public": false
-	    }
-	  ],
-	  "manufacturer": {
-	    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
-	    "slug": "supermicro"
-	  },
-	  "name": "sled5.mc1.d11.lab1.packet.net",
-	  "network_ports": [
-	    {
-	      "connected_port": {
-	        "data": {
-		      "bond": null,
-		      "mac": null
-		    },
-		    "id": "0b7fc8dc-33bf-4802-903f-55c4d076bfc7",
-		    "name": "ge-0/0/4",
-		    "type": "data"
-	      },
-	      "data": {
-		    "bond": "bond0",
-		    "mac": "00:25:90:e7:6c:78"
-	      },
-	      "id": "179b020a-74ba-4969-a97a-f8e03b3877c8",
-	      "name": "eth0",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "216f9b60-6a99-460c-9e55-99becbd8776e",
-		"name": "ge-1/0/4",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:6c:79"
-	      },
-	      "id": "f2088273-a38f-4005-ba11-845e8e2aa342",
-	      "name": "eth1",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "c7389751-1699-4e17-ba1f-f1fb439aa666",
-		"name": "Fa0/5",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": null,
-		"mac": "00:25:90:f6:2f:2d"
-	      },
-	      "id": "e6db1b93-f718-4bd1-9dea-05725a04a87a",
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ],
-	  "plan_slug": "c1.small.x86",
-	  "state": "in_use",
-	  "type": "sled",
-	  "vlan_id": null
-	}
+{
+  "arch": "x86_64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
+  "instance": {},
+  "ip_addresses": [
+    {
+      "address": "172.16.0.3",
+      "address_family": 4,
+      "enabled": true,
+      "gateway": "172.16.0.2",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "public": false
+    }
+  ],
+  "management": {
+    "address": "10.255.252.16",
+    "gateway": "10.255.252.1",
+    "netmask": "255.255.255.0"
+  },
+  "manufacturer": {
+    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
+    "slug": "supermicro"
+  },
+  "name": "sled5.mc1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "0b7fc8dc-33bf-4802-903f-55c4d076bfc7",
+        "name": "ge-0/0/4",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:6c:78"
+      },
+      "id": "179b020a-74ba-4969-a97a-f8e03b3877c8",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "216f9b60-6a99-460c-9e55-99becbd8776e",
+        "name": "ge-1/0/4",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:6c:79"
+      },
+      "id": "f2088273-a38f-4005-ba11-845e8e2aa342",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "c7389751-1699-4e17-ba1f-f1fb439aa666",
+        "name": "Fa0/5",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "00:25:90:f6:2f:2d"
+      },
+      "id": "e6db1b93-f718-4bd1-9dea-05725a04a87a",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.small.x86",
+  "state": "in_use",
+  "type": "sled",
+  "vlan_id": null
+}
 `
 
 	preinstalling = `
 {
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
   "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "preinstalling",
-  "vlan_id": "122",
-  "efi_boot": true,
-  "instance": {},
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
   "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {},
   "ip_addresses": [
     {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
       "address": "172.16.0.16",
+      "address_family": 4,
+      "cidr": 30,
       "enabled": true,
       "gateway": "172.16.0.15",
+      "management": true,
       "netmask": "255.255.255.252",
       "network": "172.16.0.14",
-      "management": true,
-      "address_family": 4
+      "public": false,
+      "type": "data"
     },
     {
-      "type": "ipmi",
       "address": "10.255.3.13",
       "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
     }
   ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
   "manufacturer": {
     "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
     "slug": "foxconn"
   },
-  "facility_code": "lab1",
+  "name": "sled3.arm1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "00:25:99:e7:6c:78",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
       "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "name": "xe-0/0/4:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:99:e7:6c:78"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
     },
     {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
       },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "name": "eth01",
       "type": "data"
     },
     {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "00:25:99:e7:6c:79",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
       "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "name": "xe-0/0/5:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:99:e7:6c:79"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
     },
     {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
       "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "name": "Fa0/3",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
     }
   ],
+  "plan_slug": "c1.large.arm",
   "preinstalled_operating_system_version": {
     "distro": "centos",
     "image_tag": null,
     "os_slug": "centos_7",
     "slug": "centos_7-t1.small.x86",
     "version": "7"
-  }
-}`
-	withInstance = `
-	{
-	  "arch": "x86_64",
-	  "bonding_mode": 4,
-	  "efi_boot": true,
-	  "facility_code": "lab1",
-	  "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
-	  "ip_addresses": [
-	    {
-		  "address": "172.16.0.7",
-	      "address_family": 4,
-		  "enabled": true,
-		  "gateway": "172.16.0.6",
-		  "management": true,
-		  "netmask": "255.255.255.252",
-		  "public": false
-	    }
-	  ],
-	  "instance": {
-	    "allow_pxe": true,
-	    "always_pxe": false,
-	    "hostname": "test.smr.2",
-	    "id": "1d62730e-a7b6-4600-a424-17d26ccc1f59",
-	    "ip_addresses": [
-	      {
-		    "address": "147.75.193.106",
-		    "address_family": 4,
-		    "enabled": true,
-		    "gateway": "147.75.193.105",
-		    "management": true,
-		    "netmask": "255.255.255.252",
-		    "public": true
-	      }
-	    ],
-	    "ipxe_script_url": null,
-	    "operating_system_version": {
-	      "distro": "centos",
-	      "image_tag": null,
-	      "os_slug": "deprovision",
-	      "slug": "deprovision",
-	      "version": ""
-	    },
-	    "rescue": false,
-	    "ssh_keys": [],
-	    "state": "failed",
-	    "userdata": null
-	  },
-	  "management": {
-	    "address": "10.255.252.15",
-	    "gateway": "10.255.252.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "manufacturer": {
-	    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
-	    "slug": "supermicro"
-	  },
-	  "name": "sled4.mc1.d11.lab1.packet.net",
-	  "network_ports": [
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "32480a81-d644-4226-a209-c600d9cc21d4",
-		"name": "ge-0/0/3",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:68:da"
-	      },
-	      "id": "3580ace2-1121-4ef9-8cd0-d471f8dc6fe5",
-	      "name": "eth0",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "5bd48979-f598-4e0a-969b-1e1bc8bd7284",
-		"name": "ge-1/0/3",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:68:db"
-	      },
-	      "id": "5415f58c-9f4a-4994-9f05-361fb646bce7",
-	      "name": "eth1",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "aeaec5b9-f820-4be4-abfb-3add725283a8",
-		"name": "Fa0/4",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": null,
-		"mac": "00:25:90:f6:28:5b"
-	      },
-	      "id": "8c775f93-4ada-44ac-a9c7-6639bd3f3349",
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ],
-	  "plan_slug": "c1.small.x86",
-	  "state": "in_use",
-	  "type": "sled",
-	  "vlan_id": null
-	}
+  },
+  "state": "preinstalling",
+  "type": "sled",
+  "vlan_id": "122"
+}
 `
-	deprovisioning = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
+	withInstance = `
+{
+  "arch": "x86_64",
+  "bonding_mode": 4,
   "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
   "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
     "allow_pxe": true,
     "always_pxe": false,
+    "hostname": "test.smr.2",
+    "id": "1d62730e-a7b6-4600-a424-17d26ccc1f59",
+    "ip_addresses": [
+      {
+        "address": "147.75.193.106",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.193.105",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
+    "ipxe_script_url": null,
+    "operating_system_version": {
+      "distro": "centos",
+      "image_tag": null,
+      "os_slug": "deprovision",
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "failed",
+    "userdata": null
+  },
+  "ip_addresses": [
+    {
+      "address": "172.16.0.7",
+      "address_family": 4,
+      "enabled": true,
+      "gateway": "172.16.0.6",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "public": false
+    }
+  ],
+  "management": {
+    "address": "10.255.252.15",
+    "gateway": "10.255.252.1",
+    "netmask": "255.255.255.0"
+  },
+  "manufacturer": {
+    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
+    "slug": "supermicro"
+  },
+  "name": "sled4.mc1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "32480a81-d644-4226-a209-c600d9cc21d4",
+        "name": "ge-0/0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:68:da"
+      },
+      "id": "3580ace2-1121-4ef9-8cd0-d471f8dc6fe5",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "5bd48979-f598-4e0a-969b-1e1bc8bd7284",
+        "name": "ge-1/0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:68:db"
+      },
+      "id": "5415f58c-9f4a-4994-9f05-361fb646bce7",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "aeaec5b9-f820-4be4-abfb-3add725283a8",
+        "name": "Fa0/4",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "00:25:90:f6:28:5b"
+      },
+      "id": "8c775f93-4ada-44ac-a9c7-6639bd3f3349",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.small.x86",
+  "state": "in_use",
+  "type": "sled",
+  "vlan_id": null
+}
+`
+	deprovisioning = `
+{
+  "arch": "aarch64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {
+    "allow_pxe": true,
+    "always_pxe": false,
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
     "ip_addresses": [],
     "ipxe_script_url": null,
     "operating_system_version": {
-      "slug": "deprovision",
       "distro": "centos",
+      "image_tag": null,
       "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
-    }
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
   },
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
-  "bonding_mode": 4,
   "ip_addresses": [
     {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
       "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
       "enabled": true,
       "gateway": "172.16.0.13",
+      "management": true,
       "netmask": "255.255.255.252",
       "network": "172.16.0.12",
-      "management": true,
-      "address_family": 4
+      "public": false,
+      "type": "data"
     },
     {
-      "type": "ipmi",
       "address": "10.255.3.13",
       "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
     }
   ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
   "manufacturer": {
     "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
     "slug": "foxconn"
   },
-  "facility_code": "lab1",
+  "name": "sled3.arm1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "fc:15:b4:97:04:e5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
       "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "name": "xe-0/0/4:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:e5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
     },
     {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
       },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "name": "eth01",
       "type": "data"
     },
     {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:e6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
       "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "name": "xe-0/0/5:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:e6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
     },
     {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
       "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "name": "Fa0/3",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
     }
   ],
-  "preinstalled_operating_system_version": {}
-}`
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {},
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
 
-	provisioning = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+	provisioning = `
+{
   "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
+  "bonding_mode": 4,
   "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
   "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
     "allow_pxe": true,
     "always_pxe": false,
-    "ip_addresses": [],
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
+    "ip_addresses": [
+      {
+        "address": "147.75.14.16",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.14.15",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
     "ipxe_script_url": null,
     "operating_system_version": {
-      "slug": "deprovision",
       "distro": "centos",
+      "image_tag": null,
       "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
+      "slug": "deprovision",
+      "version": ""
     },
-	"ip_addresses": [
-	  {
-		"address": "147.75.14.16",
-		"address_family": 4,
-		"enabled": true,
-		"gateway": "147.75.14.15",
-		"management": true,
-		"netmask": "255.255.255.252",
-		"public": true
-	  }
-	]
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
   },
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
-  "bonding_mode": 4,
   "ip_addresses": [
     {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
       "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
       "enabled": true,
       "gateway": "172.16.0.13",
+      "management": true,
       "netmask": "255.255.255.252",
       "network": "172.16.0.12",
-      "management": true,
-      "address_family": 4
+      "public": false,
+      "type": "data"
     },
     {
-      "type": "ipmi",
       "address": "10.255.3.13",
       "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
     }
   ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
   "manufacturer": {
     "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
     "slug": "foxconn"
   },
-  "facility_code": "lab1",
+  "name": "sled3.arm1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "fc:15:b4:97:04:f5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
       "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "name": "xe-0/0/4:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
     },
     {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
       },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "name": "eth01",
       "type": "data"
     },
     {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:f6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
       "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "name": "xe-0/0/5:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
     },
     {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
       "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "name": "Fa0/3",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
     }
   ],
-  "preinstalled_operating_system_version": {}
-}`
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {},
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
 
-	provisioningWithService = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+	provisioningWithService = `
+{
   "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
+  "bonding_mode": 4,
   "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
   "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
     "allow_pxe": true,
     "always_pxe": false,
-    "ip_addresses": [],
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
+    "ip_addresses": [
+      {
+        "address": "147.75.14.16",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.14.15",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
     "ipxe_script_url": null,
     "operating_system_version": {
-      "slug": "deprovision",
       "distro": "centos",
+      "image_tag": null,
       "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
+      "slug": "deprovision",
+      "version": ""
     },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
+  },
   "ip_addresses": [
     {
-    "address": "147.75.14.16",
-    "address_family": 4,
-    "enabled": true,
-    "gateway": "147.75.14.15",
-    "management": true,
-    "netmask": "255.255.255.252",
-    "public": true
-    }
-  ]
-  },
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
-  "bonding_mode": 4,
-  "ip_addresses": [
-    {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
       "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
       "enabled": true,
       "gateway": "172.16.0.13",
+      "management": true,
       "netmask": "255.255.255.252",
       "network": "172.16.0.12",
-      "management": true,
-      "address_family": 4
+      "public": false,
+      "type": "data"
     },
     {
-      "type": "ipmi",
       "address": "10.255.3.13",
       "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
     }
   ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
   "manufacturer": {
     "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
     "slug": "foxconn"
   },
-  "facility_code": "lab1",
+  "name": "sled3.arm1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "fc:15:b4:97:04:f5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
       "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "name": "xe-0/0/4:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
     },
     {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
       },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
       "name": "eth01",
       "type": "data"
     },
     {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:f6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
       "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "name": "xe-0/0/5:2",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
     },
     {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
       "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "name": "Fa0/3",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
     }
   ],
+  "plan_slug": "c1.large.arm",
   "preinstalled_operating_system_version": {},
   "services": {
-    "osie":"v19.01.01.00"
-  }
-}`
+    "osie": "v19.01.01.00"
+  },
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
 )

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -920,3 +920,33 @@ const (
 }
 `
 )
+
+func TestServicesVersion(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		SV       ServicesVersion
+		userdata string
+		osie     string
+	}{
+		{desc: "empty"},
+		{desc: "SV", SV: ServicesVersion{OSIE: "SV osie"}, osie: "SV osie"},
+		{desc: "userdata", userdata: `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "userdata:junk-text", userdata: `I'm a little teapot` + "\n" + `#services={"osie":"userdata osie"}` + "\n" + `short and stout!`, osie: "userdata osie"},
+		{desc: "userdata:cloud-config", userdata: `#cloud-config` + "\n" + `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "userdata:bash", userdata: `#!/usr/bin/bash` + "\n" + `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "invalid userdata, not commented", userdata: `services={"osie":"userdata osie"}`},
+		{desc: "invalid userdata, garbage at end commented", userdata: `services={"osie":"userdata osie"}blah`},
+		{desc: "SV over userdata", SV: ServicesVersion{OSIE: "SV over osie"}, userdata: `#services={"osie":"userdata osie"}`, osie: "SV over osie"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			i := Instance{
+				servicesVersion: test.SV,
+				UserData:        test.userdata,
+			}
+			got := i.ServicesVersion().OSIE
+			if got != test.osie {
+				t.Fatalf("incorrect services version returned, want=%q, got=%q", test.osie, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This lets us specify a custom osie version (for testing, yay testing) by supplying the info at provision time, via userdata. I've set it up so that when API has support for this in the provision call it should work already.