### PR TITLE
Add vmware firstdisk for m3.large.x86

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -398,6 +398,7 @@ func determineDisk(j job.Job) string {
 		return "--firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3"
 	case "c3.medium.x86",
 		"c3.small.x86",
+		"m3.large.x86",
 		"s3.xlarge.x86":
 		if j.PlanVersionSlug() == "c3.medium.x86.01" {
 			return "--firstdisk=Micron_5100_MTFD,vmw_ahci"


### PR DESCRIPTION
## Description

This will change the first disk option for the VMWare kickstart, for our m3.large.x86

## Why is this needed

Following the pattern of our previous third generation hardware lineup

## How Has This Been Tested?

Theoretically

## How are existing users impacted? What migration steps/scripts do we need?

Should make VMWare ESXi installs better