### PR TITLE
flatcar: networkd switch from target to service

### DIFF
--- a/installers/coreos/installer.go
+++ b/installers/coreos/installer.go
@@ -43,7 +43,7 @@ func getInstallOpts(j job.Job, channel, facilityCode string) string {
 
 func configureInstaller(j job.Job, u *ignition.SystemdUnit) {
 	distro := j.OperatingSystem().Distro
-	u.AddSection("Unit", "Requires=systemd-networkd-wait-online.target", "After=systemd-networkd-wait-online.target")
+	u.AddSection("Unit", "Requires=systemd-networkd-wait-online.service", "After=systemd-networkd-wait-online.service")
 
 	var channel string
 	var facilityCode string

--- a/installers/coreos/installer.go
+++ b/installers/coreos/installer.go
@@ -68,7 +68,7 @@ func configureInstaller(j job.Job, u *ignition.SystemdUnit) {
 	installOpts := getInstallOpts(j, channel, facilityCode)
 	lines := []string{
 		// Install to disk:
-		`/usr/bin/curl -H "Content-Type: application/json" -X POST -d '{"type":"provisioning.106"}' ${phone_home_url}`,
+		`/usr/bin/curl --retry 10 -H "Content-Type: application/json" -X POST -d '{"type":"provisioning.106"}' ${phone_home_url}`,
 		"/usr/bin/" + distro + "-install " + installOpts,
 		"/usr/bin/udevadm settle",
 		"/usr/bin/mkdir -p /oemmnt",

--- a/installers/coreos/installer_test.go
+++ b/installers/coreos/installer_test.go
@@ -49,8 +49,8 @@ func TestInstaller(t *testing.T) {
 // this is the base set of starter commands for coreos installs
 var baseStart = []string{
 	"[Unit]",
-	"Requires=systemd-networkd-wait-online.target",
-	"After=systemd-networkd-wait-online.target",
+	"Requires=systemd-networkd-wait-online.service",
+	"After=systemd-networkd-wait-online.service",
 	"",
 	"[Service]",
 	"Type=oneshot",

--- a/installers/coreos/installer_test.go
+++ b/installers/coreos/installer_test.go
@@ -66,7 +66,7 @@ var baseEnd = []string{
 }
 
 var Exec = []string{
-	`ExecStart=/usr/bin/curl -H "Content-Type: application/json" -X POST -d '{"type":"provisioning.106"}' ${phone_home_url}`,
+	`ExecStart=/usr/bin/curl --retry 10 -H "Content-Type: application/json" -X POST -d '{"type":"provisioning.106"}' ${phone_home_url}`,
 	"ExecStart=/usr/bin/coreos-install -V current -C alpha -b http://install." + facility + ".packet.net/coreos/amd64-usr/alpha -o packet -d /dev/sda",
 	"ExecStart=/usr/bin/udevadm settle",
 	"ExecStart=/usr/bin/mkdir -p /oemmnt",


### PR DESCRIPTION
Lets point at the service instead of the target. Credit to @nicolerenee

## Description
Fixes a small oversight in #88 where the target is now a service