### PR TITLE
flatcar: move to systemd-network

### DIFF
--- a/installers/coreos/ignition.go
+++ b/installers/coreos/ignition.go
@@ -30,6 +30,8 @@ func buildNetworkUnits(j job.Job) (nu ignition.NetworkUnits) {
 }
 
 func buildSystemdUnits(j job.Job) (su ignition.SystemdUnits) {
+	configureNetworkService(j, su.Add("systemd-networkd.service"))
+	configureNetworkService(j, su.Add("systemd-networkd-wait-online.service"))
 	configureInstaller(j, su.Add("install.service"))
 	return
 }

--- a/installers/coreos/installer.go
+++ b/installers/coreos/installer.go
@@ -43,7 +43,7 @@ func getInstallOpts(j job.Job, channel, facilityCode string) string {
 
 func configureInstaller(j job.Job, u *ignition.SystemdUnit) {
 	distro := j.OperatingSystem().Distro
-	u.AddSection("Unit", "Requires=network-online.target", "After=network-online.target")
+	u.AddSection("Unit", "Requires=systemd-networkd-wait-online.target", "After=systemd-networkd-wait-online.target")
 
 	var channel string
 	var facilityCode string
@@ -84,5 +84,9 @@ func configureInstaller(j job.Job, u *ignition.SystemdUnit) {
 	}
 
 	u.AddSection("Install", "WantedBy=multi-user.target")
+	u.Enable()
+}
+
+func configureNetworkService(j job.Job, u *ignition.SystemdUnit) {
 	u.Enable()
 }

--- a/installers/coreos/installer_test.go
+++ b/installers/coreos/installer_test.go
@@ -49,8 +49,8 @@ func TestInstaller(t *testing.T) {
 // this is the base set of starter commands for coreos installs
 var baseStart = []string{
 	"[Unit]",
-	"Requires=network-online.target",
-	"After=network-online.target",
+	"Requires=systemd-networkd-wait-online.target",
+	"After=systemd-networkd-wait-online.target",
 	"",
 	"[Service]",
 	"Type=oneshot",


### PR DESCRIPTION
Currently it seems that Flatcar encounters a race condition on some of 
our hardware. This fix was suggested by @t-lo and crafted by 
@nicolerenee

## Description

Adjust the systemd unit we use to wait for network connectivity

## Why is this needed
Recently Flatcar stopped working on c1 and c3 small.x86 plan types

## How Has This Been Tested?
Highly speculative, untested

## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix 🤞 