### PR TITLE
Add interpreter definition to VMware installer

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -351,11 +351,11 @@ BODY='{"type":"provisioning.109"}'
 BODY_LEN=$( echo -n ${BODY} | wc -c )
 echo -ne "POST /phone-home HTTP/1.0\r\nHost: {{ tink_host }}\r\nContent-Type: application/json\r\nContent-Length: ${BODY_LEN}\r\n\r\n${BODY}" | nc -i 3 {{ tink_host }} 80 > /tmp/post-phone-home.log
 
-%post --ignorefailure=true
+%post --interpreter=busybox --ignorefailure=true
 echo "Packet installation postinstall executed" > /packet-pi-ks.log
 sleep 20
 
-%post --ignorefailure=true
+%post --interpreter=busybox --ignorefailure=true
 echo "Packet installation postinstall executed" > /packet-pi-ks-nc.log
 sleep 20
 

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -317,11 +317,11 @@ BODY='{"type":"provisioning.109"}'
 BODY_LEN=$( echo -n ${BODY} | wc -c )
 echo -ne "POST /phone-home HTTP/1.0\r\nHost: boots-test.example.com\r\nContent-Type: application/json\r\nContent-Length: ${BODY_LEN}\r\n\r\n${BODY}" | nc -i 3 boots-test.example.com 80 > /tmp/post-phone-home.log
 
-%post --ignorefailure=true
+%post --interpreter=busybox --ignorefailure=true
 echo "Packet installation postinstall executed" > /packet-pi-ks.log
 sleep 20
 
-%post --ignorefailure=true
+%post --interpreter=busybox --ignorefailure=true
 echo "Packet installation postinstall executed" > /packet-pi-ks-nc.log
 sleep 20
 


### PR DESCRIPTION
## Description

This adds the interpreter definition to VMware installer for a few post install directives within the kickstart portion of the VMware installer.

## Why is this needed

This change addresses a hang during the ESXi installation and resolves 2 warning messages.


## How Has This Been Tested?
Testing is completed by deploying to a single facility prior to general production deployment.


## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug which was causing a ~30 second delay during legacy/kickstart based installation of VMware.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
