### PR TITLE
Cleanup after new data model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/avast/retry-go v2.2.0+incompatible
 	github.com/betawaffle/tftp-go v0.0.0-20160921192434-dc649c1318ff
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gammazero/workerpool v0.0.0-20200311205957-7b00833861c6
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 	github.com/google/uuid v1.1.1

--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -35,7 +35,7 @@ func TestScriptPerType(t *testing.T) {
 
 			want := fmt.Sprintf(script, version)
 			if !strings.Contains(want, version) {
-				t.Fatalf("expected %s to be present in script:%v\n", version, want)
+				t.Fatalf("expected %s to be present in script:%v", version, want)
 			}
 			if want != got {
 				t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(want, got))

--- a/ipxe/settings.go
+++ b/ipxe/settings.go
@@ -1,7 +1,5 @@
 package ipxe
 
-//import "fmt"
-
 const (
 	AssetTag      = "${asset}"        // Unfilled
 	BoardSerial   = "${board-serial}" // Server Serial Number
@@ -10,15 +8,3 @@ const (
 	ChassisSerial = "${serial}"       // Chassis Serial Number
 	UUID          = "${uuid}"         // 00000000-0000-0000-0000-${mac}
 )
-
-// golangci-lint: unused
-//type smbiosTag struct {
-//	Instance byte
-//	Type     byte
-//	Offset   byte
-//	Len      byte
-//}
-//
-//func (t smbiosTag) String() string {
-//	return fmt.Sprintf("smbios/%d.%d.%d.%d", t.Instance, t.Type, t.Offset, t.Len)
-//}

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -69,7 +69,7 @@ func (j Job) configureDHCP(rep, req *dhcp4.Packet) bool {
 }
 
 func (j Job) isPXEAllowed() bool {
-	if (*j.hardware).HardwareAllowPXE(j.mac) {
+	if j.hardware.HardwareAllowPXE(j.mac) {
 		return true
 	}
 	if j.InstanceID() == "" {

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -58,14 +58,13 @@ func TestSetPXEFilename(t *testing.T) {
 			tt.plan = "0"
 		}
 
-		var hardware packet.Hardware = &packet.HardwareCacher{
-			ID:       "$hardware_id",
-			State:    packet.HardwareState(tt.hState),
-			PlanSlug: "baremetal_" + tt.plan,
-		}
 		j := Job{
-			Logger:   joblog.With("index", i, "hStahe", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
-			hardware: &hardware,
+			Logger: joblog.With("index", i, "hStahe", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
+			hardware: packet.HardwareCacher{
+				ID:       "$hardware_id",
+				State:    packet.HardwareState(tt.hState),
+				PlanSlug: "baremetal_" + tt.plan,
+			},
 			instance: &packet.Instance{
 				ID:       tt.id,
 				State:    packet.InstanceState(tt.iState),
@@ -99,11 +98,10 @@ func TestAllowPXE(t *testing.T) {
 	} {
 		t.Logf("want=%t, hardware=%t, instance=%t, instance_id=%s",
 			tt.want, tt.hw, tt.instance, tt.iid)
-		var hardware packet.Hardware = packet.HardwareCacher{
-			AllowPXE: tt.hw,
-		}
 		j := Job{
-			hardware: &hardware,
+			hardware: packet.HardwareCacher{
+				AllowPXE: tt.hw,
+			},
 			instance: &packet.Instance{
 				ID:       tt.iid,
 				AllowPXE: tt.instance,

--- a/job/events.go
+++ b/job/events.go
@@ -138,26 +138,6 @@ func (j Job) postEvent(kind, body string, private bool) bool {
 	return true
 }
 
-// unused, but keeping for now
-// func (j Job) postFailure(reason string) bool {
-// 	f := failure{
-// 		Reason: reason,
-// 	}
-
-// 	if j.InstanceID() != "" {
-// 		if err := f.postInstance(j.instance.ID); err != nil {
-// 			j.Error(errors.WithMessage(err, "posting instance failure"))
-// 			return false
-// 		}
-// 	} else {
-// 		if err := f.postHardware((*j.hardware).HardwareID()); err != nil {
-// 			j.Error(errors.WithMessage(err, "posting hardware failure"))
-// 			return false
-// 		}
-// 	}
-// 	return true
-// }
-
 func posterFromJSON(b []byte) (poster, error) {
 	if len(b) == 0 {
 		return &event{_kind: "phone-home"}, nil

--- a/job/events.go
+++ b/job/events.go
@@ -54,7 +54,7 @@ func (j Job) PostHardwareProblem(slug string) bool {
 		j.With("problem", slug).Error(errors.WithMessage(err, "encoding hardware problem request"))
 		return false
 	}
-	if _, err := client.PostHardwareProblem((*j.hardware).HardwareID(), bytes.NewReader(b)); err != nil {
+	if _, err := client.PostHardwareProblem(j.hardware.HardwareID(), bytes.NewReader(b)); err != nil {
 		j.With("problem", slug).Error(errors.WithMessage(err, "posting hardware problem"))
 		return false
 	}
@@ -94,7 +94,7 @@ func (j Job) phoneHome(body []byte) bool {
 			j.With("state", j.HardwareState()).Info("ignoring hardware phone-home when state is not preinstalling")
 			return false
 		}
-		id = (*j.hardware).HardwareID()
+		id = j.hardware.HardwareID()
 		typ = "hardware"
 		post = p.postHardware
 	}

--- a/job/events_test.go
+++ b/job/events_test.go
@@ -42,14 +42,13 @@ func TestPhoneHome(t *testing.T) {
 		fmt.Println("test:", name)
 		t.Log("test:", name)
 		reqs = nil
-		var hardware packet.Hardware = packet.HardwareCacher{
-			ID:    "$hardware_id",
-			State: packet.HardwareState(test.state),
-		}
 		j := Job{
-			Logger:   joblog.With("test", name),
-			mode:     modeInstance,
-			hardware: &hardware,
+			Logger: joblog.With("test", name),
+			mode:   modeInstance,
+			hardware: packet.HardwareCacher{
+				ID:    "$hardware_id",
+				State: packet.HardwareState(test.state),
+			},
 			instance: &packet.Instance{
 				ID: test.id,
 				OS: packet.OperatingSystem{

--- a/job/fetch.go
+++ b/job/fetch.go
@@ -11,7 +11,7 @@ var (
 	servers singleflight.Group
 )
 
-func discoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID string) (*packet.Discovery, error) {
+func discoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID string) (packet.Discovery, error) {
 	fetch := func() (interface{}, error) {
 		return client.DiscoverHardwareFromDHCP(mac, giaddr, circuitID)
 	}
@@ -19,10 +19,10 @@ func discoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID str
 	if err != nil {
 		return nil, err
 	}
-	return v.(*packet.Discovery), nil
+	return v.(packet.Discovery), nil
 }
 
-func discoverHardwareFromIP(ip net.IP) (*packet.Discovery, error) {
+func discoverHardwareFromIP(ip net.IP) (packet.Discovery, error) {
 	fetch := func() (interface{}, error) {
 		return client.DiscoverHardwareFromIP(ip)
 	}
@@ -30,5 +30,5 @@ func discoverHardwareFromIP(ip net.IP) (*packet.Discovery, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v.(*packet.Discovery), nil
+	return v.(packet.Discovery), nil
 }

--- a/job/hardware.go
+++ b/job/hardware.go
@@ -47,7 +47,7 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if _, err := client.PostHardwareComponent((*j.hardware).HardwareID(), bytes.NewReader(jsonBody)); err != nil {
+	if _, err := client.PostHardwareComponent(j.hardware.HardwareID(), bytes.NewReader(jsonBody)); err != nil {
 		joblog.Error(errors.Wrap(err, "posting componenents"))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -164,11 +164,6 @@ func (j Job) PrimaryNIC() net.HardwareAddr {
 	return j.mac
 }
 
-// unused, but keeping for now
-// func (j Job) isPrimaryNIC(mac net.HardwareAddr) bool {
-// 	return bytes.Equal(mac, j.PrimaryNIC())
-// }
-
 // HardwareState will return (enrolled burn_in preinstallable preinstalling failed_preinstall provisionable provisioning deprovisioning in_use)
 func (j Job) HardwareState() string {
 	if h := j.hardware; h != nil && (*h).HardwareID() != "" {

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -18,14 +18,14 @@ func (j Job) IsARM() bool {
 
 func (j Job) IsUEFI() bool {
 	if h := j.hardware; h != nil {
-		return (*h).HardwareUEFI(j.mac)
+		return h.HardwareUEFI(j.mac)
 	}
 	return false
 }
 
 func (j Job) Arch() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwareArch(j.mac)
+		return h.HardwareArch(j.mac)
 	}
 	return ""
 }
@@ -105,7 +105,7 @@ func (j Job) ID() string {
 
 func (j Job) Interfaces() []packet.Port {
 	if h := j.hardware; h != nil {
-		return (*h).Interfaces()
+		return h.Interfaces()
 	}
 	return nil
 }
@@ -126,35 +126,35 @@ func (j Job) InterfaceMAC(i int) net.HardwareAddr {
 
 func (j Job) HardwareID() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwareID()
+		return h.HardwareID()
 	}
 	return ""
 }
 
 func (j Job) FacilityCode() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwareFacilityCode()
+		return h.HardwareFacilityCode()
 	}
 	return ""
 }
 
 func (j Job) PlanSlug() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwarePlanSlug()
+		return h.HardwarePlanSlug()
 	}
 	return ""
 }
 
 func (j Job) PlanVersionSlug() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwarePlanVersionSlug()
+		return h.HardwarePlanVersionSlug()
 	}
 	return ""
 }
 
 func (j Job) Manufacturer() string {
 	if h := j.hardware; h != nil {
-		return (*h).HardwareManufacturer()
+		return h.HardwareManufacturer()
 	}
 	return ""
 }
@@ -166,41 +166,41 @@ func (j Job) PrimaryNIC() net.HardwareAddr {
 
 // HardwareState will return (enrolled burn_in preinstallable preinstalling failed_preinstall provisionable provisioning deprovisioning in_use)
 func (j Job) HardwareState() string {
-	if h := j.hardware; h != nil && (*h).HardwareID() != "" {
-		return string((*h).HardwareState())
+	if h := j.hardware; h != nil && h.HardwareID() != "" {
+		return string(h.HardwareState())
 	}
 	return ""
 }
 
 func (j Job) ServicesVersion() string {
-	if h := j.hardware; h != nil && (*h).HardwareID() != "" {
-		return (*h).HardwareServicesVersion()
+	if h := j.hardware; h != nil && h.HardwareID() != "" {
+		return h.HardwareServicesVersion()
 	}
 	return ""
 }
 
 // CanWorkflow checks if workflow is allowed
 func (j Job) CanWorkflow() bool {
-	return (*j.hardware).HardwareAllowWorkflow(j.mac)
+	return j.hardware.HardwareAllowWorkflow(j.mac)
 }
 
 func (j Job) OsieBaseURL() string {
 	if h := j.hardware; h != nil {
-		return (*j.hardware).OsieBaseURL(j.mac)
+		return j.hardware.OsieBaseURL(j.mac)
 	}
 	return ""
 }
 
 func (j Job) KernelPath() string {
 	if h := j.hardware; h != nil {
-		return (*j.hardware).KernelPath(j.mac)
+		return j.hardware.KernelPath(j.mac)
 	}
 	return ""
 }
 
 func (j Job) InitrdPath() string {
 	if h := j.hardware; h != nil {
-		return (*j.hardware).InitrdPath(j.mac)
+		return j.hardware.InitrdPath(j.mac)
 	}
 	return ""
 }

--- a/job/job.go
+++ b/job/job.go
@@ -95,11 +95,6 @@ func (j Job) MarkDeviceActive() {
 	}
 }
 
-// golangci-lint: unused
-//func (j Job) markFailed(reason string) {
-//	j.postFailure(reason)
-//}
-
 func (j *Job) setup(dp *packet.Discovery) error {
 	d := *dp
 	dh := *d.Hardware()

--- a/job/job.go
+++ b/job/job.go
@@ -30,7 +30,7 @@ type Job struct {
 	mode Mode
 	dhcp dhcp.Config
 
-	hardware *packet.Hardware
+	hardware packet.Hardware
 	instance *packet.Instance
 }
 
@@ -74,7 +74,7 @@ func CreateFromIP(ip net.IP) (Job, error) {
 	if err != nil {
 		return Job{}, errors.WithMessage(err, "discovering from ip address")
 	}
-	mac := (*d).GetMAC(ip)
+	mac := d.GetMAC(ip)
 	if mac.String() == packet.ZeroMAC.String() {
 		joblog.With("ip", ip).Fatal(errors.New("somehow got a zero mac"))
 	}
@@ -95,9 +95,8 @@ func (j Job) MarkDeviceActive() {
 	}
 }
 
-func (j *Job) setup(dp *packet.Discovery) error {
-	d := *dp
-	dh := *d.Hardware()
+func (j *Job) setup(d packet.Discovery) error {
+	dh := d.Hardware()
 
 	j.Logger = joblog.With("mac", j.mac, "hardware.id", dh.HardwareID())
 

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -47,9 +47,9 @@ func TestSetupDiscover(t *testing.T) {
 	}
 
 	j := &Job{mac: macIPMI.HardwareAddr()}
-	j.setup(&d)
+	j.setup(d)
 
-	dh := *d.Hardware()
+	dh := d.Hardware()
 	h := dh.(*packet.HardwareCacher)
 
 	mode := d.Mode()
@@ -102,11 +102,11 @@ func TestSetupManagement(t *testing.T) {
 		},
 	}
 
-	dh := *d.Hardware()
+	dh := d.Hardware()
 	h := dh.(*packet.HardwareCacher)
 
 	j := &Job{mac: macIPMI.HardwareAddr()}
-	j.setup(&d)
+	j.setup(d)
 
 	mode := d.Mode()
 
@@ -138,7 +138,7 @@ func TestSetupInstance(t *testing.T) {
 	d, macs, _ = MakeHardwareWithInstance()
 
 	j := &Job{mac: macs[1].HardwareAddr()}
-	j.setup(&d)
+	j.setup(d)
 
 	mode := d.Mode()
 
@@ -165,7 +165,7 @@ func TestSetupFails(t *testing.T) {
 	var d packet.Discovery = &packet.DiscoveryCacher{HardwareCacher: &packet.HardwareCacher{}}
 	j := &Job{}
 
-	err := j.setup(&d)
+	err := j.setup(d)
 	if err == nil {
 		t.Fatal("expected an error but got nil")
 	}

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -56,22 +56,22 @@ func TestSetupDiscover(t *testing.T) {
 
 	wantMode := "management"
 	if mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
+		t.Fatalf("incorect mode, want: %v, got: %v", wantMode, mode)
 	}
 
 	dc := d.(*packet.DiscoveryCacher)
 	netConfig := dc.HardwareIPMI()
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
-		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
+		t.Fatalf("incorrect Address, want: %v, got: %v", netConfig.Address, j.dhcp.Address())
 	}
 	if !netConfig.Netmask.Equal(j.dhcp.Netmask()) {
-		t.Fatalf("incorrect Netmask, want: %v, got: %v\n", netConfig.Netmask, j.dhcp.Netmask())
+		t.Fatalf("incorrect Netmask, want: %v, got: %v", netConfig.Netmask, j.dhcp.Netmask())
 	}
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
-		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
+		t.Fatalf("incorrect Gateway, want: %v, got: %v", netConfig.Gateway, j.dhcp.Gateway())
 	}
 	if h.Name != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", h.Name, j.dhcp.Hostname())
+		t.Fatalf("incorrect Hostname, want: %v, got: %v", h.Name, j.dhcp.Hostname())
 	}
 }
 
@@ -112,23 +112,23 @@ func TestSetupManagement(t *testing.T) {
 
 	wantMode := "management"
 	if mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
+		t.Fatalf("incorect mode, want: %v, got: %v", wantMode, mode)
 	}
 
 	dc := d.(*packet.DiscoveryCacher)
 	netConfig := dc.HardwareIPMI()
 
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
-		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
+		t.Fatalf("incorrect Address, want: %v, got: %v", netConfig.Address, j.dhcp.Address())
 	}
 	if !netConfig.Netmask.Equal(j.dhcp.Netmask()) {
-		t.Fatalf("incorrect Netmask, want: %v, got: %v\n", netConfig.Netmask, j.dhcp.Netmask())
+		t.Fatalf("incorrect Netmask, want: %v, got: %v", netConfig.Netmask, j.dhcp.Netmask())
 	}
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
-		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
+		t.Fatalf("incorrect Gateway, want: %v, got: %v", netConfig.Gateway, j.dhcp.Gateway())
 	}
 	if h.Name != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", h.Name, j.dhcp.Hostname())
+		t.Fatalf("incorrect Hostname, want: %v, got: %v", h.Name, j.dhcp.Hostname())
 	}
 }
 
@@ -144,21 +144,21 @@ func TestSetupInstance(t *testing.T) {
 
 	wantMode := "instance"
 	if mode != wantMode {
-		t.Fatalf("incorect mode, want: %v, got: %v\n", wantMode, mode)
+		t.Fatalf("incorect mode, want: %v, got: %v", wantMode, mode)
 	}
 
 	netConfig := d.GetIP(macs[1].HardwareAddr())
 	if !netConfig.Address.Equal(j.dhcp.Address()) {
-		t.Fatalf("incorrect Address, want: %v, got: %v\n", netConfig.Address, j.dhcp.Address())
+		t.Fatalf("incorrect Address, want: %v, got: %v", netConfig.Address, j.dhcp.Address())
 	}
 	if !netConfig.Netmask.Equal(j.dhcp.Netmask()) {
-		t.Fatalf("incorrect Netmask, want: %v, got: %v\n", netConfig.Netmask, j.dhcp.Netmask())
+		t.Fatalf("incorrect Netmask, want: %v, got: %v", netConfig.Netmask, j.dhcp.Netmask())
 	}
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
-		t.Fatalf("incorrect Gateway, want: %v, got: %v\n", netConfig.Gateway, j.dhcp.Gateway())
+		t.Fatalf("incorrect Gateway, want: %v, got: %v", netConfig.Gateway, j.dhcp.Gateway())
 	}
 	if d.Instance().Hostname != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v\n", d.Instance().Hostname, j.dhcp.Hostname())
+		t.Fatalf("incorrect Hostname, want: %v, got: %v", d.Instance().Hostname, j.dhcp.Hostname())
 	}
 }
 func TestSetupFails(t *testing.T) {

--- a/job/mock.go
+++ b/job/mock.go
@@ -37,26 +37,25 @@ func NewMock(t zaptest.TestingT, slug, facility string) Mock {
 	}
 
 	mockLog := log.Test(t, "job.Mock")
-	var hardware packet.Hardware = &packet.HardwareCacher{
-		ID:              uuid.New().String(),
-		PlanSlug:        slug,
-		PlanVersionSlug: planVersion,
-		FacilityCode:    facility,
-		Arch:            arch,
-		State:           "provisionable",
-		UEFI:            uefi,
-		ServicesVersion: servicesVersion,
-	}
 	return Mock{
-		Logger:   mockLog.With("mock", true, "slug", slug, "arch", arch, "uefi", uefi),
-		hardware: &hardware,
+		Logger: mockLog.With("mock", true, "slug", slug, "arch", arch, "uefi", uefi),
+		hardware: &packet.HardwareCacher{
+			ID:              uuid.New().String(),
+			PlanSlug:        slug,
+			PlanVersionSlug: planVersion,
+			FacilityCode:    facility,
+			Arch:            arch,
+			State:           "provisionable",
+			UEFI:            uefi,
+			ServicesVersion: servicesVersion,
+		},
 		instance: &packet.Instance{
 			State: "provisioning",
 		},
 	}
 }
 
-func NewMockFromDiscovery(d *packet.Discovery, mac net.HardwareAddr) Mock {
+func NewMockFromDiscovery(d packet.Discovery, mac net.HardwareAddr) Mock {
 	mockLog, _ := log.Init("job.Mock")
 	j := Job{Logger: mockLog, mac: mac}
 	j.setup(d)
@@ -88,9 +87,9 @@ func (m *Mock) SetMAC(mac string) {
 }
 
 func (m *Mock) SetManufacturer(slug string) {
-	hp := *m.hardware
+	hp := m.hardware
 	h := hp.(*packet.HardwareCacher)
-	(*h).Manufacturer = packet.Manufacturer{Slug: slug}
+	h.Manufacturer = packet.Manufacturer{Slug: slug}
 }
 
 func (m *Mock) SetOSDistro(distro string) {
@@ -111,9 +110,9 @@ func (m *Mock) SetPassword(password string) {
 }
 
 func (m *Mock) SetState(state string) {
-	hp := *m.hardware
+	hp := m.hardware
 	h := hp.(*packet.HardwareCacher)
-	(*h).State = packet.HardwareState(state)
+	h.State = packet.HardwareState(state)
 }
 
 func MakeHardwareWithInstance() (*packet.DiscoveryCacher, []packet.MACAddr, string) {

--- a/job/network.go
+++ b/job/network.go
@@ -3,5 +3,5 @@ package job
 import "github.com/tinkerbell/boots/packet"
 
 func (j Job) BondingMode() packet.BondingMode {
-	return (*j.hardware).HardwareBondingMode()
+	return j.hardware.HardwareBondingMode()
 }

--- a/packet/client.go
+++ b/packet/client.go
@@ -140,15 +140,6 @@ func (c *Client) addHeaders(req *http.Request) {
 	}
 }
 
-// golangci-lint: unused
-//func (c *Client) do(fn func() (*http.Request, error), v interface{}) error {
-//	req, err := fn()
-//	if err != nil {
-//		return err
-//	}
-//	return c.Do(req, v)
-//}
-
 func unmarshalResponse(res *http.Response, result interface{}) error {
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body) // ensure all of the body is read so we can quickly reuse connection

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -32,7 +32,7 @@ type ComponentsResponse struct {
 	Components []Component `json:"components"`
 }
 
-func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID string) (*Discovery, error) {
+func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID string) (Discovery, error) {
 	if mac == nil {
 		return nil, errors.New("missing MAC address")
 	}
@@ -119,10 +119,10 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 	if err := c.Post("/staff/cacher/hardware-discovery", mimeJSON, bytes.NewReader(b), &res); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return res, nil
 }
 
-func (c *Client) DiscoverHardwareFromIP(ip net.IP) (*Discovery, error) {
+func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 	if ip.String() == net.IPv4zero.String() {
 		return nil, errors.New("missing ip address")
 	}
@@ -182,10 +182,10 @@ func (c *Client) GetInstanceIDFromIP(dip net.IP) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if (*d).Instance() == nil {
+	if d.Instance() == nil {
 		return "", nil
 	}
-	return (*d).Instance().ID, nil
+	return d.Instance().ID, nil
 }
 
 // PostHardwareComponent - POSTs a HardwareComponent to the API

--- a/packet/models.go
+++ b/packet/models.go
@@ -206,29 +206,6 @@ type IP struct {
 	Management bool   `json:"management"`
 }
 
-// type NetworkPorts struct {
-// 	Main []Port `json:"main"`
-// 	IPMI Port   `json:"ipmi"`
-// }
-
-// unused, but keeping for now
-// func (p *NetworkPorts) addMain(port Port) {
-// 	var (
-// 		mac   = port.MAC()
-// 		ports = p.Main
-// 	)
-// 	n := len(ports)
-// 	i := sort.Search(n, func(i int) bool {
-// 		return bytes.Compare(mac, ports[i].MAC()) < 0
-// 	})
-// 	if i < n {
-// 		ports = append(append(ports[:i], port), ports[i:]...)
-// 	} else {
-// 		ports = append(ports, port)
-// 	}
-// 	p.Main = ports
-// }
-
 // OperatingSystem holds details for the operating system
 type OperatingSystem struct {
 	Slug     string `json:"slug"`

--- a/packet/models.go
+++ b/packet/models.go
@@ -116,8 +116,10 @@ func NewDiscovery(b []byte) (*Discovery, error) {
 	switch dataModelVersion {
 	case "1":
 		res = &DiscoveryTinkerbellV1{}
-	default:
+	case "":
 		res = &DiscoveryCacher{}
+	default:
+		return nil, errors.New("unknown DATA_MODEL_VERSION")
 	}
 
 	err := json.Unmarshal(b, &res)

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -10,9 +10,9 @@ import (
 
 // models_cacher.go contains the interface methods specific to DiscoveryCacher and HardwareCacher structs
 
-func (d DiscoveryCacher) Hardware() *Hardware {
+func (d DiscoveryCacher) Hardware() Hardware {
 	var h Hardware = d.HardwareCacher
-	return &h
+	return h
 }
 
 func (d DiscoveryCacher) DnsServers(mac net.HardwareAddr) []net.IP {
@@ -131,7 +131,7 @@ func (d DiscoveryCacher) HardwareIP(mac string) *IP {
 
 // hardwareIP returns the IP configuration that should be offered to the hardware (not exported)
 func (d DiscoveryCacher) hardwareIP() *IP {
-	h := *d.Hardware()
+	h := d.Hardware()
 	for _, ip := range h.HardwareIPs() {
 		if ip.Family != 4 {
 			continue

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -58,8 +58,22 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 func TestNewDiscoveryMismatch(t *testing.T) {
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
-	os.Setenv("DATA_MODEL_VERSION", "1")
 
+	os.Unsetenv("DATA_MODEL_VERSION")
+	for name, test := range cacherTests {
+		t.Log(name)
+		d, err := NewDiscovery([]byte(test.json))
+		if err != nil {
+			t.Fatal("NewDiscovery", err)
+		}
+		dt, ok := (*d).(*DiscoveryTinkerbellV1)
+		t.Log(dt)
+		if ok {
+			t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryCacher{}, dt)
+		}
+	}
+
+	os.Setenv("DATA_MODEL_VERSION", "1")
 	for name, test := range tinkerbellTests {
 		t.Log(name)
 		d, err := NewDiscovery([]byte(test.json))
@@ -72,7 +86,6 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 			t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryTinkerbellV1{}, dt)
 		}
 	}
-
 }
 
 func TestDiscoveryCacher(t *testing.T) {

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -19,15 +19,16 @@ func TestNewDiscoveryCacher(t *testing.T) {
 	os.Unsetenv("DATA_MODEL_VERSION")
 
 	for name, test := range cacherTests {
-		t.Log(name)
-		d, err := NewDiscovery([]byte(test.json))
-		if err != nil {
-			t.Fatal("NewDiscovery", err)
-		}
-		dc := (*d).(*DiscoveryCacher)
-		if dc.PrimaryDataMAC().String() != test.primaryDataMac {
-			t.Fatalf("unexpected primary data mac, want: %s, got: %s", test.primaryDataMac, dc.PrimaryDataMAC())
-		}
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscovery([]byte(test.json))
+			if err != nil {
+				t.Fatal("NewDiscovery", err)
+			}
+			dc := (*d).(*DiscoveryCacher)
+			if dc.PrimaryDataMAC().String() != test.primaryDataMac {
+				t.Fatalf("unexpected primary data mac, want: %s, got: %s", test.primaryDataMac, dc.PrimaryDataMAC())
+			}
+		})
 	}
 }
 
@@ -37,21 +38,22 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 	os.Setenv("DATA_MODEL_VERSION", "1")
 
 	for name, test := range tinkerbellTests {
-		t.Log(name)
-		d, err := NewDiscovery([]byte(test.json))
-		if err != nil {
-			t.Fatal("NewDiscovery", err)
-		}
-		dt := (*d).(*DiscoveryTinkerbellV1)
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscovery([]byte(test.json))
+			if err != nil {
+				t.Fatal("NewDiscovery", err)
+			}
+			dt := (*d).(*DiscoveryTinkerbellV1)
 
-		mac, err := net.ParseMAC(test.mac)
-		if err != nil {
-			t.Fatal("parse test mac", err)
-		}
+			mac, err := net.ParseMAC(test.mac)
+			if err != nil {
+				t.Fatal("parse test mac", err)
+			}
 
-		if dt.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, dt.Network.InterfaceByMac([]byte(test.mac)).DHCP.IP.Address)
-		}
+			if dt.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
+				t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, dt.Network.InterfaceByMac([]byte(test.mac)).DHCP.IP.Address)
+			}
+		})
 	}
 }
 
@@ -61,200 +63,204 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 
 	os.Unsetenv("DATA_MODEL_VERSION")
 	for name, test := range cacherTests {
-		t.Log(name)
-		d, err := NewDiscovery([]byte(test.json))
-		if err != nil {
-			t.Fatal("NewDiscovery", err)
-		}
-		dt, ok := (*d).(*DiscoveryTinkerbellV1)
-		t.Log(dt)
-		if ok {
-			t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryCacher{}, dt)
-		}
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscovery([]byte(test.json))
+			if err != nil {
+				t.Fatal("NewDiscovery", err)
+			}
+			dt, ok := (*d).(*DiscoveryTinkerbellV1)
+			t.Log(dt)
+			if ok {
+				t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryCacher{}, dt)
+			}
+		})
 	}
 
 	os.Setenv("DATA_MODEL_VERSION", "1")
 	for name, test := range tinkerbellTests {
-		t.Log(name)
-		d, err := NewDiscovery([]byte(test.json))
-		if err != nil {
-			t.Fatal("NewDiscovery", err)
-		}
-		dt, ok := (*d).(*DiscoveryCacher)
-		t.Log(dt)
-		if ok {
-			t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryTinkerbellV1{}, dt)
-		}
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscovery([]byte(test.json))
+			if err != nil {
+				t.Fatal("NewDiscovery", err)
+			}
+			dt, ok := (*d).(*DiscoveryCacher)
+			t.Log(dt)
+			if ok {
+				t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryTinkerbellV1{}, dt)
+			}
+		})
 	}
 }
 
 func TestDiscoveryCacher(t *testing.T) {
 	for name, test := range cacherTests {
-		t.Log(name)
-		d := DiscoveryCacher{}
+		t.Run(name, func(t *testing.T) {
+			d := DiscoveryCacher{}
 
-		if err := json.Unmarshal([]byte(test.json), &d); err != nil {
-			t.Fatal(test.mode, err)
-		}
+			if err := json.Unmarshal([]byte(test.json), &d); err != nil {
+				t.Fatal(test.mode, err)
+			}
 
-		mac, err := net.ParseMAC(test.mac)
-		if err != nil {
-			t.Fatal(test.mode, err)
-		}
+			mac, err := net.ParseMAC(test.mac)
+			if err != nil {
+				t.Fatal(test.mode, err)
+			}
 
-		// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
-		t.Logf("MacType: %s", d.MacType(mac.String()))
-		t.Logf("MacIsType=data: %v", d.MacIsType(mac.String(), "data"))
-		t.Logf("primaryDataMac: %s", d.PrimaryDataMAC().HardwareAddr().String())
-		t.Logf("MAC: %v", d.MAC())
-		t.Logf("d.mac: %v", d.mac)
-		t.Logf("mac: %s", mac.String())
-		if d.Instance() != nil {
-			t.Logf("instance: %v", d.Instance())
-			t.Logf("instanceId: %s", d.Instance().ID)
-			t.Logf("instance State: %s", d.Instance().State)
-		}
-		t.Logf("hardware IP: %v", d.hardwareIP())
-		t.Log()
-		h := *d.Hardware()
-		for _, ip := range h.HardwareIPs() {
-			t.Logf("hardware IP: %v", ip)
+			// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
+			t.Logf("MacType: %s", d.MacType(mac.String()))
+			t.Logf("MacIsType=data: %v", d.MacIsType(mac.String(), "data"))
+			t.Logf("primaryDataMac: %s", d.PrimaryDataMAC().HardwareAddr().String())
+			t.Logf("MAC: %v", d.MAC())
+			t.Logf("d.mac: %v", d.mac)
+			t.Logf("mac: %s", mac.String())
+			if d.Instance() != nil {
+				t.Logf("instance: %v", d.Instance())
+				t.Logf("instanceId: %s", d.Instance().ID)
+				t.Logf("instance State: %s", d.Instance().State)
+			}
+			t.Logf("hardware IP: %v", d.hardwareIP())
 			t.Log()
-		}
+			h := *d.Hardware()
+			for _, ip := range h.HardwareIPs() {
+				t.Logf("hardware IP: %v", ip)
+				t.Log()
+			}
 
-		d.SetMAC(mac)
-		mode := d.Mode()
-		if mode != test.mode {
-			t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
-		}
+			d.SetMAC(mac)
+			mode := d.Mode()
+			if mode != test.mode {
+				t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
+			}
 
-		if mode == "" {
-			continue
-		}
+			if mode == "" {
+				return
+			}
 
-		if d.PrimaryDataMAC().String() != test.primaryDataMac {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.primaryDataMac, d.PrimaryDataMAC().String())
-		}
-		if d.MAC().String() != test.mac {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.mac, d.MAC().String())
-		}
+			if d.PrimaryDataMAC().String() != test.primaryDataMac {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.primaryDataMac, d.PrimaryDataMAC().String())
+			}
+			if d.MAC().String() != test.mac {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.mac, d.MAC().String())
+			}
 
-		conf := d.GetIP(mac)
-		if conf.Address.String() != test.conf.Address.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Address, conf.Address)
-		}
-		if conf.Netmask.String() != test.conf.Netmask.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Netmask, conf.Netmask)
-		}
-		if conf.Gateway.String() != test.conf.Gateway.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Gateway, conf.Gateway)
-		}
+			conf := d.GetIP(mac)
+			if conf.Address.String() != test.conf.Address.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Address, conf.Address)
+			}
+			if conf.Netmask.String() != test.conf.Netmask.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Netmask, conf.Netmask)
+			}
+			if conf.Gateway.String() != test.conf.Gateway.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Gateway, conf.Gateway)
+			}
 
-		osie := d.ServicesVersion.Osie
-		if osie != test.osie {
-			t.Fatalf("unexpected osie version, want: %s, got: %s", test.osie, osie)
-		}
+			osie := d.ServicesVersion.Osie
+			if osie != test.osie {
+				t.Fatalf("unexpected osie version, want: %s, got: %s", test.osie, osie)
+			}
+		})
 	}
 }
 
 func TestDiscoveryTinkerbell(t *testing.T) {
 	for name, test := range tinkerbellTests {
-		t.Log(name)
-		d := DiscoveryTinkerbellV1{}
+		t.Run(name, func(t *testing.T) {
+			d := DiscoveryTinkerbellV1{}
 
-		if err := json.Unmarshal([]byte(test.json), &d); err != nil {
-			t.Fatal(test.mode, err)
-		}
+			if err := json.Unmarshal([]byte(test.json), &d); err != nil {
+				t.Fatal(test.mode, err)
+			}
 
-		mac, err := net.ParseMAC(test.mac)
-		if err != nil {
-			t.Fatal("parse test mac", err)
-		}
+			mac, err := net.ParseMAC(test.mac)
+			if err != nil {
+				t.Fatal("parse test mac", err)
+			}
 
-		// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
-		if d.ID != test.id {
-			t.Fatalf("unexpected id, want: %s, got: %s", test.id, d.ID)
-		}
+			// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
+			if d.ID != test.id {
+				t.Fatalf("unexpected id, want: %s, got: %s", test.id, d.ID)
+			}
 
-		t.Logf("d.mac: %s", d.mac)
-		t.Logf("dhcp %v", d.Network.InterfaceByMac(mac).DHCP)
-		t.Log()
-		if d.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, d.Network.InterfaceByMac(mac).DHCP.IP)
-		}
-		if d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC.String() != mac.String() {
-			t.Fatalf("unexpected mac, want: %s, got: %s", mac, d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC)
-		}
-		if d.Network.InterfaceByMac(mac).DHCP.Hostname != test.hostname {
-			t.Fatalf("unexpected hostname, want: %s, got: %s", test.hostname, d.Network.InterfaceByMac(mac).DHCP.Hostname)
-		}
-		if int(d.LeaseTime(mac).Seconds()) != test.leaseTime {
-			t.Fatalf("unexpected lease time, want: %d, got: %d", test.leaseTime, d.LeaseTime(mac))
-		}
-		// note the difference between []string(nil) and []string{}; use cmp.Diff to check
-		if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.NameServers, test.nameServers) {
-			t.Fatalf("unexpected name servers, want: %v, got: %v", test.nameServers, d.Network.InterfaceByMac(mac).DHCP.NameServers)
-		}
-		if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.TimeServers, test.timeServers) {
-			t.Fatalf("unexpected time servers, want: %v, got: %v", test.timeServers, d.Network.InterfaceByMac(mac).DHCP.TimeServers)
-		}
-		if d.Network.InterfaceByMac(mac).DHCP.IP.Gateway.String() != test.ip.Gateway.String() {
-			t.Fatalf("unexpected gateway, want: %s, got: %v", test.ip.Gateway, d.Network.InterfaceByMac(mac).DHCP.IP.Gateway)
-		}
-		if d.Network.InterfaceByMac(mac).DHCP.Arch != test.arch {
-			t.Fatalf("unexpected arch, want: %s, got: %s", test.arch, d.Network.InterfaceByMac(mac).DHCP.Arch)
-		}
-		if d.Network.InterfaceByMac(mac).DHCP.UEFI != test.uefi {
-			t.Fatalf("unexpected uefi, want: %v, got: %v", test.uefi, d.Network.InterfaceByMac(mac).DHCP.UEFI)
-		}
-
-		t.Logf("netboot: %v", d.Network.InterfaceByMac(mac).Netboot)
-		t.Logf("netboot allow_pxe: %v", d.Network.InterfaceByMac(mac).Netboot.AllowPXE)
-		t.Logf("netboot allow_workflow: %v", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
-		t.Logf("netboot ipxe: %v", d.Network.InterfaceByMac(mac).Netboot.IPXE)
-		t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.Osie)
-		t.Log()
-
-		t.Logf("metadata: %v", d.Metadata)
-		t.Logf("metadata state: %v", d.Metadata.State)
-		t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
-		t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
-		if d.Instance() != nil {
-			t.Logf("instance: %v", d.Instance())
-			t.Logf("instance id: %s", d.Instance().ID)
-			t.Logf("instance state: %s", d.Instance().State)
-		}
-		t.Logf("metadata custom: %v", d.Metadata.Custom)
-		t.Logf("metadata facility: %v", d.Metadata.Facility)
-
-		//t.Logf("hardware IP: %v", d.hardwareIP())
-		t.Log()
-		h := *d.Hardware()
-		for _, ip := range h.HardwareIPs() {
-			t.Logf("hardware IP: %v", ip)
+			t.Logf("d.mac: %s", d.mac)
+			t.Logf("dhcp %v", d.Network.InterfaceByMac(mac).DHCP)
 			t.Log()
-		}
+			if d.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
+				t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, d.Network.InterfaceByMac(mac).DHCP.IP)
+			}
+			if d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC.String() != mac.String() {
+				t.Fatalf("unexpected mac, want: %s, got: %s", mac, d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC)
+			}
+			if d.Network.InterfaceByMac(mac).DHCP.Hostname != test.hostname {
+				t.Fatalf("unexpected hostname, want: %s, got: %s", test.hostname, d.Network.InterfaceByMac(mac).DHCP.Hostname)
+			}
+			if int(d.LeaseTime(mac).Seconds()) != test.leaseTime {
+				t.Fatalf("unexpected lease time, want: %d, got: %d", test.leaseTime, d.LeaseTime(mac))
+			}
+			// note the difference between []string(nil) and []string{}; use cmp.Diff to check
+			if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.NameServers, test.nameServers) {
+				t.Fatalf("unexpected name servers, want: %v, got: %v", test.nameServers, d.Network.InterfaceByMac(mac).DHCP.NameServers)
+			}
+			if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.TimeServers, test.timeServers) {
+				t.Fatalf("unexpected time servers, want: %v, got: %v", test.timeServers, d.Network.InterfaceByMac(mac).DHCP.TimeServers)
+			}
+			if d.Network.InterfaceByMac(mac).DHCP.IP.Gateway.String() != test.ip.Gateway.String() {
+				t.Fatalf("unexpected gateway, want: %s, got: %v", test.ip.Gateway, d.Network.InterfaceByMac(mac).DHCP.IP.Gateway)
+			}
+			if d.Network.InterfaceByMac(mac).DHCP.Arch != test.arch {
+				t.Fatalf("unexpected arch, want: %s, got: %s", test.arch, d.Network.InterfaceByMac(mac).DHCP.Arch)
+			}
+			if d.Network.InterfaceByMac(mac).DHCP.UEFI != test.uefi {
+				t.Fatalf("unexpected uefi, want: %v, got: %v", test.uefi, d.Network.InterfaceByMac(mac).DHCP.UEFI)
+			}
 
-		d.SetMAC(mac)
-		mode := d.Mode()
-		if mode != test.mode {
-			t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
-		}
+			t.Logf("netboot: %v", d.Network.InterfaceByMac(mac).Netboot)
+			t.Logf("netboot allow_pxe: %v", d.Network.InterfaceByMac(mac).Netboot.AllowPXE)
+			t.Logf("netboot allow_workflow: %v", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
+			t.Logf("netboot ipxe: %v", d.Network.InterfaceByMac(mac).Netboot.IPXE)
+			t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.Osie)
+			t.Log()
 
-		if mode == "" {
-			continue
-		}
+			t.Logf("metadata: %v", d.Metadata)
+			t.Logf("metadata state: %v", d.Metadata.State)
+			t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
+			t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
+			if d.Instance() != nil {
+				t.Logf("instance: %v", d.Instance())
+				t.Logf("instance id: %s", d.Instance().ID)
+				t.Logf("instance state: %s", d.Instance().State)
+			}
+			t.Logf("metadata custom: %v", d.Metadata.Custom)
+			t.Logf("metadata facility: %v", d.Metadata.Facility)
 
-		conf := d.GetIP(mac)
-		if conf.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Address, conf.Address)
-		}
-		if conf.Netmask.String() != test.ip.Netmask.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Netmask, conf.Netmask)
-		}
-		if conf.Gateway.String() != test.ip.Gateway.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Gateway, conf.Gateway)
-		}
+			//t.Logf("hardware IP: %v", d.hardwareIP())
+			t.Log()
+			h := *d.Hardware()
+			for _, ip := range h.HardwareIPs() {
+				t.Logf("hardware IP: %v", ip)
+				t.Log()
+			}
+
+			d.SetMAC(mac)
+			mode := d.Mode()
+			if mode != test.mode {
+				t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
+			}
+
+			if mode == "" {
+				return
+			}
+
+			conf := d.GetIP(mac)
+			if conf.Address.String() != test.ip.Address.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Address, conf.Address)
+			}
+			if conf.Netmask.String() != test.ip.Netmask.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Netmask, conf.Netmask)
+			}
+			if conf.Gateway.String() != test.ip.Gateway.String() {
+				t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Gateway, conf.Gateway)
+			}
+		})
 	}
 }
 

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -2,9 +2,11 @@ package packet
 
 import (
 	"encoding/json"
+	"math/rand"
 	"net"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -54,6 +56,21 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 
 			if dt.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
 				t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, dt.Network.InterfaceByMac([]byte(test.mac)).DHCP.IP.Address)
+			}
+		})
+	}
+}
+
+func TestNewDiscoveryUnknown(t *testing.T) {
+	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
+	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
+
+	for _, version := range []string{"42", strconv.Itoa(rand.Int())} {
+		t.Run(version, func(t *testing.T) {
+			os.Setenv("DATA_MODEL_VERSION", version)
+			_, err := NewDiscovery([]byte("not empty"))
+			if err == nil {
+				t.Error("expected an error, got nil")
 			}
 		})
 	}

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -18,7 +18,7 @@ func TestNewDiscoveryCacher(t *testing.T) {
 	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
 	os.Unsetenv("DATA_MODEL_VERSION")
 
-	for name, test := range tests {
+	for name, test := range cacherTests {
 		t.Log(name)
 		d, err := NewDiscovery([]byte(test.json))
 		if err != nil {
@@ -80,7 +80,7 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 }
 
 func TestDiscoveryCacher(t *testing.T) {
-	for name, test := range tests {
+	for name, test := range cacherTests {
 		t.Log(name)
 		d := DiscoveryCacher{}
 
@@ -320,7 +320,7 @@ var tinkerbellTests = map[string]struct {
 	},
 }
 
-var tests = map[string]struct {
+var cacherTests = map[string]struct {
 	mac            string
 	primaryDataMac string
 	mode           string

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -432,1119 +432,1019 @@ var tests = map[string]struct {
 	},
 }
 
+// use vim's (or equivalent) `!jq -S` on these strings
 const (
 	newJsonStructUseDefaults = `
-	{
-	  "id":"fde7c87c-d154-448e-9fce-7eb7bdec90c0",
-	  "network":{
-		 "interfaces":[
-			{
-			   "dhcp":{
-				  "mac":"ec:0d:9a:c0:01:0d",
-				  "ip":{
-					 "address":"192.168.1.5",
-					 "netmask":"255.255.255.248",
-					 "gateway":"192.168.1.1"
-				  },
-				  "hostname":"server001",
-				  "name_servers": ["1.2.3.4"],
-				  "time_servers": [],
-				  "arch":"x86_64",
-				  "uefi":false
-			   },
-			   "netboot":{
-				  "allow_pxe":true,
-				  "allow_workflow":true,
-				  "ipxe":{
-					 "url":"http://url/menu.ipxe",
-					 "contents":"#!ipxe"
-				  },
-				  "osie":{
-					 "kernel":"vmlinuz-x86_64",
-					 "initrd":"",
-					 "base_url":""
-				  }
-			   }
-			}
-		 ]
-	  }
+{
+  "id": "fde7c87c-d154-448e-9fce-7eb7bdec90c0",
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "hostname": "server001",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "ec:0d:9a:c0:01:0d",
+          "name_servers": [
+            "1.2.3.4"
+          ],
+          "time_servers": [],
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true,
+          "ipxe": {
+            "contents": "#!ipxe",
+            "url": "http://url/menu.ipxe"
+          },
+          "osie": {
+            "base_url": "",
+            "initrd": "",
+            "kernel": "vmlinuz-x86_64"
+          }
+        }
+      }
+    ]
+  }
 }
 `
-
 	newJsonStruct = `
-	{
-	  "id":"fde7c87c-d154-447e-9fce-7eb7bdec90c0",
-	  "network":{
-		 "interfaces":[
-			{
-			   "dhcp":{
-				  "mac":"ec:0d:9a:c0:01:0c",
-				  "ip":{
-					 "address":"192.168.1.5",
-					 "netmask":"255.255.255.248",
-					 "gateway":"192.168.1.1"
-				  },
-				  "hostname":"server001",
-				  "lease_time":172801,
-				  "name_servers": [],
-				  "time_servers": [],
-				  "arch":"x86_64",
-				  "uefi":false
-			   },
-			   "netboot":{
-				  "allow_pxe":true,
-				  "allow_workflow":true,
-				  "ipxe":{
-					 "url":"http://url/menu.ipxe",
-					 "contents":"#!ipxe"
-				  },
-				  "osie":{
-					 "kernel":"vmlinuz-x86_64",
-					 "initrd":"",
-					 "base_url":""
-				  }
-			   }
-			}
-		 ]
-	  },
-	  "metadata":{
-		 "state":"",
-		 "bonding_mode":5,
-		 "manufacturer":{
-			"id":"",
-			"slug":""
-		 },
-		 "instance":{},
-		 "custom":{
-			"preinstalled_operating_system_version":{},
-			"private_subnets":[]
-		 },
-		 "facility":{
-			"plan_slug":"c2.medium.x86",
-			"plan_version_slug":"",
-			"facility_code":"ewr1"
-		 }
-	  }
-	}
+{
+  "id": "fde7c87c-d154-447e-9fce-7eb7bdec90c0",
+  "metadata": {
+    "bonding_mode": 5,
+    "custom": {
+      "preinstalled_operating_system_version": {},
+      "private_subnets": []
+    },
+    "facility": {
+      "facility_code": "ewr1",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {},
+    "manufacturer": {
+      "id": "",
+      "slug": ""
+    },
+    "state": ""
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "hostname": "server001",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "lease_time": 172801,
+          "mac": "ec:0d:9a:c0:01:0c",
+          "name_servers": [],
+          "time_servers": [],
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true,
+          "ipxe": {
+            "contents": "#!ipxe",
+            "url": "http://url/menu.ipxe"
+          },
+          "osie": {
+            "base_url": "",
+            "initrd": "",
+            "kernel": "vmlinuz-x86_64"
+          }
+        }
+      }
+    ]
+  }
+}
  `
 	fullStructTinkerbell = `
-	{
-	  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
-	  "metadata": {
-		"bonding_mode": 5,
-		"custom": {
-		  "preinstalled_operating_system_version": {},
-		  "private_subnets": []
-		},
-		"facility": {
-		  "facility_code": "ewr1",
-		  "plan_slug": "c2.medium.x86",
-		  "plan_version_slug": ""
-		},
-		"instance": {
-		  "crypted_root_password": "redacted",
-		  "operating_system_version": {
-			"distro": "ubuntu",
-			"os_slug": "ubuntu_18_04",
-			"version": "18.04"
-		  },
-		  "storage": {
-			"disks": [
-			  {
-				"device": "/dev/sda",
-				"partitions": [
-				  {
-					"label": "BIOS",
-					"number": 1,
-					"size": 4096
-				  },
-				  {
-					"label": "SWAP",
-					"number": 2,
-					"size": 3993600
-				  },
-				  {
-					"label": "ROOT",
-					"number": 3,
-					"size": 0
-				  }
-				],
-				"wipe_table": true
-			  }
-			],
-			"filesystems": [
-			  {
-				"mount": {
-				  "create": {
-					"options": ["-L", "ROOT"]
-				  },
-				  "device": "/dev/sda3",
-				  "format": "ext4",
-				  "point": "/"
-				}
-			  },
-			  {
-				"mount": {
-				  "create": {
-					"options": ["-L", "SWAP"]
-				  },
-				  "device": "/dev/sda2",
-				  "format": "swap",
-				  "point": "none"
-				}
-			  }
-			]
-		  }
-		},
-		"manufacturer": {
-		  "id": "",
-		  "slug": ""
-		},
-		"state": ""
-	  },
-	  "network": {
-		"interfaces": [
-		  {
-			"dhcp": {
-			  "arch": "x86_64",
-			  "hostname": "server001",
-			  "ip": {
-				"address": "192.168.1.5",
-				"gateway": "192.168.1.1",
-				"netmask": "255.255.255.248"
-			  },
-			  "lease_time": 86400,
-			  "mac": "00:00:00:00:00:00",
-			  "name_servers": [],
-			  "time_servers": [],
-			  "uefi": false
-			},
-			"netboot": {
-			  "allow_pxe": true,
-			  "allow_workflow": true,
-			  "ipxe": {
-				"contents": "#!ipxe",
-				"url": "http://url/menu.ipxe"
-			  },
-			  "osie": {
-				"base_url": "",
-				"initrd": "",
-				"kernel": "vmlinuz-x86_64"
-			  }
-			}
-		  }
-		]
-	  }
-	}`
-	discovered = `
-	{
-	  "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
-	  "management": {
-	    "address": "10.250.142.74",
-	    "gateway": "10.250.142.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "network_ports": [
-	    {
-	      "data": {
-		    "mac": "84:b5:9c:cf:17:01"
-	      },
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ]
-	}
-`
-
-	noInstance = `
-	{
-	  "arch": "x86_64",
-	  "bonding_mode": 4,
-	  "efi_boot": true,
-	  "facility_code": "lab1",
-	  "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
-	  "instance": {},
-	  "management": {
-	    "address": "10.255.252.16",
-	    "gateway": "10.255.252.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "ip_addresses": [
-	    {
-		  "address": "172.16.0.3",
-	      "address_family": 4,
-		  "enabled": true,
-		  "gateway": "172.16.0.2",
-		  "management": true,
-		  "netmask": "255.255.255.252",
-		  "public": false
-	    }
-	  ],
-	  "manufacturer": {
-	    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
-	    "slug": "supermicro"
-	  },
-	  "name": "sled5.mc1.d11.lab1.packet.net",
-	  "network_ports": [
-	    {
-	      "connected_port": {
-	        "data": {
-		      "bond": null,
-		      "mac": null
-		    },
-		    "id": "0b7fc8dc-33bf-4802-903f-55c4d076bfc7",
-		    "name": "ge-0/0/4",
-		    "type": "data"
-	      },
-	      "data": {
-		    "bond": "bond0",
-		    "mac": "00:25:90:e7:6c:78"
-	      },
-	      "id": "179b020a-74ba-4969-a97a-f8e03b3877c8",
-	      "name": "eth0",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "216f9b60-6a99-460c-9e55-99becbd8776e",
-		"name": "ge-1/0/4",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:6c:79"
-	      },
-	      "id": "f2088273-a38f-4005-ba11-845e8e2aa342",
-	      "name": "eth1",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "c7389751-1699-4e17-ba1f-f1fb439aa666",
-		"name": "Fa0/5",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": null,
-		"mac": "00:25:90:f6:2f:2d"
-	      },
-	      "id": "e6db1b93-f718-4bd1-9dea-05725a04a87a",
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ],
-	  "plan_slug": "c1.small.x86",
-	  "state": "in_use",
-	  "type": "sled",
-	  "vlan_id": null
-	}
-`
-
-	preinstalling = `
 {
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "preinstalling",
-  "vlan_id": "122",
-  "efi_boot": true,
-  "instance": {},
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "bonding_mode": 5,
+    "custom": {
+      "preinstalled_operating_system_version": {},
+      "private_subnets": []
+    },
+    "facility": {
+      "facility_code": "ewr1",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {
+      "crypted_root_password": "redacted",
+      "operating_system_version": {
+        "distro": "ubuntu",
+        "os_slug": "ubuntu_18_04",
+        "version": "18.04"
+      },
+      "storage": {
+        "disks": [
+          {
+            "device": "/dev/sda",
+            "partitions": [
+              {
+                "label": "BIOS",
+                "number": 1,
+                "size": 4096
+              },
+              {
+                "label": "SWAP",
+                "number": 2,
+                "size": 3993600
+              },
+              {
+                "label": "ROOT",
+                "number": 3,
+                "size": 0
+              }
+            ],
+            "wipe_table": true
+          }
+        ],
+        "filesystems": [
+          {
+            "mount": {
+              "create": {
+                "options": [
+                  "-L",
+                  "ROOT"
+                ]
+              },
+              "device": "/dev/sda3",
+              "format": "ext4",
+              "point": "/"
+            }
+          },
+          {
+            "mount": {
+              "create": {
+                "options": [
+                  "-L",
+                  "SWAP"
+                ]
+              },
+              "device": "/dev/sda2",
+              "format": "swap",
+              "point": "none"
+            }
+          }
+        ]
+      }
+    },
+    "manufacturer": {
+      "id": "",
+      "slug": ""
+    },
+    "state": ""
   },
-  "bonding_mode": 4,
-  "ip_addresses": [
-    {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
-      "address": "172.16.0.16",
-      "enabled": true,
-      "gateway": "172.16.0.15",
-      "netmask": "255.255.255.252",
-      "network": "172.16.0.14",
-      "management": true,
-      "address_family": 4
-    },
-    {
-      "type": "ipmi",
-      "address": "10.255.3.13",
-      "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
-    }
-  ],
-  "manufacturer": {
-    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
-    "slug": "foxconn"
-  },
-  "facility_code": "lab1",
-  "network_ports": [
-    {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "00:25:99:e7:6c:78",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
-      "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
-        "data": {
-          "mac": null,
-          "bond": null
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "hostname": "server001",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "lease_time": 86400,
+          "mac": "00:00:00:00:00:00",
+          "name_servers": [],
+          "time_servers": [],
+          "uefi": false
         },
-        "name": "xe-0/0/4:2",
-        "type": "data"
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true,
+          "ipxe": {
+            "contents": "#!ipxe",
+            "url": "http://url/menu.ipxe"
+          },
+          "osie": {
+            "base_url": "",
+            "initrd": "",
+            "kernel": "vmlinuz-x86_64"
+          }
+        }
       }
-    },
-    {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
-      "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
-      },
-      "name": "eth01",
-      "type": "data"
-    },
-    {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "00:25:99:e7:6c:79",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
-      "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "xe-0/0/5:2",
-        "type": "data"
-      }
-    },
-    {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
-      "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "Fa0/3",
-        "type": "data"
-      }
-    }
-  ],
-  "preinstalled_operating_system_version": {
-    "distro": "centos",
-    "image_tag": null,
-    "os_slug": "centos_7",
-    "slug": "centos_7-t1.small.x86",
-    "version": "7"
+    ]
   }
-}`
-	withInstance = `
-	{
-	  "arch": "x86_64",
-	  "bonding_mode": 4,
-	  "efi_boot": true,
-	  "facility_code": "lab1",
-	  "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
-	  "ip_addresses": [
-	    {
-		  "address": "172.16.0.7",
-	      "address_family": 4,
-		  "enabled": true,
-		  "gateway": "172.16.0.6",
-		  "management": true,
-		  "netmask": "255.255.255.252",
-		  "public": false
-	    }
-	  ],
-	  "instance": {
-	    "allow_pxe": true,
-	    "always_pxe": false,
-	    "hostname": "test.smr.2",
-	    "id": "1d62730e-a7b6-4600-a424-17d26ccc1f59",
-	    "ip_addresses": [
-	      {
-		    "address": "147.75.193.106",
-		    "address_family": 4,
-		    "enabled": true,
-		    "gateway": "147.75.193.105",
-		    "management": true,
-		    "netmask": "255.255.255.252",
-		    "public": true
-	      }
-	    ],
-	    "ipxe_script_url": null,
-	    "operating_system_version": {
-	      "distro": "centos",
-	      "image_tag": null,
-	      "os_slug": "deprovision",
-	      "slug": "deprovision",
-	      "version": ""
-	    },
-	    "rescue": false,
-	    "ssh_keys": [],
-	    "state": "failed",
-	    "userdata": null
-	  },
-	  "management": {
-	    "address": "10.255.252.15",
-	    "gateway": "10.255.252.1",
-	    "netmask": "255.255.255.0"
-	  },
-	  "manufacturer": {
-	    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
-	    "slug": "supermicro"
-	  },
-	  "name": "sled4.mc1.d11.lab1.packet.net",
-	  "network_ports": [
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "32480a81-d644-4226-a209-c600d9cc21d4",
-		"name": "ge-0/0/3",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:68:da"
-	      },
-	      "id": "3580ace2-1121-4ef9-8cd0-d471f8dc6fe5",
-	      "name": "eth0",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "5bd48979-f598-4e0a-969b-1e1bc8bd7284",
-		"name": "ge-1/0/3",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": "bond0",
-		"mac": "00:25:90:e7:68:db"
-	      },
-	      "id": "5415f58c-9f4a-4994-9f05-361fb646bce7",
-	      "name": "eth1",
-	      "type": "data"
-	    },
-	    {
-	      "connected_port": {
-		"data": {
-		  "bond": null,
-		  "mac": null
-		},
-		"id": "aeaec5b9-f820-4be4-abfb-3add725283a8",
-		"name": "Fa0/4",
-		"type": "data"
-	      },
-	      "data": {
-		"bond": null,
-		"mac": "00:25:90:f6:28:5b"
-	      },
-	      "id": "8c775f93-4ada-44ac-a9c7-6639bd3f3349",
-	      "name": "ipmi0",
-	      "type": "ipmi"
-	    }
-	  ],
-	  "plan_slug": "c1.small.x86",
-	  "state": "in_use",
-	  "type": "sled",
-	  "vlan_id": null
-	}
+}
 `
-	deprovisioning = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
-  "efi_boot": true,
-  "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
-    "allow_pxe": true,
-    "always_pxe": false,
-    "ip_addresses": [],
-    "ipxe_script_url": null,
-    "operating_system_version": {
-      "slug": "deprovision",
-      "distro": "centos",
-      "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
-    }
-  },
-  "plan_slug": "c1.large.arm",
+	discovered = `
+{
+  "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
   "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
+    "address": "10.250.142.74",
+    "gateway": "10.250.142.1",
     "netmask": "255.255.255.0"
   },
-  "bonding_mode": 4,
-  "ip_addresses": [
-    {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
-      "address": "172.16.0.14",
-      "enabled": true,
-      "gateway": "172.16.0.13",
-      "netmask": "255.255.255.252",
-      "network": "172.16.0.12",
-      "management": true,
-      "address_family": 4
-    },
-    {
-      "type": "ipmi",
-      "address": "10.255.3.13",
-      "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
-    }
-  ],
-  "manufacturer": {
-    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
-    "slug": "foxconn"
-  },
-  "facility_code": "lab1",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
       "data": {
-        "mac": "fc:15:b4:97:04:e5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
-      "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "xe-0/0/4:2",
-        "type": "data"
-      }
-    },
-    {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
-      "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
-      },
-      "name": "eth01",
-      "type": "data"
-    },
-    {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:e6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
-      "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "xe-0/0/5:2",
-        "type": "data"
-      }
-    },
-    {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
+        "mac": "84:b5:9c:cf:17:01"
       },
       "name": "ipmi0",
-      "type": "ipmi",
-      "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "Fa0/3",
-        "type": "data"
-      }
-    }
-  ],
-  "preinstalled_operating_system_version": {}
-}`
-
-	provisioning = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
-  "efi_boot": true,
-  "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
-    "allow_pxe": true,
-    "always_pxe": false,
-    "ip_addresses": [],
-    "ipxe_script_url": null,
-    "operating_system_version": {
-      "slug": "deprovision",
-      "distro": "centos",
-      "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
-    },
-	"ip_addresses": [
-	  {
-		"address": "147.75.14.16",
-		"address_family": 4,
-		"enabled": true,
-		"gateway": "147.75.14.15",
-		"management": true,
-		"netmask": "255.255.255.252",
-		"public": true
-	  }
-	]
-  },
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
-  "bonding_mode": 4,
-  "ip_addresses": [
-    {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
-      "address": "172.16.0.14",
-      "enabled": true,
-      "gateway": "172.16.0.13",
-      "netmask": "255.255.255.252",
-      "network": "172.16.0.12",
-      "management": true,
-      "address_family": 4
-    },
-    {
-      "type": "ipmi",
-      "address": "10.255.3.13",
-      "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
-    }
-  ],
-  "manufacturer": {
-    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
-    "slug": "foxconn"
-  },
-  "facility_code": "lab1",
-  "network_ports": [
-    {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "fc:15:b4:97:04:f5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
-      "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "xe-0/0/4:2",
-        "type": "data"
-      }
-    },
-    {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
-      "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
-      },
-      "name": "eth01",
-      "type": "data"
-    },
-    {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:f6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
-      "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "xe-0/0/5:2",
-        "type": "data"
-      }
-    },
-    {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
-      "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
-        "data": {
-          "mac": null,
-          "bond": null
-        },
-        "name": "Fa0/3",
-        "type": "data"
-      }
-    }
-  ],
-  "preinstalled_operating_system_version": {}
-}`
-
-	provisioningWithService = `{
-  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "arch": "aarch64",
-  "name": "sled3.arm1.d11.lab1.packet.net",
-  "type": "sled",
-  "state": "deprovisioning",
-  "vlan_id": "122",
-  "efi_boot": true,
-  "instance": {
-    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
-    "state": "deprovisioning",
-    "rescue": false,
-    "hostname": "testing-layer-2",
-    "ssh_keys": [],
-    "userdata": null,
-    "allow_pxe": true,
-    "always_pxe": false,
-    "ip_addresses": [],
-    "ipxe_script_url": null,
-    "operating_system_version": {
-      "slug": "deprovision",
-      "distro": "centos",
-      "os_slug": "deprovision",
-      "version": "",
-      "image_tag": null
-    },
-  "ip_addresses": [
-    {
-    "address": "147.75.14.16",
-    "address_family": 4,
-    "enabled": true,
-    "gateway": "147.75.14.15",
-    "management": true,
-    "netmask": "255.255.255.252",
-    "public": true
+      "type": "ipmi"
     }
   ]
-  },
-  "plan_slug": "c1.large.arm",
-  "management": {
-    "type": "ipmi",
-    "address": "10.255.3.13",
-    "gateway": "10.255.3.1",
-    "netmask": "255.255.255.0"
-  },
+}
+`
+	noInstance = `
+{
+  "arch": "x86_64",
   "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
+  "instance": {},
   "ip_addresses": [
     {
-      "cidr": 30,
-      "type": "data",
-      "public": false,
-      "address": "172.16.0.14",
+      "address": "172.16.0.3",
+      "address_family": 4,
       "enabled": true,
-      "gateway": "172.16.0.13",
-      "netmask": "255.255.255.252",
-      "network": "172.16.0.12",
+      "gateway": "172.16.0.2",
       "management": true,
-      "address_family": 4
-    },
-    {
-      "type": "ipmi",
-      "address": "10.255.3.13",
-      "gateway": "10.255.3.1",
-      "netmask": "255.255.255.0"
+      "netmask": "255.255.255.252",
+      "public": false
     }
   ],
-  "manufacturer": {
-    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
-    "slug": "foxconn"
+  "management": {
+    "address": "10.255.252.16",
+    "gateway": "10.255.252.1",
+    "netmask": "255.255.255.0"
   },
-  "facility_code": "lab1",
+  "manufacturer": {
+    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
+    "slug": "supermicro"
+  },
+  "name": "sled5.mc1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
-      "data": {
-        "mac": "fc:15:b4:97:04:f5",
-        "bond": "bond0"
-      },
-      "name": "eth0",
-      "type": "data",
       "connected_port": {
-        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
-        "name": "xe-0/0/4:2",
+        "id": "0b7fc8dc-33bf-4802-903f-55c4d076bfc7",
+        "name": "ge-0/0/4",
         "type": "data"
-      }
-    },
-    {
-      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
-      "data": {
-        "mac": "38:bc:01:c6:cc:de",
-        "bond": null
       },
-      "name": "eth01",
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:6c:78"
+      },
+      "id": "179b020a-74ba-4969-a97a-f8e03b3877c8",
+      "name": "eth0",
       "type": "data"
     },
     {
-      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
-      "data": {
-        "mac": "fc:15:b4:97:04:f6",
-        "bond": "bond0"
-      },
-      "name": "eth1",
-      "type": "data",
       "connected_port": {
-        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
-        "name": "xe-0/0/5:2",
+        "id": "216f9b60-6a99-460c-9e55-99becbd8776e",
+        "name": "ge-1/0/4",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:6c:79"
+      },
+      "id": "f2088273-a38f-4005-ba11-845e8e2aa342",
+      "name": "eth1",
+      "type": "data"
     },
     {
-      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
-      "data": {
-        "mac": "fc:15:b4:97:04:e7",
-        "bond": null
-      },
-      "name": "ipmi0",
-      "type": "ipmi",
       "connected_port": {
-        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
         "data": {
-          "mac": null,
-          "bond": null
+          "bond": null,
+          "mac": null
         },
-        "name": "Fa0/3",
+        "id": "c7389751-1699-4e17-ba1f-f1fb439aa666",
+        "name": "Fa0/5",
         "type": "data"
-      }
+      },
+      "data": {
+        "bond": null,
+        "mac": "00:25:90:f6:2f:2d"
+      },
+      "id": "e6db1b93-f718-4bd1-9dea-05725a04a87a",
+      "name": "ipmi0",
+      "type": "ipmi"
     }
   ],
-  "preinstalled_operating_system_version": {},
-  "services": {
-    "osie":"v19.01.01.00"
-  }
-}`
-	fullStructCacher = `{
-  "id": "55639911-2278-498c-b364-8b2a62f5493c",
-  "name": "test.dfw2.packet.net",
-  "type": "server",
+  "plan_slug": "c1.small.x86",
   "state": "in_use",
-  "allow_pxe": false,
-  "preinstalled_operating_system_version": {},
+  "type": "sled",
+  "vlan_id": null
+}
+`
+	preinstalling = `
+{
+  "arch": "aarch64",
   "bonding_mode": 4,
-  "manufacturer": {
-    "id": "d2ea68db-a82a-4273-a590-594cf311ed52",
-    "slug": "dell"
-  },
-  "plan_slug": "n2.xlarge.x86",
-  "facility_code": "dfw2",
-  "private_subnets": [
-    "10.0.0.0/8"
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {},
+  "ip_addresses": [
+    {
+      "address": "172.16.0.16",
+      "address_family": 4,
+      "cidr": 30,
+      "enabled": true,
+      "gateway": "172.16.0.15",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "network": "172.16.0.14",
+      "public": false,
+      "type": "data"
+    },
+    {
+      "address": "10.255.3.13",
+      "gateway": "10.255.3.1",
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
+    }
   ],
-  "plan_version_slug": "n2.xlarge.x86.01",
   "management": {
     "address": "10.255.3.13",
     "gateway": "10.255.3.1",
     "netmask": "255.255.255.0",
     "type": "ipmi"
   },
-  "arch": "x86_64",
-  "efi_boot": false,
+  "manufacturer": {
+    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
+    "slug": "foxconn"
+  },
+  "name": "sled3.arm1.d11.lab1.packet.net",
   "network_ports": [
     {
-      "id": "c31fb859-1fe0-4a53-b42b-4cfb45fb7185",
-      "type": "data",
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
+        "name": "xe-0/0/4:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:99:e7:6c:78"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
       "name": "eth0",
-      "data": {
-        "mac": "e4:45:19:c4:ba:50",
-        "bond": "bond0"
-      },
-      "connected_ports": [
-        {
-          "id": "dc76eb4f-6e21-4b6a-b622-08d1970b2224",
-          "type": "data",
-          "name": "xe-0/0/14:0",
-          "data": {
-            "mac": null,
-            "bond": null
-          },
-          "hostname": "test.test.dfw2.packet.net"
-        }
-      ]
+      "type": "data"
     },
     {
-      "id": "b676f474-5dc3-4337-8d57-b25b8f7febdf",
-      "type": "data",
+      "data": {
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
+      },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
+      "name": "eth01",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
+        "name": "xe-0/0/5:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:99:e7:6c:79"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
       "name": "eth1",
-      "data": {
-        "mac": "e4:45:19:c4:ba:51",
-        "bond": "bond1"
-      },
-      "connected_ports": [
-        {
-          "id": "a7e87953-0b44-4d4d-af63-2fac95083549",
-          "type": "data",
-          "name": "xe-0/0/15:0",
-          "data": {
-            "mac": null,
-            "bond": null
-          },
-          "hostname": "test.test.dfw2.packet.net"
-        }
-      ]
+      "type": "data"
     },
     {
-      "id": "36ba8732-05a4-46c6-857f-8e5765055394",
-      "type": "data",
-      "name": "eth2",
-      "data": {
-        "mac": "e4:45:19:c4:ba:52",
-        "bond": "bond0"
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
+        "name": "Fa0/3",
+        "type": "data"
       },
-      "connected_ports": [
-        {
-          "id": "d10295d3-2bc6-4e76-afdc-e28383ba0766",
-          "type": "data",
-          "name": "xe-1/0/14:0",
-          "data": {
-            "mac": null,
-            "bond": null
-          },
-          "hostname": "test.test.dfw2.packet.net"
-        }
-      ]
-    },
-    {
-      "id": "b36277ed-602d-4736-8fa3-fc1fa647e1d4",
-      "type": "data",
-      "name": "eth3",
       "data": {
-        "mac": "e4:45:19:c4:ba:53",
-        "bond": "bond1"
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
       },
-      "connected_ports": [
-        {
-          "id": "e8e9d7a2-bc7b-4a3d-9512-8f10b5a3632a",
-          "type": "data",
-          "name": "xe-1/0/15:0",
-          "data": {
-            "mac": null,
-            "bond": null
-          },
-          "hostname": "test.test.dfw2.packet.net"
-        }
-      ]
-    },
-    {
-      "id": "2f038e8a-9381-4dc0-8928-3a621a84fd09",
-      "type": "ipmi",
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
       "name": "ipmi0",
-      "data": {
-        "mac": "f4:79:2b:fa:4f:ae",
-        "bond": null
-      },
-      "connected_ports": [
-        {
-          "id": "1fdcf403-59b3-40e5-a581-885d1349732e",
-          "type": "data",
-          "name": "ge-0/0/29",
-          "data": {
-            "mac": null,
-            "bond": null
-          },
-          "hostname": "rest.test.dfw2.packet.net"
-        }
-      ]
+      "type": "ipmi"
     }
   ],
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {
+    "distro": "centos",
+    "image_tag": null,
+    "os_slug": "centos_7",
+    "slug": "centos_7-t1.small.x86",
+    "version": "7"
+  },
+  "state": "preinstalling",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
+	withInstance = `
+{
+  "arch": "x86_64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
   "instance": {
-    "id": "331d355a-1925-4ecf-ab6b-75990733c50c",
-    "state": "active",
-    "hostname": "test",
-    "allow_pxe": false,
-    "rescue": false,
-    "operating_system_version": {
-      "slug": "vmware_esxi_7_0",
-      "distro": "vmware",
-      "version": "7.0",
-      "image_tag": "abc123",
-      "os_slug": "vmware_esxi_7_0"
-    },
-    "ipxe_script_url": null,
+    "allow_pxe": true,
     "always_pxe": false,
-    "userdata": "",
+    "hostname": "test.smr.2",
+    "id": "1d62730e-a7b6-4600-a424-17d26ccc1f59",
+    "ip_addresses": [
+      {
+        "address": "147.75.193.106",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.193.105",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
+    "ipxe_script_url": null,
+    "operating_system_version": {
+      "distro": "centos",
+      "image_tag": null,
+      "os_slug": "deprovision",
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "failed",
+    "userdata": null
+  },
+  "ip_addresses": [
+    {
+      "address": "172.16.0.7",
+      "address_family": 4,
+      "enabled": true,
+      "gateway": "172.16.0.6",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "public": false
+    }
+  ],
+  "management": {
+    "address": "10.255.252.15",
+    "gateway": "10.255.252.1",
+    "netmask": "255.255.255.0"
+  },
+  "manufacturer": {
+    "id": "f7dbf901-d210-4594-ab82-f529a36bdd70",
+    "slug": "supermicro"
+  },
+  "name": "sled4.mc1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "32480a81-d644-4226-a209-c600d9cc21d4",
+        "name": "ge-0/0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:68:da"
+      },
+      "id": "3580ace2-1121-4ef9-8cd0-d471f8dc6fe5",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "5bd48979-f598-4e0a-969b-1e1bc8bd7284",
+        "name": "ge-1/0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "00:25:90:e7:68:db"
+      },
+      "id": "5415f58c-9f4a-4994-9f05-361fb646bce7",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "aeaec5b9-f820-4be4-abfb-3add725283a8",
+        "name": "Fa0/4",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "00:25:90:f6:28:5b"
+      },
+      "id": "8c775f93-4ada-44ac-a9c7-6639bd3f3349",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.small.x86",
+  "state": "in_use",
+  "type": "sled",
+  "vlan_id": null
+}
+`
+	deprovisioning = `
+{
+  "arch": "aarch64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {
+    "allow_pxe": true,
+    "always_pxe": false,
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
+    "ip_addresses": [],
+    "ipxe_script_url": null,
+    "operating_system_version": {
+      "distro": "centos",
+      "image_tag": null,
+      "os_slug": "deprovision",
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
+  },
+  "ip_addresses": [
+    {
+      "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
+      "enabled": true,
+      "gateway": "172.16.0.13",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "network": "172.16.0.12",
+      "public": false,
+      "type": "data"
+    },
+    {
+      "address": "10.255.3.13",
+      "gateway": "10.255.3.1",
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
+    }
+  ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
+  "manufacturer": {
+    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
+    "slug": "foxconn"
+  },
+  "name": "sled3.arm1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
+        "name": "xe-0/0/4:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:e5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "data": {
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
+      },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
+      "name": "eth01",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
+        "name": "xe-0/0/5:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:e6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
+        "name": "Fa0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {},
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
+	provisioning = `
+{
+  "arch": "aarch64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {
+    "allow_pxe": true,
+    "always_pxe": false,
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
+    "ip_addresses": [
+      {
+        "address": "147.75.14.16",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.14.15",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
+    "ipxe_script_url": null,
+    "operating_system_version": {
+      "distro": "centos",
+      "image_tag": null,
+      "os_slug": "deprovision",
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
+  },
+  "ip_addresses": [
+    {
+      "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
+      "enabled": true,
+      "gateway": "172.16.0.13",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "network": "172.16.0.12",
+      "public": false,
+      "type": "data"
+    },
+    {
+      "address": "10.255.3.13",
+      "gateway": "10.255.3.1",
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
+    }
+  ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
+  "manufacturer": {
+    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
+    "slug": "foxconn"
+  },
+  "name": "sled3.arm1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
+        "name": "xe-0/0/4:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "data": {
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
+      },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
+      "name": "eth01",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
+        "name": "xe-0/0/5:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
+        "name": "Fa0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {},
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
+	provisioningWithService = `
+{
+  "arch": "aarch64",
+  "bonding_mode": 4,
+  "efi_boot": true,
+  "facility_code": "lab1",
+  "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "instance": {
+    "allow_pxe": true,
+    "always_pxe": false,
+    "hostname": "testing-layer-2",
+    "id": "93068549-726c-4adc-8b0f-b93692cb78ff",
+    "ip_addresses": [
+      {
+        "address": "147.75.14.16",
+        "address_family": 4,
+        "enabled": true,
+        "gateway": "147.75.14.15",
+        "management": true,
+        "netmask": "255.255.255.252",
+        "public": true
+      }
+    ],
+    "ipxe_script_url": null,
+    "operating_system_version": {
+      "distro": "centos",
+      "image_tag": null,
+      "os_slug": "deprovision",
+      "slug": "deprovision",
+      "version": ""
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "deprovisioning",
+    "userdata": null
+  },
+  "ip_addresses": [
+    {
+      "address": "172.16.0.14",
+      "address_family": 4,
+      "cidr": 30,
+      "enabled": true,
+      "gateway": "172.16.0.13",
+      "management": true,
+      "netmask": "255.255.255.252",
+      "network": "172.16.0.12",
+      "public": false,
+      "type": "data"
+    },
+    {
+      "address": "10.255.3.13",
+      "gateway": "10.255.3.1",
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
+    }
+  ],
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
+  "manufacturer": {
+    "id": "d31118e9-53ab-48ef-a761-5b8811d9a0f5",
+    "slug": "foxconn"
+  },
+  "name": "sled3.arm1.d11.lab1.packet.net",
+  "network_ports": [
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "49614525-e949-4e1a-8564-4bfc93bc441a",
+        "name": "xe-0/0/4:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f5"
+      },
+      "id": "fe2d825c-339a-490f-ae23-a336a4f28228",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "data": {
+        "bond": null,
+        "mac": "38:bc:01:c6:cc:de"
+      },
+      "id": "f7957820-43aa-48d1-b902-b0865b73c34d",
+      "name": "eth01",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "1b8a43bf-80ab-440b-af8f-f9416e9b9a2c",
+        "name": "xe-0/0/5:2",
+        "type": "data"
+      },
+      "data": {
+        "bond": "bond0",
+        "mac": "fc:15:b4:97:04:f6"
+      },
+      "id": "77ecde07-4b32-408e-bbc0-87295c496f8a",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_port": {
+        "data": {
+          "bond": null,
+          "mac": null
+        },
+        "id": "ee7e96af-2ea0-4f0b-b169-67814ece9800",
+        "name": "Fa0/3",
+        "type": "data"
+      },
+      "data": {
+        "bond": null,
+        "mac": "fc:15:b4:97:04:e7"
+      },
+      "id": "2185ee9c-1c1e-4d70-926a-7404eb41b43b",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "c1.large.arm",
+  "preinstalled_operating_system_version": {},
+  "services": {
+    "osie": "v19.01.01.00"
+  },
+  "state": "deprovisioning",
+  "type": "sled",
+  "vlan_id": "122"
+}
+`
+	fullStructCacher = `
+{
+  "allow_pxe": false,
+  "arch": "x86_64",
+  "bonding_mode": 4,
+  "efi_boot": false,
+  "facility_code": "dfw2",
+  "id": "55639911-2278-498c-b364-8b2a62f5493c",
+  "instance": {
+    "allow_pxe": false,
+    "always_pxe": false,
+    "crypted_root_password": "r3d4c73d",
+    "customdata": {},
+    "hostname": "test",
+    "id": "331d355a-1925-4ecf-ab6b-75990733c50c",
+    "ip_addresses": [],
+    "ipxe_script_url": null,
+    "network_ready": false,
+    "operating_system_version": {
+      "distro": "vmware",
+      "image_tag": "abc123",
+      "os_slug": "vmware_esxi_7_0",
+      "slug": "vmware_esxi_7_0",
+      "version": "7.0"
+    },
+    "project": {
+      "id": "b9638412-a71e-4390-8366-98bc6244725f",
+      "name": "Test",
+      "organization": {
+        "id": "f27c556e-9476-4703-932f-a198b587c60d",
+        "name": "Testing123"
+      },
+      "primary_owner": {
+        "full_name": "Tester Jester",
+        "id": "ca8c6279-1d01-4426-83de-cf7f0d62f0ed"
+      }
+    },
+    "rescue": false,
+    "ssh_keys": [],
+    "state": "active",
     "storage": {
       "disks": [
         {
           "device": "/dev/sda",
-          "wipeTable": true,
           "partitions": [
             {
               "label": "BIOS",
@@ -1561,71 +1461,55 @@ const (
               "number": 3,
               "size": 0
             }
-          ]
+          ],
+          "wipeTable": true
         }
       ],
       "filesystems": [
         {
           "mount": {
-            "device": "/dev/sda3",
-            "format": "ext4",
-            "point": "/",
             "create": {
               "options": [
                 "-L",
                 "ROOT"
               ]
-            }
+            },
+            "device": "/dev/sda3",
+            "format": "ext4",
+            "point": "/"
           }
         },
         {
           "mount": {
-            "device": "/dev/sda2",
-            "format": "swap",
-            "point": "none",
             "create": {
               "options": [
                 "-L",
                 "SWAP"
               ]
-            }
+            },
+            "device": "/dev/sda2",
+            "format": "swap",
+            "point": "none"
           }
         }
       ]
     },
-    "ip_addresses": [],
-    "ssh_keys": [],
     "tags": [],
-    "customdata": {},
-    "project": {
-      "id": "b9638412-a71e-4390-8366-98bc6244725f",
-      "name": "Test",
-      "organization": {
-        "id": "f27c556e-9476-4703-932f-a198b587c60d",
-        "name": "Testing123"
-      },
-      "primary_owner": {
-        "id": "ca8c6279-1d01-4426-83de-cf7f0d62f0ed",
-        "full_name": "Tester Jester"
-      }
-    },
-    "network_ready": false,
-    "crypted_root_password": "r3d4c73d"
+    "userdata": ""
   },
-  "vlan_id": null,
   "ip_addresses": [
     {
       "address": "172.16.10.73",
-      "netmask": "255.255.255.254",
-      "gateway": "172.16.10.72",
       "address_family": 4,
-      "public": false,
-      "management": true,
-      "enabled": true,
-      "network": "172.16.10.72",
       "cidr": 31,
-      "type": "data",
-      "port": "bond0"
+      "enabled": true,
+      "gateway": "172.16.10.72",
+      "management": true,
+      "netmask": "255.255.255.254",
+      "network": "172.16.10.72",
+      "port": "bond0",
+      "public": false,
+      "type": "data"
     },
     {
       "address": "10.255.3.13",
@@ -1634,6 +1518,134 @@ const (
       "type": "ipmi"
     }
   ],
-  "services": {}
-}`
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
+  "manufacturer": {
+    "id": "d2ea68db-a82a-4273-a590-594cf311ed52",
+    "slug": "dell"
+  },
+  "name": "test.dfw2.packet.net",
+  "network_ports": [
+    {
+      "connected_ports": [
+        {
+          "data": {
+            "bond": null,
+            "mac": null
+          },
+          "hostname": "test.test.dfw2.packet.net",
+          "id": "dc76eb4f-6e21-4b6a-b622-08d1970b2224",
+          "name": "xe-0/0/14:0",
+          "type": "data"
+        }
+      ],
+      "data": {
+        "bond": "bond0",
+        "mac": "e4:45:19:c4:ba:50"
+      },
+      "id": "c31fb859-1fe0-4a53-b42b-4cfb45fb7185",
+      "name": "eth0",
+      "type": "data"
+    },
+    {
+      "connected_ports": [
+        {
+          "data": {
+            "bond": null,
+            "mac": null
+          },
+          "hostname": "test.test.dfw2.packet.net",
+          "id": "a7e87953-0b44-4d4d-af63-2fac95083549",
+          "name": "xe-0/0/15:0",
+          "type": "data"
+        }
+      ],
+      "data": {
+        "bond": "bond1",
+        "mac": "e4:45:19:c4:ba:51"
+      },
+      "id": "b676f474-5dc3-4337-8d57-b25b8f7febdf",
+      "name": "eth1",
+      "type": "data"
+    },
+    {
+      "connected_ports": [
+        {
+          "data": {
+            "bond": null,
+            "mac": null
+          },
+          "hostname": "test.test.dfw2.packet.net",
+          "id": "d10295d3-2bc6-4e76-afdc-e28383ba0766",
+          "name": "xe-1/0/14:0",
+          "type": "data"
+        }
+      ],
+      "data": {
+        "bond": "bond0",
+        "mac": "e4:45:19:c4:ba:52"
+      },
+      "id": "36ba8732-05a4-46c6-857f-8e5765055394",
+      "name": "eth2",
+      "type": "data"
+    },
+    {
+      "connected_ports": [
+        {
+          "data": {
+            "bond": null,
+            "mac": null
+          },
+          "hostname": "test.test.dfw2.packet.net",
+          "id": "e8e9d7a2-bc7b-4a3d-9512-8f10b5a3632a",
+          "name": "xe-1/0/15:0",
+          "type": "data"
+        }
+      ],
+      "data": {
+        "bond": "bond1",
+        "mac": "e4:45:19:c4:ba:53"
+      },
+      "id": "b36277ed-602d-4736-8fa3-fc1fa647e1d4",
+      "name": "eth3",
+      "type": "data"
+    },
+    {
+      "connected_ports": [
+        {
+          "data": {
+            "bond": null,
+            "mac": null
+          },
+          "hostname": "rest.test.dfw2.packet.net",
+          "id": "1fdcf403-59b3-40e5-a581-885d1349732e",
+          "name": "ge-0/0/29",
+          "type": "data"
+        }
+      ],
+      "data": {
+        "bond": null,
+        "mac": "f4:79:2b:fa:4f:ae"
+      },
+      "id": "2f038e8a-9381-4dc0-8928-3a621a84fd09",
+      "name": "ipmi0",
+      "type": "ipmi"
+    }
+  ],
+  "plan_slug": "n2.xlarge.x86",
+  "plan_version_slug": "n2.xlarge.x86.01",
+  "preinstalled_operating_system_version": {},
+  "private_subnets": [
+    "10.0.0.0/8"
+  ],
+  "services": {},
+  "state": "in_use",
+  "type": "server",
+  "vlan_id": null
+}
+`
 )

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -102,11 +102,11 @@ func TestDiscoveryCacher(t *testing.T) {
 			t.Logf("instance State: %s", d.Instance().State)
 		}
 		t.Logf("hardware IP: %v", d.hardwareIP())
-		t.Log("")
+		t.Log()
 		h := *d.Hardware()
 		for _, ip := range h.HardwareIPs() {
 			t.Logf("hardware IP: %v", ip)
-			t.Log("")
+			t.Log()
 		}
 
 		d.SetMAC(mac)
@@ -165,7 +165,7 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 
 		t.Logf("d.mac: %s", d.mac)
 		t.Logf("dhcp %v", d.Network.InterfaceByMac(mac).DHCP)
-		t.Log("")
+		t.Log()
 		if d.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
 			t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, d.Network.InterfaceByMac(mac).DHCP.IP)
 		}
@@ -200,7 +200,7 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 		t.Logf("netboot allow_workflow: %v", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
 		t.Logf("netboot ipxe: %v", d.Network.InterfaceByMac(mac).Netboot.IPXE)
 		t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.Osie)
-		t.Log("")
+		t.Log()
 
 		t.Logf("metadata: %v", d.Metadata)
 		t.Logf("metadata state: %v", d.Metadata.State)
@@ -215,11 +215,11 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 		t.Logf("metadata facility: %v", d.Metadata.Facility)
 
 		//t.Logf("hardware IP: %v", d.hardwareIP())
-		t.Log("")
+		t.Log()
 		h := *d.Hardware()
 		for _, ip := range h.HardwareIPs() {
 			t.Logf("hardware IP: %v", ip)
-			t.Log("")
+			t.Log()
 		}
 
 		d.SetMAC(mac)

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestInterfaces(t *testing.T) {
@@ -107,17 +109,12 @@ func TestDiscoveryCacher(t *testing.T) {
 			}
 
 			// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
+			t.Logf("Discovery: %s", spew.Sdump(d))
 			t.Logf("MacType: %s", d.MacType(mac.String()))
 			t.Logf("MacIsType=data: %v", d.MacIsType(mac.String(), "data"))
-			t.Logf("primaryDataMac: %s", d.PrimaryDataMAC().HardwareAddr().String())
+			t.Logf("PrimaryDataMac: %s", d.PrimaryDataMAC().HardwareAddr().String())
 			t.Logf("MAC: %v", d.MAC())
-			t.Logf("d.mac: %v", d.mac)
 			t.Logf("mac: %s", mac.String())
-			if d.Instance() != nil {
-				t.Logf("instance: %v", d.Instance())
-				t.Logf("instanceId: %s", d.Instance().ID)
-				t.Logf("instance State: %s", d.Instance().State)
-			}
 			t.Logf("hardware IP: %v", d.hardwareIP())
 			t.Log()
 			h := *d.Hardware()

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -24,7 +24,7 @@ func TestNewDiscoveryCacher(t *testing.T) {
 		}
 		dc := (*d).(*DiscoveryCacher)
 		if dc.PrimaryDataMAC().String() != test.primaryDataMac {
-			t.Fatalf("unexpected primary data mac, want: %s, got: %s\n", test.primaryDataMac, dc.PrimaryDataMAC())
+			t.Fatalf("unexpected primary data mac, want: %s, got: %s", test.primaryDataMac, dc.PrimaryDataMAC())
 		}
 	}
 }
@@ -47,7 +47,7 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 		}
 
 		if dt.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected ip, want: %v, got: %v\n", test.ip, dt.Network.InterfaceByMac([]byte(test.mac)).DHCP.IP.Address)
+			t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, dt.Network.InterfaceByMac([]byte(test.mac)).DHCP.IP.Address)
 		}
 	}
 }
@@ -90,29 +90,29 @@ func TestDiscoveryCacher(t *testing.T) {
 		}
 
 		// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
-		t.Logf("MacType: %s\n", d.MacType(mac.String()))
-		t.Logf("MacIsType=data: %v\n", d.MacIsType(mac.String(), "data"))
-		t.Logf("primaryDataMac: %s\n", d.PrimaryDataMAC().HardwareAddr().String())
-		t.Logf("MAC: %v\n", d.MAC())
-		t.Logf("d.mac: %v\n", d.mac)
-		t.Logf("mac: %s\n", mac.String())
+		t.Logf("MacType: %s", d.MacType(mac.String()))
+		t.Logf("MacIsType=data: %v", d.MacIsType(mac.String(), "data"))
+		t.Logf("primaryDataMac: %s", d.PrimaryDataMAC().HardwareAddr().String())
+		t.Logf("MAC: %v", d.MAC())
+		t.Logf("d.mac: %v", d.mac)
+		t.Logf("mac: %s", mac.String())
 		if d.Instance() != nil {
-			t.Logf("instance: %v\n", d.Instance())
-			t.Logf("instanceId: %s\n", d.Instance().ID)
-			t.Logf("instance State: %s\n", d.Instance().State)
+			t.Logf("instance: %v", d.Instance())
+			t.Logf("instanceId: %s", d.Instance().ID)
+			t.Logf("instance State: %s", d.Instance().State)
 		}
-		t.Logf("hardware IP: %v\n", d.hardwareIP())
-		t.Log("\n")
+		t.Logf("hardware IP: %v", d.hardwareIP())
+		t.Log("")
 		h := *d.Hardware()
 		for _, ip := range h.HardwareIPs() {
-			t.Logf("hardware IP: %v\n", ip)
-			t.Log("\n")
+			t.Logf("hardware IP: %v", ip)
+			t.Log("")
 		}
 
 		d.SetMAC(mac)
 		mode := d.Mode()
 		if mode != test.mode {
-			t.Fatalf("unexpected mode, want: %s, got: %s\n", test.mode, mode)
+			t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
 		}
 
 		if mode == "" {
@@ -120,26 +120,26 @@ func TestDiscoveryCacher(t *testing.T) {
 		}
 
 		if d.PrimaryDataMAC().String() != test.primaryDataMac {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.primaryDataMac, d.PrimaryDataMAC().String())
+			t.Fatalf("unexpected address, want: %s, got: %s", test.primaryDataMac, d.PrimaryDataMAC().String())
 		}
 		if d.MAC().String() != test.mac {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.mac, d.MAC().String())
+			t.Fatalf("unexpected address, want: %s, got: %s", test.mac, d.MAC().String())
 		}
 
 		conf := d.GetIP(mac)
 		if conf.Address.String() != test.conf.Address.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.conf.Address, conf.Address)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Address, conf.Address)
 		}
 		if conf.Netmask.String() != test.conf.Netmask.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.conf.Netmask, conf.Netmask)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Netmask, conf.Netmask)
 		}
 		if conf.Gateway.String() != test.conf.Gateway.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.conf.Gateway, conf.Gateway)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Gateway, conf.Gateway)
 		}
 
 		osie := d.ServicesVersion.Osie
 		if osie != test.osie {
-			t.Fatalf("unexpected osie version, want: %s, got: %s\n", test.osie, osie)
+			t.Fatalf("unexpected osie version, want: %s, got: %s", test.osie, osie)
 		}
 	}
 }
@@ -160,72 +160,72 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 
 		// suggest we leave this here for the time being for ease of test why we're not seeing what we expect
 		if d.ID != test.id {
-			t.Fatalf("unexpected id, want: %s, got: %s\n", test.id, d.ID)
+			t.Fatalf("unexpected id, want: %s, got: %s", test.id, d.ID)
 		}
 
-		t.Logf("d.mac: %s\n", d.mac)
-		t.Logf("dhcp %v\n", d.Network.InterfaceByMac(mac).DHCP)
-		t.Log("\n")
+		t.Logf("d.mac: %s", d.mac)
+		t.Logf("dhcp %v", d.Network.InterfaceByMac(mac).DHCP)
+		t.Log("")
 		if d.Network.InterfaceByMac(mac).DHCP.IP.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected ip, want: %v, got: %v\n", test.ip, d.Network.InterfaceByMac(mac).DHCP.IP)
+			t.Fatalf("unexpected ip, want: %v, got: %v", test.ip, d.Network.InterfaceByMac(mac).DHCP.IP)
 		}
 		if d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC.String() != mac.String() {
-			t.Fatalf("unexpected mac, want: %s, got: %s\n", mac, d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC)
+			t.Fatalf("unexpected mac, want: %s, got: %s", mac, d.Network.InterfaceByIp(test.ip.Address).DHCP.MAC)
 		}
 		if d.Network.InterfaceByMac(mac).DHCP.Hostname != test.hostname {
-			t.Fatalf("unexpected hostname, want: %s, got: %s\n", test.hostname, d.Network.InterfaceByMac(mac).DHCP.Hostname)
+			t.Fatalf("unexpected hostname, want: %s, got: %s", test.hostname, d.Network.InterfaceByMac(mac).DHCP.Hostname)
 		}
 		if int(d.LeaseTime(mac).Seconds()) != test.leaseTime {
-			t.Fatalf("unexpected lease time, want: %d, got: %d\n", test.leaseTime, d.LeaseTime(mac))
+			t.Fatalf("unexpected lease time, want: %d, got: %d", test.leaseTime, d.LeaseTime(mac))
 		}
 		// note the difference between []string(nil) and []string{}; use cmp.Diff to check
 		if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.NameServers, test.nameServers) {
-			t.Fatalf("unexpected name servers, want: %v, got: %v\n", test.nameServers, d.Network.InterfaceByMac(mac).DHCP.NameServers)
+			t.Fatalf("unexpected name servers, want: %v, got: %v", test.nameServers, d.Network.InterfaceByMac(mac).DHCP.NameServers)
 		}
 		if !reflect.DeepEqual(d.Network.InterfaceByMac(mac).DHCP.TimeServers, test.timeServers) {
-			t.Fatalf("unexpected time servers, want: %v, got: %v\n", test.timeServers, d.Network.InterfaceByMac(mac).DHCP.TimeServers)
+			t.Fatalf("unexpected time servers, want: %v, got: %v", test.timeServers, d.Network.InterfaceByMac(mac).DHCP.TimeServers)
 		}
 		if d.Network.InterfaceByMac(mac).DHCP.IP.Gateway.String() != test.ip.Gateway.String() {
-			t.Fatalf("unexpected gateway, want: %s, got: %v\n", test.ip.Gateway, d.Network.InterfaceByMac(mac).DHCP.IP.Gateway)
+			t.Fatalf("unexpected gateway, want: %s, got: %v", test.ip.Gateway, d.Network.InterfaceByMac(mac).DHCP.IP.Gateway)
 		}
 		if d.Network.InterfaceByMac(mac).DHCP.Arch != test.arch {
-			t.Fatalf("unexpected arch, want: %s, got: %s\n", test.arch, d.Network.InterfaceByMac(mac).DHCP.Arch)
+			t.Fatalf("unexpected arch, want: %s, got: %s", test.arch, d.Network.InterfaceByMac(mac).DHCP.Arch)
 		}
 		if d.Network.InterfaceByMac(mac).DHCP.UEFI != test.uefi {
-			t.Fatalf("unexpected uefi, want: %v, got: %v\n", test.uefi, d.Network.InterfaceByMac(mac).DHCP.UEFI)
+			t.Fatalf("unexpected uefi, want: %v, got: %v", test.uefi, d.Network.InterfaceByMac(mac).DHCP.UEFI)
 		}
 
-		t.Logf("netboot: %v\n", d.Network.InterfaceByMac(mac).Netboot)
-		t.Logf("netboot allow_pxe: %v\n", d.Network.InterfaceByMac(mac).Netboot.AllowPXE)
-		t.Logf("netboot allow_workflow: %v\n", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
-		t.Logf("netboot ipxe: %v\n", d.Network.InterfaceByMac(mac).Netboot.IPXE)
-		t.Logf("netboot osie: %v\n", d.Network.InterfaceByMac(mac).Netboot.Osie)
-		t.Log("\n")
+		t.Logf("netboot: %v", d.Network.InterfaceByMac(mac).Netboot)
+		t.Logf("netboot allow_pxe: %v", d.Network.InterfaceByMac(mac).Netboot.AllowPXE)
+		t.Logf("netboot allow_workflow: %v", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
+		t.Logf("netboot ipxe: %v", d.Network.InterfaceByMac(mac).Netboot.IPXE)
+		t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.Osie)
+		t.Log("")
 
-		t.Logf("metadata: %v\n", d.Metadata)
-		t.Logf("metadata state: %v\n", d.Metadata.State)
-		t.Logf("metadata bonding_mode: %v\n", d.Metadata.BondingMode)
-		t.Logf("metadata manufacturer: %v\n", d.Metadata.Manufacturer)
+		t.Logf("metadata: %v", d.Metadata)
+		t.Logf("metadata state: %v", d.Metadata.State)
+		t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
+		t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
 		if d.Instance() != nil {
-			t.Logf("instance: %v\n", d.Instance())
-			t.Logf("instance id: %s\n", d.Instance().ID)
-			t.Logf("instance state: %s\n", d.Instance().State)
+			t.Logf("instance: %v", d.Instance())
+			t.Logf("instance id: %s", d.Instance().ID)
+			t.Logf("instance state: %s", d.Instance().State)
 		}
-		t.Logf("metadata custom: %v\n", d.Metadata.Custom)
-		t.Logf("metadata facility: %v\n", d.Metadata.Facility)
+		t.Logf("metadata custom: %v", d.Metadata.Custom)
+		t.Logf("metadata facility: %v", d.Metadata.Facility)
 
-		//t.Logf("hardware IP: %v\n", d.hardwareIP())
-		t.Log("\n")
+		//t.Logf("hardware IP: %v", d.hardwareIP())
+		t.Log("")
 		h := *d.Hardware()
 		for _, ip := range h.HardwareIPs() {
-			t.Logf("hardware IP: %v\n", ip)
-			t.Log("\n")
+			t.Logf("hardware IP: %v", ip)
+			t.Log("")
 		}
 
 		d.SetMAC(mac)
 		mode := d.Mode()
 		if mode != test.mode {
-			t.Fatalf("unexpected mode, want: %s, got: %s\n", test.mode, mode)
+			t.Fatalf("unexpected mode, want: %s, got: %s", test.mode, mode)
 		}
 
 		if mode == "" {
@@ -234,13 +234,13 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 
 		conf := d.GetIP(mac)
 		if conf.Address.String() != test.ip.Address.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.ip.Address, conf.Address)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Address, conf.Address)
 		}
 		if conf.Netmask.String() != test.ip.Netmask.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.ip.Netmask, conf.Netmask)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Netmask, conf.Netmask)
 		}
 		if conf.Gateway.String() != test.ip.Gateway.String() {
-			t.Fatalf("unexpected address, want: %s, got: %s\n", test.ip.Gateway, conf.Gateway)
+			t.Fatalf("unexpected address, want: %s, got: %s", test.ip.Gateway, conf.Gateway)
 		}
 	}
 }

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestInterfaces(t *testing.T) {
-	var _ Discovery = (*DiscoveryCacher)(nil)
-	var _ Discovery = (*DiscoveryTinkerbellV1)(nil)
+	var _ Discovery = &DiscoveryCacher{}
+	var _ Discovery = &DiscoveryTinkerbellV1{}
 }
 
 func TestNewDiscoveryCacher(t *testing.T) {
@@ -28,7 +28,7 @@ func TestNewDiscoveryCacher(t *testing.T) {
 			if err != nil {
 				t.Fatal("NewDiscovery", err)
 			}
-			dc := (*d).(*DiscoveryCacher)
+			dc := d.(*DiscoveryCacher)
 			if dc.PrimaryDataMAC().String() != test.primaryDataMac {
 				t.Fatalf("unexpected primary data mac, want: %s, got: %s", test.primaryDataMac, dc.PrimaryDataMAC())
 			}
@@ -47,7 +47,7 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 			if err != nil {
 				t.Fatal("NewDiscovery", err)
 			}
-			dt := (*d).(*DiscoveryTinkerbellV1)
+			dt := d.(*DiscoveryTinkerbellV1)
 
 			mac, err := net.ParseMAC(test.mac)
 			if err != nil {
@@ -87,7 +87,7 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 			if err != nil {
 				t.Fatal("NewDiscovery", err)
 			}
-			dt, ok := (*d).(*DiscoveryTinkerbellV1)
+			dt, ok := d.(*DiscoveryTinkerbellV1)
 			t.Log(dt)
 			if ok {
 				t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryCacher{}, dt)
@@ -102,7 +102,7 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 			if err != nil {
 				t.Fatal("NewDiscovery", err)
 			}
-			dt, ok := (*d).(*DiscoveryCacher)
+			dt, ok := d.(*DiscoveryCacher)
 			t.Log(dt)
 			if ok {
 				t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryTinkerbellV1{}, dt)
@@ -114,7 +114,7 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 func TestDiscoveryCacher(t *testing.T) {
 	for name, test := range cacherTests {
 		t.Run(name, func(t *testing.T) {
-			d := DiscoveryCacher{}
+			d := &DiscoveryCacher{}
 
 			if err := json.Unmarshal([]byte(test.json), &d); err != nil {
 				t.Fatal(test.mode, err)
@@ -134,7 +134,7 @@ func TestDiscoveryCacher(t *testing.T) {
 			t.Logf("mac: %s", mac.String())
 			t.Logf("hardware IP: %v", d.hardwareIP())
 			t.Log()
-			h := *d.Hardware()
+			h := d.Hardware()
 			for _, ip := range h.HardwareIPs() {
 				t.Logf("hardware IP: %v", ip)
 				t.Log()
@@ -246,9 +246,8 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("metadata custom: %v", d.Metadata.Custom)
 			t.Logf("metadata facility: %v", d.Metadata.Facility)
 
-			//t.Logf("hardware IP: %v", d.hardwareIP())
 			t.Log()
-			h := *d.Hardware()
+			h := d.Hardware()
 			for _, ip := range h.HardwareIPs() {
 				t.Logf("hardware IP: %v", ip)
 				t.Log()

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -14,7 +14,9 @@ func TestInterfaces(t *testing.T) {
 }
 
 func TestNewDiscoveryCacher(t *testing.T) {
-	t.Log("DATA_MODEL_VERSION (should be empty to use cacher):", os.Getenv("DATA_MODEL_VERSION"))
+	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
+	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
+	os.Unsetenv("DATA_MODEL_VERSION")
 
 	for name, test := range tests {
 		t.Log(name)
@@ -30,8 +32,9 @@ func TestNewDiscoveryCacher(t *testing.T) {
 }
 
 func TestNewDiscoveryTinkerbell(t *testing.T) {
+	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
+	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
 	os.Setenv("DATA_MODEL_VERSION", "1")
-	t.Log("DATA_MODEL_VERSION:", os.Getenv("DATA_MODEL_VERSION"))
 
 	for name, test := range tinkerbellTests {
 		t.Log(name)
@@ -53,15 +56,16 @@ func TestNewDiscoveryTinkerbell(t *testing.T) {
 }
 
 func TestNewDiscoveryMismatch(t *testing.T) {
+	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
+	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
+	os.Setenv("DATA_MODEL_VERSION", "1")
+
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Fatal("TestDiscoveryMismatch should have panicked")
 			}
 		}()
-
-		os.Setenv("DATA_MODEL_VERSION", "1")
-		t.Log("DATA_MODEL_VERSION:", os.Getenv("DATA_MODEL_VERSION"))
 
 		for name, test := range tinkerbellTests {
 			t.Log(name)

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -60,23 +60,19 @@ func TestNewDiscoveryMismatch(t *testing.T) {
 	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
 	os.Setenv("DATA_MODEL_VERSION", "1")
 
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("TestDiscoveryMismatch should have panicked")
-			}
-		}()
-
-		for name, test := range tinkerbellTests {
-			t.Log(name)
-			d, err := NewDiscovery([]byte(test.json))
-			if err != nil {
-				t.Fatal("NewDiscovery", err)
-			}
-			dt := (*d).(*DiscoveryCacher)
-			t.Log(dt)
+	for name, test := range tinkerbellTests {
+		t.Log(name)
+		d, err := NewDiscovery([]byte(test.json))
+		if err != nil {
+			t.Fatal("NewDiscovery", err)
 		}
-	}()
+		dt, ok := (*d).(*DiscoveryCacher)
+		t.Log(dt)
+		if ok {
+			t.Fatalf("unexpected concrete type returned from NewDiscovery: want=%T, got=%T", &DiscoveryTinkerbellV1{}, dt)
+		}
+	}
+
 }
 
 func TestDiscoveryCacher(t *testing.T) {

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -24,9 +24,9 @@ func (d DiscoveryTinkerbellV1) LeaseTime(mac net.HardwareAddr) time.Duration {
 	return duration
 }
 
-func (d DiscoveryTinkerbellV1) Hardware() *Hardware {
+func (d DiscoveryTinkerbellV1) Hardware() Hardware {
 	var h Hardware = d.HardwareTinkerbellV1
-	return &h
+	return h
 }
 
 func (d DiscoveryTinkerbellV1) DnsServers(mac net.HardwareAddr) []net.IP {
@@ -88,11 +88,11 @@ func (d *DiscoveryTinkerbellV1) PrimaryDataMAC() MACAddr {
 	return mac
 }
 
-func (d *DiscoveryTinkerbellV1) Hostname() (string, error) {
+func (d DiscoveryTinkerbellV1) Hostname() (string, error) {
 	return d.Instance().Hostname, nil // temp
 }
 
-func (d *DiscoveryTinkerbellV1) SetMAC(mac net.HardwareAddr) {
+func (d DiscoveryTinkerbellV1) SetMAC(mac net.HardwareAddr) {
 	d.mac = mac
 }
 

--- a/packet/util.go
+++ b/packet/util.go
@@ -50,26 +50,3 @@ func (m MACAddr) IsZero() bool {
 func (m MACAddr) IsOnes() bool {
 	return bytes.Equal(m[:], OnesMAC[:])
 }
-
-// golangci-lint: unused
-// withLSB sets the least significant bit to 1 if val == true or 0 if val == false.
-//func (m MACAddr) withLSB(val bool) MACAddr {
-//	if val {
-//		m[5] |= 1 // set the last bit
-//	} else {
-//		m[5] &= ^byte(1) // clear the last bit
-//	}
-//	return m
-//}
-//
-//type ref struct {
-//	HRef string `json:"href"`
-//}
-//
-//func (r *ref) Get() (*http.Request, error) {
-//	if r.HRef == "" || r.HRef[0] == '#' {
-//		return nil, errors.New("URL not available")
-//	}
-//	req, err := http.NewRequest("GET", r.HRef, nil)
-//	return req, errors.Wrap(err, "fetching ref")
-//}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

Change from pointers to interface to just an interface for the recent data model split. Took the opportunity to clean up some of the related tests so they would be more correct (when setting env vars) / easier to follow (making TestNewDiscoveryMismatch not panic). 

## Why is this needed

<!--- Link to issue you have raised -->

I think #27 was merged prematurely. Lots of commented out code that should have been deleted, oddness in the pointer-to-interface and some hard to follow tests. This is me polishing some of that up.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`go test ./...`


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

No anticipated impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade