### PR TITLE
Add site-eng as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Documentation https://help.github.com/articles/about-codeowners/
+*       @tinkerbell/site-eng


### PR DESCRIPTION
## Description

Add site-eng as CODEOWNERS

## Why is this needed

To avoid having PRs merged without site-eng taking a look with a packet-production perspective by having site-eng automatically set as a reviewer.
