### PR TITLE
f3.x86: opt for ttyS0 instead

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -122,7 +122,7 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		}
 	} else {
 		s.Args("console=tty0")
-		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" {
+		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" || j.PlanSlug() == "f3.medium.x86" || j.PlanSlug() == "f3.large.x86" {
 			console = "ttyS0"
 		} else {
 			console = "ttyS1"


### PR DESCRIPTION
Seems these new HP machines use this TTY instead

## Description

For the f3.medium and f3.large plans, lets use ttyS0 instead

## Why is this needed

Not working on ttyS1
