### PR TITLE
Added changes for boots to have centralized logging in tinkerbell

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -82,6 +82,10 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("grpc_cert_url=" + grpcCertURL)
 		s.Args("registry_username=" + registryUsername)
 		s.Args("registry_password=" + registryPassword)
+		s.Args("log_driver=" + log_driver)
+		s.Args("log_tag=" + log_tag)
+		s.Args("log_server_address=" + log_server_address)
+		s.Args("log_server_address_type=" + log_server_address_type)
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID())
 	}

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -83,9 +83,9 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("registry_username=" + registryUsername)
 		s.Args("registry_password=" + registryPassword)
 		s.Args("log_driver=" + log_driver)
-		s.Args("log_tag=" + log_tag)
-		s.Args("log_server_address=" + log_server_address)
-		s.Args("log_server_address_type=" + log_server_address_type)
+		s.Args("log_opt_tag=" + log_opt_tag)
+		s.Args("log_opt_server_address=" + log_opt_server_address)
+		s.Args("log_opt_server_address_type=" + log_opt_server_address_type)
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID())
 	}

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -85,7 +85,6 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("log_driver=" + log_driver)
 		s.Args("log_opt_tag=" + log_opt_tag)
 		s.Args("log_opt_server_address=" + log_opt_server_address)
-		s.Args("log_opt_server_address_type=" + log_opt_server_address_type)
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID())
 	}

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -82,6 +82,7 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("grpc_cert_url=" + grpcCertURL)
 		s.Args("registry_username=" + registryUsername)
 		s.Args("registry_password=" + registryPassword)
+		s.Args("centralized_logging=" + centralized_logging)
 		s.Args("log_driver=" + log_driver)
 		s.Args("log_opt_tag=" + log_opt_tag)
 		s.Args("log_opt_server_address=" + log_opt_server_address)

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,11 +14,13 @@ const (
 )
 
 var (
-	osieURL                            = mustBuildOSIEURL().String()
-	mirrorBaseURL                      = conf.MirrorBaseUrl
-	dockerRegistry                     string
-	grpcAuthority, grpcCertURL         string
-	registryUsername, registryPassword string
+	osieURL                                 = mustBuildOSIEURL().String()
+	mirrorBaseURL                           = conf.MirrorBaseUrl
+	dockerRegistry                          string
+	grpcAuthority, grpcCertURL              string
+	registryUsername, registryPassword      string
+	log_driver, log_tag, log_server_address string
+	log_server_address_type                 string
 )
 
 func buildOSIEURL() (*url.URL, error) {
@@ -54,6 +56,10 @@ func buildWorkerParams() {
 	grpcCertURL = getParam("TINKERBELL_CERT_URL")
 	registryUsername = getParam("REGISTRY_USERNAME")
 	registryPassword = getParam("REGISTRY_PASSWORD")
+	log_driver = getParam("LOG_DRIVER")
+	log_tag = getParam("LOG_TAG")
+	log_server_address = getParam("LOG_SERVER_ADDRESS")
+	log_server_address_type = getParam("LOG_SERVER_ADDRESS_TYPE")
 }
 
 func getParam(key string) string {

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,13 +14,12 @@ const (
 )
 
 var (
-	osieURL                                 = mustBuildOSIEURL().String()
-	mirrorBaseURL                           = conf.MirrorBaseUrl
-	dockerRegistry                          string
-	grpcAuthority, grpcCertURL              string
-	registryUsername, registryPassword      string
-	log_driver, log_tag, log_server_address string
-	log_server_address_type                 string
+	osieURL                                                                      = mustBuildOSIEURL().String()
+	mirrorBaseURL                                                                = conf.MirrorBaseUrl
+	dockerRegistry                                                               string
+	grpcAuthority, grpcCertURL                                                   string
+	registryUsername, registryPassword                                           string
+	log_driver, log_opt_tag, log_opt_server_address, log_opt_server_address_type string
 )
 
 func buildOSIEURL() (*url.URL, error) {
@@ -57,9 +56,9 @@ func buildWorkerParams() {
 	registryUsername = getParam("REGISTRY_USERNAME")
 	registryPassword = getParam("REGISTRY_PASSWORD")
 	log_driver = getParam("LOG_DRIVER")
-	log_tag = getParam("LOG_TAG")
-	log_server_address = getParam("LOG_SERVER_ADDRESS")
-	log_server_address_type = getParam("LOG_SERVER_ADDRESS_TYPE")
+	log_opt_tag = getParam("LOG_OPT_TAG")
+	log_opt_server_address = getParam("LOG_OPT_SERVER_ADDRESS")
+	log_opt_server_address_type = getParam("LOG_OPT_SERVER_ADDRESS_TYPE")
 }
 
 func getParam(key string) string {

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,12 +14,12 @@ const (
 )
 
 var (
-	osieURL                                                                      = mustBuildOSIEURL().String()
-	mirrorBaseURL                                                                = conf.MirrorBaseUrl
-	dockerRegistry                                                               string
-	grpcAuthority, grpcCertURL                                                   string
-	registryUsername, registryPassword                                           string
-	log_driver, log_opt_tag, log_opt_server_address, log_opt_server_address_type string
+	osieURL                                         = mustBuildOSIEURL().String()
+	mirrorBaseURL                                   = conf.MirrorBaseUrl
+	dockerRegistry                                  string
+	grpcAuthority, grpcCertURL                      string
+	registryUsername, registryPassword              string
+	log_driver, log_opt_tag, log_opt_server_address string
 )
 
 func buildOSIEURL() (*url.URL, error) {
@@ -58,7 +58,6 @@ func buildWorkerParams() {
 	log_driver = getParam("LOG_DRIVER")
 	log_opt_tag = getParam("LOG_OPT_TAG")
 	log_opt_server_address = getParam("LOG_OPT_SERVER_ADDRESS")
-	log_opt_server_address_type = getParam("LOG_OPT_SERVER_ADDRESS_TYPE")
 }
 
 func getParam(key string) string {

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,12 +14,14 @@ const (
 )
 
 var (
-	osieURL                                                              = mustBuildOSIEURL().String()
-	mirrorBaseURL                                                        = conf.MirrorBaseUrl
-	dockerRegistry                                                       string
-	grpcAuthority, grpcCertURL                                           string
-	registryUsername, registryPassword                                   string
-	centralized_logging, log_driver, log_opt_tag, log_opt_server_address string
+	osieURL                             = mustBuildOSIEURL().String()
+	mirrorBaseURL                       = conf.MirrorBaseUrl
+	dockerRegistry                      string
+	grpcAuthority, grpcCertURL          string
+	registryUsername, registryPassword  string
+	centralized_logging                 string
+	log_driver                          string
+	log_opt_tag, log_opt_server_address string
 )
 
 func buildOSIEURL() (*url.URL, error) {

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,12 +14,12 @@ const (
 )
 
 var (
-	osieURL                                         = mustBuildOSIEURL().String()
-	mirrorBaseURL                                   = conf.MirrorBaseUrl
-	dockerRegistry                                  string
-	grpcAuthority, grpcCertURL                      string
-	registryUsername, registryPassword              string
-	log_driver, log_opt_tag, log_opt_server_address string
+	osieURL                                                              = mustBuildOSIEURL().String()
+	mirrorBaseURL                                                        = conf.MirrorBaseUrl
+	dockerRegistry                                                       string
+	grpcAuthority, grpcCertURL                                           string
+	registryUsername, registryPassword                                   string
+	centralized_logging, log_driver, log_opt_tag, log_opt_server_address string
 )
 
 func buildOSIEURL() (*url.URL, error) {
@@ -55,6 +55,7 @@ func buildWorkerParams() {
 	grpcCertURL = getParam("TINKERBELL_CERT_URL")
 	registryUsername = getParam("REGISTRY_USERNAME")
 	registryPassword = getParam("REGISTRY_PASSWORD")
+	centralized_logging = getParam("CENTRALIZED_LOGGING")
 	log_driver = getParam("LOG_DRIVER")
 	log_opt_tag = getParam("LOG_OPT_TAG")
 	log_opt_server_address = getParam("LOG_OPT_SERVER_ADDRESS")


### PR DESCRIPTION
Signed-off-by: cbkhare <Chitrabasukhare89@gmail.com>

## Description

Changes to add centralized logging for the Tinkerbell. 

## Why is this needed

- We need a log aggregator for Tinkerbell which can collect log from tink services and tink worker containers. 
- Tink PR: https://github.com/tinkerbell/tink/pull/267
- osie PR: https://github.com/tinkerbell/osie/pull/104
- RFD: https://github.com/tinkerbell/proposals/pull/7

Fixes: #

## How Has This Been Tested?
- [x] Tested with basic hello-world example.
- [x] Verified the testing of logrotation.
- [x] Added below test results. 

**log_aggregation**
```
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/
total 20
drwxr-xr-x 2 syslog syslog 4096 Sep  8 12:59 provisioner
-rw-r----- 1 syslog adm    9521 Sep  8 13:04 daemon.log
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:17 192.168.1.5
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/192.168.1.5/
total 12
-rw-r----- 1 syslog adm 2985 Sep  8 13:17 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log
-rw-r----- 1 syslog adm 4789 Sep  8 13:17 tink-worker.log
```

**logrotation**:
```
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/provisioner/
total 36
-rw-r----- 1 syslog adm  513 Sep  8 13:04 deploy_db_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 4099 Sep  8 13:17 deploy_boots_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm  577 Sep  8 13:17 deploy_nginx_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm  400 Sep  8 13:17 deploy_hegel_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 1450 Sep  8 13:17 deploy_tink-server_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 6155 Sep  8 13:37 deploy_registry_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_boots_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_db_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_hegel_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_nginx_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_tink-server_1.log
-rw-r----- 1 syslog adm  147 Sep  8 13:37 deploy_registry_1.log
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/192.168.1.5/
total 8
-rw-r----- 1 syslog adm 571 Sep  8 13:17 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 918 Sep  8 13:17 tink-worker.log-20200908131599572256.gz
-rw-r----- 1 syslog adm   0 Sep  8 13:37 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log
-rw-r----- 1 syslog adm   0 Sep  8 13:37 tink-worker.log
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/
total 12
-rw-r----- 1 syslog adm    1642 Sep  8 13:04 daemon.log-20200908131599572256.gz
-rw-r----- 1 syslog adm       0 Sep  8 13:37 daemon.log
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:37 192.168.1.5
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:37 provisioner

``` 
## How are existing users impacted? What migration steps/scripts do we need?

- Log location has been updated. Documentation will need an update.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
