### PR TITLE
Update golangci lint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: go vet
       run: go vet ./...
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
         version: v1.30
         args: -v -D errcheck

--- a/shell.nix
+++ b/shell.nix
@@ -9,24 +9,7 @@ in { pkgs ? import (_pkgs.fetchFromGitHub {
 
 with pkgs;
 
-let
-
-  mockgen = buildGoModule rec {
-    pname = "mock";
-    version = "1.4.3";
-
-    doCheck = false;
-    src = fetchFromGitHub {
-      owner = "golang";
-      repo = pname;
-      rev = "v${version}";
-      sha256 = "1p37xnja1dgq5ykx24n7wincwz2gahjh71b95p8vpw7ss2g8j8wx";
-    };
-    vendorSha256 = "1kpiij3pimwv3gn28rbrdvlw9q5c76lzw6zpa12q6pgck76acdw4";
-    subPackages = [ "mockgen" ];
-  };
-
-in mkShell {
+mkShell {
   buildInputs = [
     gcc
     git-lfs

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs";
-  #branch@date: nixpkgs@2020-02-01
-  rev = "e3a9318b6fdb2b022c0bda66d399e1e481b24b5c";
-  sha256 = "1hlblna9j0afvcm20p15f5is7cmwl96mc4vavc99ydc4yc9df62a";
+  #branch@date: nixpkgs@2020-10-25
+  rev = "1920b371c870f4e939e1e73ee83db9d8b6e0b217";
+  sha256 = "0riyyxvygc7dbz2jh1n0gss1x03m0wh7dwqldczisx15hws3w3nm";
 }) { } }:
 
 with pkgs;
@@ -15,13 +15,14 @@ let
     pname = "mock";
     version = "1.4.3";
 
+    doCheck = false;
     src = fetchFromGitHub {
       owner = "golang";
       repo = pname;
       rev = "v${version}";
       sha256 = "1p37xnja1dgq5ykx24n7wincwz2gahjh71b95p8vpw7ss2g8j8wx";
     };
-    modSha256 = "0nfbh1sb4zh32xpfg25mbfnd4xflks95ram1m1rfdqbdwx2yc5jl";
+    vendorSha256 = "1kpiij3pimwv3gn28rbrdvlw9q5c76lzw6zpa12q6pgck76acdw4";
     subPackages = [ "mockgen" ];
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
 let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
-  repo = "nixpkgs-channels";
-  #branch@date: nixpkgs-unstable@2020-02-01
+  repo = "nixpkgs";
+  #branch@date: nixpkgs@2020-02-01
   rev = "e3a9318b6fdb2b022c0bda66d399e1e481b24b5c";
   sha256 = "1hlblna9j0afvcm20p15f5is7cmwl96mc4vavc99ydc4yc9df62a";
 }) { } }:


### PR DESCRIPTION
## Description

Hopefully this fixes golangci-lint action spamming CI with unrelated errors. This is both noisy in the stderr output and also ends up failing the action itself. For example:

https://github.com/tinkerbell/boots/runs/1344481754?check_suite_focus=true#step:6:64

> Error: /bin/tar: ../../../go/pkg/mod/github.com/andreyvit/diff@v0.0.0-20170406064948-c7f18ee00883/doc.go: Cannot open: File exists