### PR TITLE
Remove unused MirrorBaseIP variable and associated functions

### DIFF
--- a/conf/mirror.go
+++ b/conf/mirror.go
@@ -2,7 +2,6 @@ package conf
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -21,7 +20,6 @@ var (
 	mirrorURL     = mustBuildMirrorURL()
 	MirrorURL     = mirrorURL.String()
 	MirrorHost    = mirrorURL.Host
-	MirrorBaseIP  = mustFindMirrorIPBase()
 	MirrorPath    = mirrorURL.Path
 	MirrorBase    = strings.TrimSuffix(MirrorURL, MirrorPath)
 	mirrorBaseUrl = mustBuildMirrorBaseURL()
@@ -74,17 +72,6 @@ func buildMirrorBaseURL() (*url.URL, error) {
 		return nil, errors.Wrapf(err, "invalid default mirror host: %s", mirror)
 	}
 	return u, nil
-}
-
-func mustFindMirrorIPBase() string {
-	i, err := net.LookupIP(mirrorURL.Host)
-	if err != nil {
-		panic(errors.Wrap(err, "looking up ip of mirror url"))
-	}
-	if len(i) == 0 || i[0].String() == "" {
-		panic(fmt.Sprintf("Looking up %s failed to return either an IPv4 or IPv6 address", mirrorURL.Host))
-	}
-	return "http://" + i[0].String()
 }
 
 func mustBuildMirrorURL() *url.URL {

--- a/conf/mirror_test.go
+++ b/conf/mirror_test.go
@@ -1,0 +1,261 @@
+package conf
+
+import (
+	"net/url"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_buildMirrorBaseURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		facilityCode  string
+		mirrorBaseURL string
+		mirrorHost    string
+		want          *url.URL
+		wantErr       bool
+	}{
+		{
+			name:       "Accepts MIRROR_HOST value that contains a port number",
+			mirrorHost: "10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+			},
+		},
+		{
+			name:       "Accepts MIRROR_HOST value that does not contain a port number",
+			mirrorHost: "10.10.10.10",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+			},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that does not contain a port number",
+			mirrorBaseURL: "http://10.10.10.10",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+			},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+			},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+			},
+		},
+		{
+			name:          "Rejects MIRROR_BASE_URL value that contains a path",
+			mirrorBaseURL: "http://10.10.10.10/path",
+			wantErr:       true,
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			mirrorHost:    "http://172.30.10.0",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+			},
+		},
+		{
+			name: "Default value",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "install.ewr1.packet.net",
+			},
+		},
+		{
+			name:         "Default value, override facility",
+			facilityCode: "blue",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "install.blue.packet.net",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mirrorBaseURL != "" {
+				os.Setenv("MIRROR_BASE_URL", tt.mirrorBaseURL)
+			} else {
+				os.Unsetenv("MIRROR_BASE_URL")
+			}
+
+			if tt.mirrorHost != "" {
+				os.Setenv("MIRROR_HOST", tt.mirrorHost)
+			} else {
+				os.Unsetenv("MIRROR_HOST")
+			}
+
+			if tt.facilityCode != "" {
+				FacilityCode = tt.facilityCode
+			}
+			got, err := buildMirrorBaseURL()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildMirrorBaseURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildMirrorBaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildMirrorURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		facilityCode  string
+		mirrorBaseURL string
+		mirrorHost    string
+		mirrorPath    string
+		want          *url.URL
+		wantErr       bool
+	}{
+		{
+			name:       "Accepts MIRROR_HOST value that contains a port number",
+			mirrorHost: "10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+				Path:   defaultMirrorPath,
+			},
+		},
+		{
+			name:       "Accepts MIRROR_HOST value that does not contain a port number",
+			mirrorHost: "10.10.10.10",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:       "Specifying MIRROR_HOST and MIRROR_PATH returns the correct result",
+			mirrorHost: "10.10.10.10",
+			mirrorPath: "/my/special/path",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+				Path:   "/my/special/path"},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that does not contain a port number",
+			mirrorBaseURL: "http://10.10.10.10",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:          "Specifying MIRROR_BASE_URL and MIRROR_PATH returns the correct result",
+			mirrorBaseURL: "http://10.10.10.10",
+			mirrorPath:    "/my/special/path",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10",
+				Path:   "/my/special/path"},
+		},
+		{
+			name:          "Rejects MIRROR_BASE_URL value that contains a path",
+			mirrorBaseURL: "http://10.10.10.10/path",
+			wantErr:       true,
+		},
+		{
+			name:          "Accepts MIRROR_BASE_URL value that contains a port number",
+			mirrorBaseURL: "http://10.10.10.10:8080",
+			mirrorHost:    "http://172.30.10.0",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "10.10.10.10:8080",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name: "Default value",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "install.ewr1.packet.net",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:         "Default value, override facility",
+			facilityCode: "blue",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "install.blue.packet.net",
+				Path:   defaultMirrorPath},
+		},
+		{
+			name:       "Default value, override MIRROR_PATH",
+			mirrorPath: "/my/special/path",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "install.ewr1.packet.net",
+				Path:   "/my/special/path"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mirrorBaseURL != "" {
+				os.Setenv("MIRROR_BASE_URL", tt.mirrorBaseURL)
+			} else {
+				os.Unsetenv("MIRROR_BASE_URL")
+			}
+
+			if tt.mirrorHost != "" {
+				os.Setenv("MIRROR_HOST", tt.mirrorHost)
+			} else {
+				os.Unsetenv("MIRROR_HOST")
+			}
+
+			if tt.mirrorPath != "" {
+				os.Setenv("MIRROR_PATH", tt.mirrorPath)
+			} else {
+				os.Unsetenv("MIRROR_PATH")
+			}
+
+			if tt.facilityCode != "" {
+				FacilityCode = tt.facilityCode
+			} else {
+				FacilityCode = defaultFacility
+			}
+
+			got, err := buildMirrorURL()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildMirrorURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildMirrorURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
-	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
 )
@@ -21,7 +20,6 @@ var facility = func() string {
 }()
 
 func TestScriptPerType(t *testing.T) {
-	conf.MirrorBaseIP = "http://install.ewr1.packet.net"
 	for typ, script := range type2pxe {
 		for version, bootScript := range versions {
 			t.Log(typ + ":" + version)

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -28,7 +28,6 @@ func TestScriptKickstart(t *testing.T) {
 	manufacturers := []string{"supermicro", "dell"}
 	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0"}
 	assert := require.New(t)
-	conf.MirrorBaseIP = "http://127.0.0.1"
 	conf.PublicIPv4 = net.ParseIP("127.0.0.1")
 	conf.PublicFQDN = "boots-test.example.com"
 


### PR DESCRIPTION
Signed-off-by: Jason DeTiberus <detiber@users.noreply.github.com>

## Description

We were generating a value for the MirrorBaseIP variable that caused issues when specifying a MIRROR_BASE_URL or MIRROR_HOST value that contained a port number, however MirrorBaseIP is never referenced anywhere other than a couple of tests where it is being overridden (to no effect).

## Why is this needed

This allows users to specify MIRROR_BASE_URL or MIRROR_HOST that contains a host:port combination, when the mirror server is not listening on port 80

## How Has This Been Tested?

Tested using the local setup described in the docs, slightly modified to expose the mirror host on a port other than port 80.

## How are existing users impacted? What migration steps/scripts do we need?

This should not affect existing users.

## Checklist:

I have:

- [x] added unit or e2e tests
