### PR TITLE
ENG-6658 user defined metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/tinkerbell/tink v0.0.0-20200714130438-0100e535bd94
+	github.com/tinkerbell/tink v0.0.0-20200724140154-850584d46c8d
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20191212201129-5f9f41018e9d/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -98,8 +99,13 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kdeng3849/tink v0.0.0-20200707134055-37bac1d809b1 h1:PRIIgoWz4b7b0qLDBT0U8cuI1HmIYaY3Pkmb9cJWZPk=
+github.com/kdeng3849/tink v0.0.0-20200707134055-37bac1d809b1/go.mod h1:76mIaisvbix90uCd7nRXXNO198WiL+TeJihDr4BXRas=
+github.com/kdeng3849/tink v0.0.0-20200723210025-4b39ab5c7dc9 h1:Zdrw8dDyawmch+albWmIsujyFgXqxjRhEbJjzmlipK4=
+github.com/kdeng3849/tink v0.0.0-20200723210025-4b39ab5c7dc9/go.mod h1:LCMa/UyQYNA0Tf6E26+94gjpy5jA8k0IM1fNryFfGns=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -150,6 +156,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -201,6 +208,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinkerbell/tink v0.0.0-20200714130438-0100e535bd94 h1:EqE+Jvuh2WIdUcmAlY8K6MqJxQQZksMTCEA8MLKOFnI=
 github.com/tinkerbell/tink v0.0.0-20200714130438-0100e535bd94/go.mod h1:fVMM7v8aqMiptIq3DZWleonNo30JIBA4CX7gT0vDaiU=
+github.com/tinkerbell/tink v0.0.0-20200720072021-7bcc7d6ba816 h1:FO6yzXry0AAgZVDzO3eSU6jV6AnB6EhU0YRVC+c37uA=
+github.com/tinkerbell/tink v0.0.0-20200720072021-7bcc7d6ba816/go.mod h1:fVMM7v8aqMiptIq3DZWleonNo30JIBA4CX7gT0vDaiU=
+github.com/tinkerbell/tink v0.0.0-20200724140154-850584d46c8d h1:n8Z9XVLfObhWMLnCvx7kf1KtuigdnU/EULDMHgQ6ILI=
+github.com/tinkerbell/tink v0.0.0-20200724140154-850584d46c8d/go.mod h1:LCMa/UyQYNA0Tf6E26+94gjpy5jA8k0IM1fNryFfGns=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.uber.org/atomic v1.2.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -253,6 +264,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -11,6 +11,7 @@ import (
 	"github.com/packethost/cacher/protos/cacher"
 	tink "github.com/tinkerbell/tink/protos/hardware"
 	tw "github.com/tinkerbell/tink/protos/workflow"
+	tinkUtil "github.com/tinkerbell/tink/util"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -103,7 +104,7 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 			return nil, errors.Wrap(err, "get hardware by mac from tink")
 		}
 
-		b, err := json.Marshal(resp)
+		b, err := json.Marshal(&tinkUtil.HardwareWrapper{Hardware: resp}) // uses HardwareWrapper for its custom marshaler
 		if err != nil {
 			return nil, errors.New("marshalling tink hardware")
 		}
@@ -195,7 +196,7 @@ func (c *Client) DiscoverHardwareFromIP(ip net.IP) (Discovery, error) {
 			return nil, errors.Wrap(err, "get hardware by ip from tink")
 		}
 
-		b, err = json.Marshal(resp)
+		b, err = json.Marshal(&tinkUtil.HardwareWrapper{Hardware: resp}) // uses HardwareWrapper for its custom marshaler
 		if err != nil {
 			return nil, errors.New("marshalling tink hardware")
 		}


### PR DESCRIPTION
## Description
<!--- Please describe what this PR is going to change -->
The [metadata](https://github.com/tinkerbell/tink/blob/a2944c1dd079bd72b61cb955919524fc4542f14c/protos/hardware/hardware.proto#L221) field under hardware is being changed to a (json formatted) string in Tink.  
In order to accommodate that, this PR uses a custom unmarshaller for the `hardware.Hardware` object returned from tink to be able to parse the json formatted string.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: https://github.com/tinkerbell/tink/issues/199

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Successfully ran a basic workflow using a tinkerbell/packet setup


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->
Should work as before, no migration needed.

Related PRs:
hegel: https://github.com/tinkerbell/hegel/pull/16
tink: https://github.com/tinkerbell/tink/pull/197

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
