### PR TITLE
Stricter data model version handling

### DIFF
--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -44,6 +44,26 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
+	case "":
+		cc := c.hardwareClient.(cacher.CacherClient)
+		msg := &cacher.GetRequest{
+			MAC: mac.String(),
+		}
+
+		resp, err := cc.ByMAC(context.Background(), msg)
+
+		cacherTimer.ObserveDuration()
+		metrics.CacherRequestsInProgress.With(labels).Dec()
+
+		if err != nil {
+			return nil, errors.Wrap(err, "get hardware by mac from cacher")
+		}
+
+		b := []byte(resp.JSON)
+		if string(b) != "" {
+			metrics.CacherCacheHits.With(labels).Inc()
+			return NewDiscovery(b)
+		}
 	case "1":
 		tc := c.hardwareClient.(tink.HardwareServiceClient)
 		msg := &tink.GetRequest{
@@ -65,26 +85,6 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 		}
 
 		if string(b) != "{}" {
-			metrics.CacherCacheHits.With(labels).Inc()
-			return NewDiscovery(b)
-		}
-	case "":
-		cc := c.hardwareClient.(cacher.CacherClient)
-		msg := &cacher.GetRequest{
-			MAC: mac.String(),
-		}
-
-		resp, err := cc.ByMAC(context.Background(), msg)
-
-		cacherTimer.ObserveDuration()
-		metrics.CacherRequestsInProgress.With(labels).Dec()
-
-		if err != nil {
-			return nil, errors.Wrap(err, "get hardware by mac from cacher")
-		}
-
-		b := []byte(resp.JSON)
-		if string(b) != "" {
 			metrics.CacherCacheHits.With(labels).Inc()
 			return NewDiscovery(b)
 		}
@@ -138,6 +138,22 @@ func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 	var b []byte
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
+	case "":
+		cc := c.hardwareClient.(cacher.CacherClient)
+		msg := &cacher.GetRequest{
+			IP: ip.String(),
+		}
+
+		resp, err := cc.ByIP(context.Background(), msg)
+
+		cacherTimer.ObserveDuration()
+		metrics.CacherRequestsInProgress.With(labels).Dec()
+
+		if err != nil {
+			return nil, errors.Wrap(err, "get hardware by ip from cacher")
+		}
+
+		b = []byte(resp.JSON)
 	case "1":
 		tc := c.hardwareClient.(tink.HardwareServiceClient)
 		msg := &tink.GetRequest{
@@ -157,22 +173,6 @@ func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 		if err != nil {
 			return nil, errors.New("marshalling tink hardware")
 		}
-	case "":
-		cc := c.hardwareClient.(cacher.CacherClient)
-		msg := &cacher.GetRequest{
-			IP: ip.String(),
-		}
-
-		resp, err := cc.ByIP(context.Background(), msg)
-
-		cacherTimer.ObserveDuration()
-		metrics.CacherRequestsInProgress.With(labels).Dec()
-
-		if err != nil {
-			return nil, errors.Wrap(err, "get hardware by ip from cacher")
-		}
-
-		b = []byte(resp.JSON)
 	default:
 		return nil, errors.New("unknown DATA_MODEL_VERSION")
 	}

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -68,7 +68,7 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 			metrics.CacherCacheHits.With(labels).Inc()
 			return NewDiscovery(b)
 		}
-	default:
+	case "":
 		cc := c.hardwareClient.(cacher.CacherClient)
 		msg := &cacher.GetRequest{
 			MAC: mac.String(),
@@ -88,6 +88,8 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 			metrics.CacherCacheHits.With(labels).Inc()
 			return NewDiscovery(b)
 		}
+	default:
+		return nil, errors.New("unknown DATA_MODEL_VERSION")
 	}
 
 	if giaddr == nil {
@@ -155,7 +157,7 @@ func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 		if err != nil {
 			return nil, errors.New("marshalling tink hardware")
 		}
-	default:
+	case "":
 		cc := c.hardwareClient.(cacher.CacherClient)
 		msg := &cacher.GetRequest{
 			IP: ip.String(),
@@ -171,6 +173,8 @@ func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 		}
 
 		b = []byte(resp.JSON)
+	default:
+		return nil, errors.New("unknown DATA_MODEL_VERSION")
 	}
 
 	return NewDiscovery(b)

--- a/packet/models.go
+++ b/packet/models.go
@@ -112,15 +112,15 @@ func NewDiscovery(b []byte) (Discovery, error) {
 
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
-	case "1":
-		d := &DiscoveryTinkerbellV1{}
+	case "":
+		d := &DiscoveryCacher{}
 		err := json.Unmarshal(b, &d)
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal json for discovery")
 		}
 		return d, nil
-	case "":
-		d := &DiscoveryCacher{}
+	case "1":
+		d := &DiscoveryTinkerbellV1{}
 		err := json.Unmarshal(b, &d)
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal json for discovery")


### PR DESCRIPTION
## Description

Missed some sections that have logic dealing with DATA_MODEL_VERSION.

## Why is this needed

To be future compatible with any new DATA_MODEL_VERSION revisions.


## How Has This Been Tested?

Compiles.

## How are existing users impacted? What migration steps/scripts do we need?

No impacted expected.
