### PR TITLE
Production into master

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -40,7 +40,7 @@ func bootScript(action string, j job.Job, s *ipxe.Script) {
 	s.Set("arch", j.Arch())
 	s.Set("parch", j.PArch())
 	s.Set("bootdevmac", j.PrimaryNIC().String())
-	s.Set("base-url", osieBaseUrl(j))
+	s.Set("base-url", osieBaseURL(j))
 	s.Kernel("${base-url}/" + kernelPath(j))
 
 	kernelParams(action, j.HardwareState(), j, s)
@@ -70,8 +70,8 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("eclypsium_token=" + conf.EclypsiumToken)
 	}
 
-	if isCustomOsie(j) {
-		s.Args("packet_base_url=" + osieBaseUrl(j))
+	if isCustomOSIE(j) {
+		s.Args("packet_base_url=" + osieBaseURL(j))
 	}
 
 	if j.CanWorkflow() {
@@ -152,19 +152,19 @@ func initrdPath(j job.Job) string {
 	return "initramfs-${parch}"
 }
 
-func isCustomOsie(j job.Job) bool {
+func isCustomOSIE(j job.Job) bool {
 	if version := j.ServicesVersion(); version != "" {
 		return true
 	}
 	return false
 }
 
-// OsieBaseUrl returns the value of Osie Custom Service Version, or boots/osie
-func osieBaseUrl(j job.Job) string {
-	if u := j.OsieBaseURL(); u != "" {
+// osieBaseURL returns the value of Custom OSIE Service Version or just /current
+func osieBaseURL(j job.Job) string {
+	if u := j.OSIEBaseURL(); u != "" {
 		return u
 	}
-	if isCustomOsie(j) {
+	if isCustomOSIE(j) {
 		return osieURL + "/" + j.ServicesVersion()
 	}
 	return osieURL + "/current"

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -153,10 +153,7 @@ func initrdPath(j job.Job) string {
 }
 
 func isCustomOSIE(j job.Job) bool {
-	if version := j.ServicesVersion(); version != "" {
-		return true
-	}
-	return false
+	return j.OSIEVersion() != ""
 }
 
 // osieBaseURL returns the value of Custom OSIE Service Version or just /current
@@ -165,7 +162,7 @@ func osieBaseURL(j job.Job) string {
 		return u
 	}
 	if isCustomOSIE(j) {
-		return osieURL + "/" + j.ServicesVersion()
+		return osieURL + "/" + j.OSIEVersion()
 	}
 	return osieURL + "/current"
 }

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -10,18 +10,18 @@ import (
 )
 
 const (
-	defaultOsiePath = "/misc/osie"
+	defaultOSIEPath = "/misc/osie"
 )
 
 var (
-	osieURL                            = mustBuildOsieURL().String()
+	osieURL                            = mustBuildOSIEURL().String()
 	mirrorBaseURL                      = conf.MirrorBaseUrl
 	dockerRegistry                     string
 	grpcAuthority, grpcCertURL         string
 	registryUsername, registryPassword string
 )
 
-func buildOsieURL() (*url.URL, error) {
+func buildOSIEURL() (*url.URL, error) {
 	base, err := url.Parse(conf.MirrorBaseUrl)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing MirrorBaseUrl")
@@ -33,15 +33,15 @@ func buildOsieURL() (*url.URL, error) {
 		}
 		return u, nil
 	}
-	u, err := base.Parse(defaultOsiePath)
+	u, err := base.Parse(defaultOSIEPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid default osie path: %s", defaultOsiePath)
+		return nil, errors.Wrapf(err, "invalid default osie path: %s", defaultOSIEPath)
 	}
 	return u, nil
 }
 
-func mustBuildOsieURL() *url.URL {
-	u, err := buildOsieURL()
+func mustBuildOSIEURL() *url.URL {
+	u, err := buildOSIEURL()
 	if err != nil {
 		panic(err)
 	}

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -25,7 +25,6 @@ func (j Job) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) bool {
 	// setup reply
 	reply := dhcp.NewReply(w, req)
 	if reply == nil {
-		j.Error(errors.New("unable to create DHCP reply"))
 		return false
 	}
 

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -172,8 +172,14 @@ func (j Job) HardwareState() string {
 	return ""
 }
 
-// OSIEVersion returns any non-standard osie versions specified in the underlying hardware
+// OSIEVersion returns any non-standard osie versions specified in either the instance proper or in userdata or attached to underlying hardware
 func (j Job) OSIEVersion() string {
+	if i := j.instance; i != nil {
+		ov := i.ServicesVersion().OSIE
+		if ov != "" {
+			return ov
+		}
+	}
 	h := j.hardware
 	if h == nil {
 		return ""

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -172,11 +172,14 @@ func (j Job) HardwareState() string {
 	return ""
 }
 
-func (j Job) ServicesVersion() string {
-	if h := j.hardware; h != nil && h.HardwareID() != "" {
-		return h.HardwareServicesVersion()
+// OSIEVersion returns any non-standard osie versions specified in the underlying hardware
+func (j Job) OSIEVersion() string {
+	h := j.hardware
+	if h == nil {
+		return ""
 	}
-	return ""
+
+	return h.HardwareServicesVersion()
 }
 
 // CanWorkflow checks if workflow is allowed

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -179,7 +179,7 @@ func (j Job) OSIEVersion() string {
 		return ""
 	}
 
-	return h.HardwareServicesVersion()
+	return h.HardwareOSIEVersion()
 }
 
 // CanWorkflow checks if workflow is allowed

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -184,9 +184,9 @@ func (j Job) CanWorkflow() bool {
 	return j.hardware.HardwareAllowWorkflow(j.mac)
 }
 
-func (j Job) OsieBaseURL() string {
+func (j Job) OSIEBaseURL() string {
 	if h := j.hardware; h != nil {
-		return j.hardware.OsieBaseURL(j.mac)
+		return j.hardware.OSIEBaseURL(j.mac)
 	}
 	return ""
 }

--- a/job/mock.go
+++ b/job/mock.go
@@ -33,7 +33,7 @@ func NewMock(t zaptest.TestingT, slug, facility string) Mock {
 
 	servicesVersion := packet.ServicesVersion{}
 	if strings.Contains(slug, "custom-osie") {
-		servicesVersion.Osie = "osie-v18.08.13.00"
+		servicesVersion.OSIE = "osie-v18.08.13.00"
 	}
 
 	mockLog := log.Test(t, "job.Mock")

--- a/packet/models.go
+++ b/packet/models.go
@@ -68,7 +68,7 @@ type Hardware interface {
 	HardwareState() HardwareState
 	HardwareServicesVersion() string
 	HardwareUEFI(mac net.HardwareAddr) bool
-	OsieBaseURL(mac net.HardwareAddr) string
+	OSIEBaseURL(mac net.HardwareAddr) string
 	KernelPath(mac net.HardwareAddr) string
 	InitrdPath(mac net.HardwareAddr) string
 }
@@ -194,7 +194,7 @@ type UserEvent struct {
 }
 
 type ServicesVersion struct {
-	Osie string `json:"osie"`
+	OSIE string `json:"osie"`
 }
 
 // HardwareState is the hardware state (e.g. provisioning)
@@ -273,11 +273,11 @@ type Netboot struct {
 		URL      string `json:"url"`
 		Contents string `json:"contents"`
 	} `json:"ipxe"`
-	Osie Osie `json:"osie"`
+	OSIE OSIE `json:"osie"`
 }
 
 // Bootstrapper is the bootstrapper to be used during netboot
-type Osie struct {
+type OSIE struct {
 	BaseURL string `json:"base_url"`
 	Kernel  string `json:"kernel"`
 	Initrd  string `json:"initrd"`

--- a/packet/models.go
+++ b/packet/models.go
@@ -66,7 +66,7 @@ type Hardware interface {
 	HardwarePlanSlug() string
 	HardwarePlanVersionSlug() string
 	HardwareState() HardwareState
-	HardwareServicesVersion() string
+	HardwareOSIEVersion() string
 	HardwareUEFI(mac net.HardwareAddr) bool
 	OSIEBaseURL(mac net.HardwareAddr) string
 	KernelPath(mac net.HardwareAddr) string

--- a/packet/models.go
+++ b/packet/models.go
@@ -139,11 +139,12 @@ type Instance struct {
 	AllowPXE bool          `json:"allow_pxe"`
 	Rescue   bool          `json:"rescue"`
 
-	OS            OperatingSystem `json:"operating_system_version"`
-	AlwaysPXE     bool            `json:"always_pxe,omitempty"`
-	IPXEScriptURL string          `json:"ipxe_script_url,omitempty"`
-	IPs           []IP            `json:"ip_addresses"`
-	UserData      string          `json:"userdata,omitempty"`
+	OS              OperatingSystem `json:"operating_system_version"`
+	AlwaysPXE       bool            `json:"always_pxe,omitempty"`
+	IPXEScriptURL   string          `json:"ipxe_script_url,omitempty"`
+	IPs             []IP            `json:"ip_addresses"`
+	UserData        string          `json:"userdata,omitempty"`
+	servicesVersion ServicesVersion
 
 	// Only returned in the first 24 hours
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -286,7 +286,7 @@ func (h HardwareCacher) HardwarePlanVersionSlug() string {
 	return h.PlanVersionSlug
 }
 
-func (h HardwareCacher) HardwareServicesVersion() string {
+func (h HardwareCacher) HardwareOSIEVersion() string {
 	return h.ServicesVersion.OSIE
 }
 

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -287,7 +287,7 @@ func (h HardwareCacher) HardwarePlanVersionSlug() string {
 }
 
 func (h HardwareCacher) HardwareServicesVersion() string {
-	return h.ServicesVersion.Osie
+	return h.ServicesVersion.OSIE
 }
 
 func (h HardwareCacher) HardwareState() HardwareState {
@@ -299,7 +299,7 @@ func (h HardwareCacher) HardwareUEFI(mac net.HardwareAddr) bool {
 }
 
 // dummy method for tink data model transition
-func (h HardwareCacher) OsieBaseURL(mac net.HardwareAddr) string {
+func (h HardwareCacher) OSIEBaseURL(mac net.HardwareAddr) string {
 	return ""
 }
 

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -1681,3 +1681,33 @@ const (
 }
 `
 )
+
+func TestServicesVersion(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		SV       ServicesVersion
+		userdata string
+		osie     string
+	}{
+		{desc: "empty"},
+		{desc: "SV", SV: ServicesVersion{OSIE: "SV osie"}, osie: "SV osie"},
+		{desc: "userdata", userdata: `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "userdata:junk-text", userdata: `I'm a little teapot` + "\n" + `#services={"osie":"userdata osie"}` + "\n" + `short and stout!`, osie: "userdata osie"},
+		{desc: "userdata:cloud-config", userdata: `#cloud-config` + "\n" + `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "userdata:bash", userdata: `#!/usr/bin/bash` + "\n" + `#services={"osie":"userdata osie"}`, osie: "userdata osie"},
+		{desc: "invalid userdata, not commented", userdata: `services={"osie":"userdata osie"}`},
+		{desc: "invalid userdata, garbage at end commented", userdata: `services={"osie":"userdata osie"}blah`},
+		{desc: "SV over userdata", SV: ServicesVersion{OSIE: "SV over osie"}, userdata: `#services={"osie":"userdata osie"}`, osie: "SV over osie"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			i := Instance{
+				servicesVersion: test.SV,
+				UserData:        test.userdata,
+			}
+			got := i.ServicesVersion().OSIE
+			if got != test.osie {
+				t.Fatalf("incorrect services version returned, want=%q, got=%q", test.osie, got)
+			}
+		})
+	}
+}

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -168,7 +168,7 @@ func TestDiscoveryCacher(t *testing.T) {
 				t.Fatalf("unexpected address, want: %s, got: %s", test.conf.Gateway, conf.Gateway)
 			}
 
-			osie := d.ServicesVersion.Osie
+			osie := d.ServicesVersion.OSIE
 			if osie != test.osie {
 				t.Fatalf("unexpected osie version, want: %s, got: %s", test.osie, osie)
 			}
@@ -231,7 +231,7 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("netboot allow_pxe: %v", d.Network.InterfaceByMac(mac).Netboot.AllowPXE)
 			t.Logf("netboot allow_workflow: %v", d.Network.InterfaceByMac(mac).Netboot.AllowWorkflow)
 			t.Logf("netboot ipxe: %v", d.Network.InterfaceByMac(mac).Netboot.IPXE)
-			t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.Osie)
+			t.Logf("netboot osie: %v", d.Network.InterfaceByMac(mac).Netboot.OSIE)
 			t.Log()
 
 			t.Logf("metadata: %v", d.Metadata)

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -161,14 +161,14 @@ func (h HardwareTinkerbellV1) Interfaces() []Port {
 	return ports
 }
 
-func (h HardwareTinkerbellV1) OsieBaseURL(mac net.HardwareAddr) string {
-	return h.Network.InterfaceByMac(mac).Netboot.Osie.BaseURL
+func (h HardwareTinkerbellV1) OSIEBaseURL(mac net.HardwareAddr) string {
+	return h.Network.InterfaceByMac(mac).Netboot.OSIE.BaseURL
 }
 
 func (h HardwareTinkerbellV1) KernelPath(mac net.HardwareAddr) string {
-	return h.Network.InterfaceByMac(mac).Netboot.Osie.Kernel
+	return h.Network.InterfaceByMac(mac).Netboot.OSIE.Kernel
 }
 
 func (h HardwareTinkerbellV1) InitrdPath(mac net.HardwareAddr) string {
-	return h.Network.InterfaceByMac(mac).Netboot.Osie.Initrd
+	return h.Network.InterfaceByMac(mac).Netboot.OSIE.Initrd
 }

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -147,7 +147,7 @@ func (h HardwareTinkerbellV1) HardwareState() HardwareState {
 }
 
 // dummy method for backward compatibility
-func (h HardwareTinkerbellV1) HardwareServicesVersion() string {
+func (h HardwareTinkerbellV1) HardwareOSIEVersion() string {
 	return ""
 }
 


### PR DESCRIPTION
## Description

Bring in changes that were merged into the `production` branch, and thus deployed into Packet's actual production system, back into master. This was done while master was in a state that would break Packet provisioning.

## Why is this needed

With this merged we can get back to having Packet working off of `master` branch.


## How Has This Been Tested?

`go test` passes.
Tested in both YYZ1 and NRT1, provisions/deprovisions working well.


## How are existing users impacted? What migration steps/scripts do we need?

No anticipated issues.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
