### PR TITLE
Add arm platforms as part of docker image release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         lfs: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        version: "v0.4.1"
     - name: Login to quay.io
       uses: docker/login-action@v1
       if: ${{ startsWith(github.ref, 'refs/heads/master') }}
@@ -61,4 +65,4 @@ jobs:
         cache-from: type=registry,ref=quay.io/tinkerbell/boots:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
         tags: ${{ steps.docker-image-tag.outputs.tags }}
-        platforms: linux/386,linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64


### PR DESCRIPTION
This PR adds linux/arm/v6,linux/arm/v7,linux/arm64 platform as target for Docker
Images.
