### PR TITLE
remove unnecessary error 'unable to create DHCP reply'

### DIFF
--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -25,7 +25,6 @@ func (j Job) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) bool {
 	// setup reply
 	reply := dhcp.NewReply(w, req)
 	if reply == nil {
-		j.Error(errors.New("unable to create DHCP reply"))
 		return false
 	}
 


### PR DESCRIPTION
this error was printed if a dhcp packet was received that was
not either a DHCPDISCOVER or DHCPREQUEST. Which we just don't need
to respond to, and no reason to log an error.
