### PR TITLE
use tinkerbell/tftp-go for fixed block size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
+	github.com/tinkerbell/tftp-go v0.0.0-20200825172122-d9200358b6cd // indirect
 	github.com/tinkerbell/tink v0.0.0-20200806104854-0f947d87c35f
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinkerbell/tftp-go v0.0.0-20200825172122-d9200358b6cd h1:xzbrPNdX+FbdZla90nnDPf3wv0v0Re6PfhZOwX7tSdo=
+github.com/tinkerbell/tftp-go v0.0.0-20200825172122-d9200358b6cd/go.mod h1:fIVwBIM3uQepwxarJe/ixO4KtVYcoXPIUBtVFK/OhY0=
 github.com/tinkerbell/tink v0.0.0-20200806104854-0f947d87c35f h1:zEKK3pMw8hB0BYkv0mIhJzhouh32v6/PwvMQBRCVmgk=
 github.com/tinkerbell/tink v0.0.0-20200806104854-0f947d87c35f/go.mod h1:5Kv1re+s/uSfE3vWsoOS+tKwZYwLrrPXgEXViTbEmv4=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/job/tftp.go
+++ b/job/tftp.go
@@ -1,8 +1,8 @@
 package job
 
 import (
-	tftpgo "github.com/betawaffle/tftp-go"
 	"github.com/tinkerbell/boots/tftp"
+	tftpgo "github.com/tinkerbell/tftp-go"
 )
 
 func (j Job) ServeTFTP(filename, client string) (tftpgo.ReadCloser, error) {

--- a/tftp.go
+++ b/tftp.go
@@ -8,12 +8,12 @@ import (
 	"path"
 
 	"github.com/avast/retry-go"
-	tftp "github.com/betawaffle/tftp-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/job"
 	"github.com/tinkerbell/boots/metrics"
+	tftp "github.com/tinkerbell/tftp-go"
 )
 
 var (


### PR DESCRIPTION
In some cases we hit an issue with mtu and tftp in cilium. This change
includes a fix to reduce the block size to 1400 which has been working
well under cilium.