### PR TITLE
flatcar: exclude NVMe disks for s3.xl

### DIFF
--- a/installers/coreos/installer.go
+++ b/installers/coreos/installer.go
@@ -25,7 +25,11 @@ func getInstallOpts(j job.Job, channel, facilityCode string) string {
 	}
 
 	if strings.HasPrefix(distro, "flatcar") {
-		args = append(args, "-s")
+		if strings.Contains(j.PlanSlug(), "s3.xlarge") {
+			args = append(args, "-s", "-e", "259")
+		} else {
+			args = append(args, "-s")
+		}
 	} else {
 		disk := "/dev/sda"
 		if strings.Contains(j.PlanSlug(), "s1.large") {


### PR DESCRIPTION
## Description

For the s3.xlarge plan type, lets exclude NVMe disks from the installation targets

## Why is this needed

Seems Flatcar isn't working well with those. Also they are marked for cache instead of boot in any case.

## How Has This Been Tested?
Confirmed NVMe only installs seem broken by creating m3.large NVMe only setup.
Barely tested otherwise.

## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix 🤞 

