### PR TITLE
Set different firstdisk on c3.medium.x86.01 plan version

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -401,6 +401,8 @@ func determineDisk(j job.Job) string {
 		"s3.xlarge.x86":
 		if j.PlanVersionSlug() == "c3.medium.x86.01" {
 			return "--firstdisk=Micron_5100_MTFD,vmw_ahci"
+		} else if j.PlanVersionSlug() == "s3.xlarge.x86.01" {
+			return "--firstdisk=KXG50ZNV256G_TOSHIBA,vmw_ahci"
 		}
 
 		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -399,6 +399,10 @@ func determineDisk(j job.Job) string {
 	case "c3.medium.x86",
 		"c3.small.x86",
 		"s3.xlarge.x86":
+                if j.PlanVersionSlug() == "c3.medium.x86.01" {
+                        return "--firstdisk=Micron_5100_MTFD,vmw_ahci"
+                }
+
 		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "m1.xlarge.x86":
 		if j.PlanVersionSlug() == "baremetal_2_04" {

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -399,9 +399,9 @@ func determineDisk(j job.Job) string {
 	case "c3.medium.x86",
 		"c3.small.x86",
 		"s3.xlarge.x86":
-                if j.PlanVersionSlug() == "c3.medium.x86.01" {
-                        return "--firstdisk=Micron_5100_MTFD,vmw_ahci"
-                }
+		if j.PlanVersionSlug() == "c3.medium.x86.01" {
+			return "--firstdisk=Micron_5100_MTFD,vmw_ahci"
+		}
 
 		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "m1.xlarge.x86":


### PR DESCRIPTION
This is to add logic around the firstdisk config option, specifically for the v1 plan version of c3.medium.