### PR TITLE
removed Storage as a field under Instance

### DIFF
--- a/packet/models.go
+++ b/packet/models.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tinkerbell/boots/files/ignition"
 )
 
 // models.go contains the Hardware structures matching the data models defined by tink and cacher
@@ -147,8 +146,7 @@ type Instance struct {
 
 	Tags []string `json:"tags,omitempty"`
 	// Project
-	Storage ignition.Storage `json:"storage,omitempty"`
-	SSHKeys []string         `json:"ssh_keys,omitempty"`
+	SSHKeys []string `json:"ssh_keys,omitempty"`
 	// CustomData
 	NetworkReady bool `json:"network_ready,omitempty"`
 }

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -281,6 +281,23 @@ var tinkerbellTests = map[string]struct {
 		mode:        "hardware",
 		json:        newJsonStruct,
 	},
+	"full structure tinkerbell": {
+		id:  "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+		mac: "00:00:00:00:00:00",
+		ip: IP{
+			Address: net.ParseIP("192.168.1.5"),
+			Netmask: net.ParseIP("255.255.255.248"),
+			Gateway: net.ParseIP("192.168.1.1"),
+		},
+		hostname:    "server001",
+		leaseTime:   86400,
+		nameServers: []string{},
+		timeServers: []string{},
+		arch:        "x86_64",
+		uefi:        false,
+		mode:        "hardware",
+		json:        fullStructTinkerbell,
+	},
 }
 
 var tests = map[string]struct {
@@ -386,6 +403,17 @@ var tests = map[string]struct {
 		},
 		json: provisioningWithService,
 	},
+	"full structure cacher": {
+		mac:            "f4:79:2b:fa:4f:ae",
+		primaryDataMac: "e4:45:19:c4:ba:50",
+		mode:           "management",
+		conf: IP{
+			Address: net.ParseIP("10.255.3.13"),
+			Gateway: net.ParseIP("10.255.3.1"),
+			Netmask: net.ParseIP("255.255.255.0"),
+		},
+		json: fullStructCacher,
+	},
 }
 
 const (
@@ -445,7 +473,115 @@ const (
 	  }
 	}
  `
-
+	fullStructTinkerbell = `
+	{
+	  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+	  "metadata": {
+		"bonding_mode": 5,
+		"custom": {
+		  "preinstalled_operating_system_version": {},
+		  "private_subnets": []
+		},
+		"facility": {
+		  "facility_code": "ewr1",
+		  "plan_slug": "c2.medium.x86",
+		  "plan_version_slug": ""
+		},
+		"instance": {
+		  "crypted_root_password": "redacted",
+		  "operating_system_version": {
+			"distro": "ubuntu",
+			"os_slug": "ubuntu_18_04",
+			"version": "18.04"
+		  },
+		  "storage": {
+			"disks": [
+			  {
+				"device": "/dev/sda",
+				"partitions": [
+				  {
+					"label": "BIOS",
+					"number": 1,
+					"size": 4096
+				  },
+				  {
+					"label": "SWAP",
+					"number": 2,
+					"size": 3993600
+				  },
+				  {
+					"label": "ROOT",
+					"number": 3,
+					"size": 0
+				  }
+				],
+				"wipe_table": true
+			  }
+			],
+			"filesystems": [
+			  {
+				"mount": {
+				  "create": {
+					"options": ["-L", "ROOT"]
+				  },
+				  "device": "/dev/sda3",
+				  "format": "ext4",
+				  "point": "/"
+				}
+			  },
+			  {
+				"mount": {
+				  "create": {
+					"options": ["-L", "SWAP"]
+				  },
+				  "device": "/dev/sda2",
+				  "format": "swap",
+				  "point": "none"
+				}
+			  }
+			]
+		  }
+		},
+		"manufacturer": {
+		  "id": "",
+		  "slug": ""
+		},
+		"state": ""
+	  },
+	  "network": {
+		"interfaces": [
+		  {
+			"dhcp": {
+			  "arch": "x86_64",
+			  "hostname": "server001",
+			  "ip": {
+				"address": "192.168.1.5",
+				"gateway": "192.168.1.1",
+				"netmask": "255.255.255.248"
+			  },
+			  "lease_time": 86400,
+			  "mac": "00:00:00:00:00:00",
+			  "name_servers": [],
+			  "time_servers": [],
+			  "uefi": false
+			},
+			"netboot": {
+			  "allow_pxe": true,
+			  "allow_workflow": true,
+			  "ipxe": {
+				"contents": "#!ipxe",
+				"url": "http://url/menu.ipxe"
+			  },
+			  "osie": {
+				"base_url": "",
+				"initrd": "",
+				"kernel": "vmlinuz-x86_64"
+			  }
+			}
+		  }
+		]
+	  }
+	}`
 	discovered = `
 	{
 	  "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
@@ -1200,5 +1336,250 @@ const (
   "services": {
     "osie":"v19.01.01.00"
   }
+}`
+	fullStructCacher = `{
+  "id": "55639911-2278-498c-b364-8b2a62f5493c",
+  "name": "test.dfw2.packet.net",
+  "type": "server",
+  "state": "in_use",
+  "allow_pxe": false,
+  "preinstalled_operating_system_version": {},
+  "bonding_mode": 4,
+  "manufacturer": {
+    "id": "d2ea68db-a82a-4273-a590-594cf311ed52",
+    "slug": "dell"
+  },
+  "plan_slug": "n2.xlarge.x86",
+  "facility_code": "dfw2",
+  "private_subnets": [
+    "10.0.0.0/8"
+  ],
+  "plan_version_slug": "n2.xlarge.x86.01",
+  "management": {
+    "address": "10.255.3.13",
+    "gateway": "10.255.3.1",
+    "netmask": "255.255.255.0",
+    "type": "ipmi"
+  },
+  "arch": "x86_64",
+  "efi_boot": false,
+  "network_ports": [
+    {
+      "id": "c31fb859-1fe0-4a53-b42b-4cfb45fb7185",
+      "type": "data",
+      "name": "eth0",
+      "data": {
+        "mac": "e4:45:19:c4:ba:50",
+        "bond": "bond0"
+      },
+      "connected_ports": [
+        {
+          "id": "dc76eb4f-6e21-4b6a-b622-08d1970b2224",
+          "type": "data",
+          "name": "xe-0/0/14:0",
+          "data": {
+            "mac": null,
+            "bond": null
+          },
+          "hostname": "test.test.dfw2.packet.net"
+        }
+      ]
+    },
+    {
+      "id": "b676f474-5dc3-4337-8d57-b25b8f7febdf",
+      "type": "data",
+      "name": "eth1",
+      "data": {
+        "mac": "e4:45:19:c4:ba:51",
+        "bond": "bond1"
+      },
+      "connected_ports": [
+        {
+          "id": "a7e87953-0b44-4d4d-af63-2fac95083549",
+          "type": "data",
+          "name": "xe-0/0/15:0",
+          "data": {
+            "mac": null,
+            "bond": null
+          },
+          "hostname": "test.test.dfw2.packet.net"
+        }
+      ]
+    },
+    {
+      "id": "36ba8732-05a4-46c6-857f-8e5765055394",
+      "type": "data",
+      "name": "eth2",
+      "data": {
+        "mac": "e4:45:19:c4:ba:52",
+        "bond": "bond0"
+      },
+      "connected_ports": [
+        {
+          "id": "d10295d3-2bc6-4e76-afdc-e28383ba0766",
+          "type": "data",
+          "name": "xe-1/0/14:0",
+          "data": {
+            "mac": null,
+            "bond": null
+          },
+          "hostname": "test.test.dfw2.packet.net"
+        }
+      ]
+    },
+    {
+      "id": "b36277ed-602d-4736-8fa3-fc1fa647e1d4",
+      "type": "data",
+      "name": "eth3",
+      "data": {
+        "mac": "e4:45:19:c4:ba:53",
+        "bond": "bond1"
+      },
+      "connected_ports": [
+        {
+          "id": "e8e9d7a2-bc7b-4a3d-9512-8f10b5a3632a",
+          "type": "data",
+          "name": "xe-1/0/15:0",
+          "data": {
+            "mac": null,
+            "bond": null
+          },
+          "hostname": "test.test.dfw2.packet.net"
+        }
+      ]
+    },
+    {
+      "id": "2f038e8a-9381-4dc0-8928-3a621a84fd09",
+      "type": "ipmi",
+      "name": "ipmi0",
+      "data": {
+        "mac": "f4:79:2b:fa:4f:ae",
+        "bond": null
+      },
+      "connected_ports": [
+        {
+          "id": "1fdcf403-59b3-40e5-a581-885d1349732e",
+          "type": "data",
+          "name": "ge-0/0/29",
+          "data": {
+            "mac": null,
+            "bond": null
+          },
+          "hostname": "rest.test.dfw2.packet.net"
+        }
+      ]
+    }
+  ],
+  "instance": {
+    "id": "331d355a-1925-4ecf-ab6b-75990733c50c",
+    "state": "active",
+    "hostname": "test",
+    "allow_pxe": false,
+    "rescue": false,
+    "operating_system_version": {
+      "slug": "vmware_esxi_7_0",
+      "distro": "vmware",
+      "version": "7.0",
+      "image_tag": "abc123",
+      "os_slug": "vmware_esxi_7_0"
+    },
+    "ipxe_script_url": null,
+    "always_pxe": false,
+    "userdata": "",
+    "storage": {
+      "disks": [
+        {
+          "device": "/dev/sda",
+          "wipeTable": true,
+          "partitions": [
+            {
+              "label": "BIOS",
+              "number": 1,
+              "size": 4096
+            },
+            {
+              "label": "SWAP",
+              "number": 2,
+              "size": "3993600"
+            },
+            {
+              "label": "ROOT",
+              "number": 3,
+              "size": 0
+            }
+          ]
+        }
+      ],
+      "filesystems": [
+        {
+          "mount": {
+            "device": "/dev/sda3",
+            "format": "ext4",
+            "point": "/",
+            "create": {
+              "options": [
+                "-L",
+                "ROOT"
+              ]
+            }
+          }
+        },
+        {
+          "mount": {
+            "device": "/dev/sda2",
+            "format": "swap",
+            "point": "none",
+            "create": {
+              "options": [
+                "-L",
+                "SWAP"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ip_addresses": [],
+    "ssh_keys": [],
+    "tags": [],
+    "customdata": {},
+    "project": {
+      "id": "b9638412-a71e-4390-8366-98bc6244725f",
+      "name": "Test",
+      "organization": {
+        "id": "f27c556e-9476-4703-932f-a198b587c60d",
+        "name": "Testing123"
+      },
+      "primary_owner": {
+        "id": "ca8c6279-1d01-4426-83de-cf7f0d62f0ed",
+        "full_name": "Tester Jester"
+      }
+    },
+    "network_ready": false,
+    "crypted_root_password": "r3d4c73d"
+  },
+  "vlan_id": null,
+  "ip_addresses": [
+    {
+      "address": "172.16.10.73",
+      "netmask": "255.255.255.254",
+      "gateway": "172.16.10.72",
+      "address_family": 4,
+      "public": false,
+      "management": true,
+      "enabled": true,
+      "network": "172.16.10.72",
+      "cidr": 31,
+      "type": "data",
+      "port": "bond0"
+    },
+    {
+      "address": "10.255.3.13",
+      "gateway": "10.255.3.1",
+      "netmask": "255.255.255.0",
+      "type": "ipmi"
+    }
+  ],
+  "services": {}
 }`
 )


### PR DESCRIPTION
## Description

Removed the [`Storage`](https://github.com/tinkerbell/boots/blob/master/packet/models.go#L150) field under `Instance`

## Why is this needed

The `Storage` field was erroneously added in a [previous commit](https://github.com/tinkerbell/boots/pull/27), which made boots try to parse [`partition.size`](https://github.com/tinkerbell/boots/blob/master/files/ignition/storage.go#L32) (which can either be an int or string) and was crashing the code.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
