### PR TITLE
#260 boots changed the name for HW client

### DIFF
--- a/packet/client.go
+++ b/packet/client.go
@@ -48,7 +48,7 @@ func NewClient(consumerToken, authToken string, baseURL *url.URL) (*Client, erro
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
 	case "1":
-		hg, err = tinkClient.TinkerbellHWClient()
+		hg, err = tinkClient.TinkHardwareClient()
 		if err != nil {
 			return nil, errors.Wrap(err, "connect to tink")
 		}

--- a/packet/client.go
+++ b/packet/client.go
@@ -48,7 +48,7 @@ func NewClient(consumerToken, authToken string, baseURL *url.URL) (*Client, erro
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
 	case "1":
-		hg, err = tinkClient.NewTinkerbellClient()
+		hg, err = tinkClient.TinkerbellHWClient()
 		if err != nil {
 			return nil, errors.Wrap(err, "connect to tink")
 		}


### PR DESCRIPTION
## Description

Changed name of tinkerbell HW client 

## Why is this needed

Hw client in tink repo hsa been changed

Fixes: #

## How Has This Been Tested?
Has been tested along with PR https://github.com/tinkerbell/tink/pull/210 and by bringing worker up. 

