### PR TITLE
testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,9 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: boots
-        path: ./boots
-    - name: set boots permission
-      run: ls -l && ls -alR boots/ && chmod +x ./boots && ls -l && ls -alR boots/
+        path: ./boots-artifact
+    - name: Fixup boots binary from artifact
+      run: install -m0755 -o root -g root boots-artifact/boots boots
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,21 +17,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.14.6'
-    - name: goimports
-      run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
-    - name: go vet
-      run: go vet ./...
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
-      with:
-        version: v1.30
-        args: -v -D errcheck
-    - name: go test
-      run: go test -v ./...
-    - name: go test coverage
-      run: go test -coverprofile=coverage.txt ./...
-    - name: upload codecov
-      run: bash <(curl -s https://codecov.io/bash)
     - name: Build binaries
       run: go build
     - name: Upload boots binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
       with:
         name: boots
         path: ./boots
+    - name: Dump Env
+      run: env
   docker-images:
     runs-on: ubuntu-latest
     needs: [validation]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         name: boots
         path: ./boots-artifact
     - name: Fixup boots binary from artifact
-      run: install -m0755 -o root -g root boots-artifact/boots boots
+      run: sudo install -m0755 -o root -g root boots-artifact/boots boots
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         name: boots
         path: ./boots
     - name: set boots permission
-      run: chmod +x  ./boots
+      run: ls -l && ls -alR boots/ && chmod +x ./boots && ls -l && ls -alR boots/
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io


### PR DESCRIPTION
## Description

Container images built via GitHub Actions do not have the boots binary with execute perms and thus the container does not work.

## Why is this needed

Fixes: #93 

## How Has This Been Tested?

Added container test to CI.