### PR TITLE
Eng 8624 os field mismatch

### DIFF
--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -65,11 +65,13 @@ func TestSetPXEFilename(t *testing.T) {
 				State:    packet.HardwareState(tt.hState),
 				PlanSlug: "baremetal_" + tt.plan,
 			},
-			instance: &packet.Instance{
-				ID:       tt.id,
-				State:    packet.InstanceState(tt.iState),
-				AllowPXE: tt.allowPXE,
-				OS: packet.OperatingSystem{
+			instance: &packet.InstanceCacher{
+				InstanceCommon: &packet.InstanceCommon{
+					ID:       tt.id,
+					State:    packet.InstanceState(tt.iState),
+					AllowPXE: tt.allowPXE,
+				},
+				OS: &packet.OperatingSystem{
 					OsSlug: tt.slug,
 				},
 			},
@@ -102,9 +104,11 @@ func TestAllowPXE(t *testing.T) {
 			hardware: packet.HardwareCacher{
 				AllowPXE: tt.hw,
 			},
-			instance: &packet.Instance{
-				ID:       tt.iid,
-				AllowPXE: tt.instance,
+			instance: &packet.InstanceCacher{
+				InstanceCommon: &packet.InstanceCommon{
+					ID:       tt.iid,
+					AllowPXE: tt.instance,
+				},
 			},
 		}
 		got := j.isPXEAllowed()

--- a/job/events_test.go
+++ b/job/events_test.go
@@ -49,9 +49,11 @@ func TestPhoneHome(t *testing.T) {
 				ID:    "$hardware_id",
 				State: packet.HardwareState(test.state),
 			},
-			instance: &packet.Instance{
-				ID: test.id,
-				OS: packet.OperatingSystem{
+			instance: &packet.InstanceCacher{
+				InstanceCommon: &packet.InstanceCommon{
+					ID: test.id,
+				},
+				OS: &packet.OperatingSystem{
 					OsSlug: test.os,
 				},
 			},

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -54,7 +54,7 @@ func (j Job) PArch() string {
 
 func (j Job) InstanceID() string {
 	if i := j.instance; i != nil {
-		return i.ID
+		return i.Common().ID
 	}
 	return ""
 }
@@ -62,7 +62,7 @@ func (j Job) InstanceID() string {
 // UserData returns instance.UserData
 func (j Job) UserData() string {
 	if i := j.instance; i != nil {
-		return i.UserData
+		return i.Common().UserData
 	}
 	return ""
 }
@@ -70,31 +70,31 @@ func (j Job) UserData() string {
 // IPXEScriptURL returns the value of instance.IPXEScriptURL
 func (j Job) IPXEScriptURL() string {
 	if i := j.instance; i != nil {
-		return i.IPXEScriptURL
+		return i.Common().IPXEScriptURL
 	}
 	return ""
 }
 
 func (j Job) InstanceIPs() []packet.IP {
 	if i := j.instance; i != nil {
-		return i.IPs
+		return i.Common().IPs
 	}
 	return nil
 }
 
 func (j Job) CryptedPassword() string {
 	if j.instance != nil {
-		return j.instance.CryptedRootPassword
+		return j.instance.Common().CryptedRootPassword
 	}
 	return ""
 }
 
 func (j Job) OperatingSystem() *packet.OperatingSystem {
 	if i := j.instance; i != nil {
-		if i.Rescue {
+		if i.Common().Rescue {
 			return rescueOS
 		}
-		return &i.OS
+		return i.OperatingSystem()
 	}
 	return nil
 }
@@ -175,7 +175,7 @@ func (j Job) HardwareState() string {
 // OSIEVersion returns any non-standard osie versions specified in either the instance proper or in userdata or attached to underlying hardware
 func (j Job) OSIEVersion() string {
 	if i := j.instance; i != nil {
-		ov := i.ServicesVersion().OSIE
+		ov := i.Common().ServicesVersion().OSIE
 		if ov != "" {
 			return ov
 		}

--- a/job/ipxe.go
+++ b/job/ipxe.go
@@ -74,11 +74,11 @@ func auto(j Job, s *ipxe.Script) {
 		shell(j, s)
 		return
 	}
-	if f, ok := bySlug[j.instance.OS.Slug]; ok {
+	if f, ok := bySlug[j.instance.OperatingSystem().Slug]; ok {
 		f(j, s)
 		return
 	}
-	if f, ok := byDistro[j.instance.OS.Distro]; ok {
+	if f, ok := byDistro[j.instance.OperatingSystem().Distro]; ok {
 		f(j, s)
 		return
 	}
@@ -86,7 +86,7 @@ func auto(j Job, s *ipxe.Script) {
 		defaultInstaller(j, s)
 		return
 	}
-	j.With("slug", j.instance.OS.Slug, "distro", j.instance.OS.Distro).Error(errors.New("unsupported slug/distro"))
+	j.With("slug", j.instance.OperatingSystem().Slug, "distro", j.instance.OperatingSystem().Distro).Error(errors.New("unsupported slug/distro"))
 	shell(j, s)
 }
 

--- a/job/job.go
+++ b/job/job.go
@@ -33,7 +33,7 @@ type Job struct {
 	dhcp dhcp.Config
 
 	hardware packet.Hardware
-	instance *packet.Instance
+	instance packet.Instance
 }
 
 // hasActiveWorkflow fetches workflows for a given hwID and returns
@@ -148,7 +148,12 @@ func (j *Job) setup(d packet.Discovery) error {
 	// (kdeng3849) how can we remove this?
 	j.instance = d.Instance()
 	if j.instance == nil {
-		j.instance = &packet.Instance{}
+		switch d.(type) {
+		case *packet.DiscoveryCacher:
+			j.instance = &packet.InstanceCacher{}
+		case *packet.DiscoveryTinkerbellV1:
+			j.instance = &packet.InstanceTinkerbell{}
+		}
 	} else {
 		j.Logger = j.Logger.With("instance.id", j.InstanceID())
 	}

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -83,7 +83,7 @@ func TestSetupManagement(t *testing.T) {
 	var d packet.Discovery = &packet.DiscoveryCacher{
 		HardwareCacher: &packet.HardwareCacher{
 			Name:     "TestSetupManagement",
-			Instance: &packet.Instance{},
+			Instance: &packet.InstanceCacher{},
 			PlanSlug: "f1.fake.x86",
 			NetworkPorts: []packet.Port{
 				packet.Port{
@@ -159,8 +159,8 @@ func TestSetupInstance(t *testing.T) {
 	if !netConfig.Gateway.Equal(j.dhcp.Gateway()) {
 		t.Fatalf("incorrect Gateway, want: %v, got: %v", netConfig.Gateway, j.dhcp.Gateway())
 	}
-	if d.Instance().Hostname != j.dhcp.Hostname() {
-		t.Fatalf("incorrect Hostname, want: %v, got: %v", d.Instance().Hostname, j.dhcp.Hostname())
+	if d.Instance().Common().Hostname != j.dhcp.Hostname() {
+		t.Fatalf("incorrect Hostname, want: %v, got: %v", d.Instance().Common().Hostname, j.dhcp.Hostname())
 	}
 }
 

--- a/job/mock.go
+++ b/job/mock.go
@@ -49,8 +49,10 @@ func NewMock(t zaptest.TestingT, slug, facility string) Mock {
 			UEFI:            uefi,
 			ServicesVersion: servicesVersion,
 		},
-		instance: &packet.Instance{
-			State: "provisioning",
+		instance: &packet.InstanceCacher{
+			InstanceCommon: &packet.InstanceCommon{
+				State: "provisioning",
+			},
 		},
 	}
 }
@@ -75,7 +77,7 @@ func (m *Mock) SetIP(ip net.IP) {
 }
 
 func (m *Mock) SetIPXEScriptURL(url string) {
-	m.instance.IPXEScriptURL = url
+	m.instance.Common().IPXEScriptURL = url
 }
 
 func (m *Mock) SetMAC(mac string) {
@@ -93,20 +95,20 @@ func (m *Mock) SetManufacturer(slug string) {
 }
 
 func (m *Mock) SetOSDistro(distro string) {
-	m.instance.OS.Distro = distro
+	m.instance.OperatingSystem().Distro = distro
 }
 
 func (m *Mock) SetOSSlug(slug string) {
-	m.instance.OS.Slug = slug
-	m.instance.OS.OsSlug = slug
+	m.instance.OperatingSystem().Slug = slug
+	m.instance.OperatingSystem().OsSlug = slug
 }
 
 func (m *Mock) SetOSVersion(version string) {
-	m.instance.OS.Version = version
+	m.instance.OperatingSystem().Version = version
 }
 
 func (m *Mock) SetPassword(password string) {
-	m.instance.CryptedRootPassword = "insecure"
+	m.instance.Common().CryptedRootPassword = "insecure"
 }
 
 func (m *Mock) SetState(state string) {
@@ -182,25 +184,27 @@ func MakeHardwareWithInstance() (*packet.DiscoveryCacher, []packet.MACAddr, stri
 					},
 				},
 			},
-			Instance: &packet.Instance{
-				ID:       instanceId,
-				Hostname: "TestSetupInstanceHostname",
-				IPs: []packet.IP{
-					packet.IP{
-						Address:    net.ParseIP("192.168.100.2"),
-						Gateway:    net.ParseIP("192.168.100.1"),
-						Netmask:    net.ParseIP("192.168.100.255"),
-						Family:     4,
-						Management: true,
-						Public:     true,
-					},
-					packet.IP{
-						Address:    net.ParseIP("192.168.200.2"),
-						Gateway:    net.ParseIP("192.168.200.1"),
-						Netmask:    net.ParseIP("192.168.200.255"),
-						Family:     4,
-						Management: true,
-						Public:     false,
+			Instance: &packet.InstanceCacher{
+				InstanceCommon: &packet.InstanceCommon{
+					ID:       instanceId,
+					Hostname: "TestSetupInstanceHostname",
+					IPs: []packet.IP{
+						packet.IP{
+							Address:    net.ParseIP("192.168.100.2"),
+							Gateway:    net.ParseIP("192.168.100.1"),
+							Netmask:    net.ParseIP("192.168.100.255"),
+							Family:     4,
+							Management: true,
+							Public:     true,
+						},
+						packet.IP{
+							Address:    net.ParseIP("192.168.200.2"),
+							Gateway:    net.ParseIP("192.168.200.1"),
+							Netmask:    net.ParseIP("192.168.200.255"),
+							Family:     4,
+							Management: true,
+							Public:     false,
+						},
 					},
 				},
 			},

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -216,7 +216,7 @@ func (c *Client) GetInstanceIDFromIP(dip net.IP) (string, error) {
 	if d.Instance() == nil {
 		return "", nil
 	}
-	return d.Instance().ID, nil
+	return d.Instance().Common().ID, nil
 }
 
 // PostHardwareComponent - POSTs a HardwareComponent to the API

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -240,8 +240,8 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
 			if d.Instance() != nil {
 				t.Logf("instance: %v", d.Instance())
-				t.Logf("instance id: %s", d.Instance().ID)
-				t.Logf("instance state: %s", d.Instance().State)
+				t.Logf("instance id: %s", d.Instance().Common().ID)
+				t.Logf("instance state: %s", d.Instance().Common().State)
 			}
 			t.Logf("metadata custom: %v", d.Metadata.Custom)
 			t.Logf("metadata facility: %v", d.Metadata.Facility)
@@ -1700,9 +1700,11 @@ func TestServicesVersion(t *testing.T) {
 		{desc: "SV over userdata", SV: ServicesVersion{OSIE: "SV over osie"}, userdata: `#services={"osie":"userdata osie"}`, osie: "SV over osie"},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			i := Instance{
-				servicesVersion: test.SV,
-				UserData:        test.userdata,
+			i := InstanceCacher{
+				InstanceCommon: &InstanceCommon{
+					servicesVersion: test.SV,
+					UserData:        test.userdata,
+				},
 			}
 			got := i.ServicesVersion().OSIE
 			if got != test.osie {

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -277,6 +277,58 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 	}
 }
 
+func TestInstanceCacher(t *testing.T) {
+	for name, test := range cacherTests {
+		t.Run(name, func(t *testing.T) {
+			d := &DiscoveryCacher{}
+
+			if err := json.Unmarshal([]byte(test.json), &d); err != nil {
+				t.Fatal(test.mode, err)
+			}
+
+			if d.Instance() != nil {
+				t.Logf("instance: %v", d.Instance())
+				t.Logf("instance id: %s", d.Instance().Common().ID)
+				t.Logf("instance state: %s", d.Instance().Common().State)
+				t.Logf("instance operating system slug: %s", d.Instance().OperatingSystem().Slug)
+
+				d.Instance().OperatingSystem().Slug = "test" // test setting a field
+
+				if d.Instance().OperatingSystem().Slug != "test" {
+					t.Fatal("operating system slug should have been set to 'test'")
+				}
+			}
+
+		})
+	}
+}
+
+func TestInstanceTinkerbell(t *testing.T) {
+	for name, test := range tinkerbellTests {
+		t.Run(name, func(t *testing.T) {
+			d := &DiscoveryTinkerbellV1{}
+
+			if err := json.Unmarshal([]byte(test.json), &d); err != nil {
+				t.Fatal(test.mode, err)
+			}
+
+			if d.Instance() != nil { // instead of just logging, actually check for id, etc.
+				t.Logf("instance: %v", d.Instance())
+				t.Logf("instance id: %s", d.Instance().Common().ID)
+				//t.Logf("instance state: %s", d.Instance().Common().State)
+				t.Logf("instance operating system slug: %s", d.Instance().OperatingSystem().Slug)
+
+				d.Instance().OperatingSystem().Slug = "test" // test setting a field
+
+				if d.Instance().OperatingSystem().Slug != "test" {
+					t.Fatal("operating system slug should have been set to 'test'")
+				}
+			}
+
+		})
+	}
+}
+
 var tinkerbellTests = map[string]struct {
 	id            string
 	mac           string
@@ -576,6 +628,7 @@ const (
       "plan_version_slug": ""
     },
     "instance": {
+      "id": "331d355a-1925-4ecf-ab6b-75990733c50c",
       "crypted_root_password": "redacted",
       "operating_system_version": {
         "distro": "ubuntu",

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -44,8 +44,11 @@ func (d DiscoveryTinkerbellV1) DnsServers(mac net.HardwareAddr) []net.IP {
 	return conf.ParseIPv4s(strings.Join(dnsServers, ","))
 }
 
-func (d DiscoveryTinkerbellV1) Instance() *Instance {
-	return d.Metadata.Instance
+func (d DiscoveryTinkerbellV1) Instance() (i Instance) {
+	if d.Metadata.Instance != nil {
+		i = d.Metadata.Instance
+	}
+	return
 }
 
 func (d DiscoveryTinkerbellV1) MAC() net.HardwareAddr {
@@ -99,10 +102,10 @@ func (d DiscoveryTinkerbellV1) Hostname() (string, error) {
 	if d.Instance() == nil {
 		return "", nil
 	}
-	return d.Instance().Hostname, nil
+	return d.Instance().Common().Hostname, nil
 }
 
-func (d DiscoveryTinkerbellV1) SetMAC(mac net.HardwareAddr) {
+func (d *DiscoveryTinkerbellV1) SetMAC(mac net.HardwareAddr) {
 	d.mac = mac
 }
 


### PR DESCRIPTION
Signed-off-by: Kelly Deng <kelly@packet.com>

## Description

<!--- Please describe what this PR is going to change -->
This PR fixes the mismatch in field names [`operating_system_version`](https://github.com/tinkerbell/tink/blob/master/protos/packet/packet.proto#L86) vs [`operating_system`](https://github.com/tinkerbell/hegel/blob/a3138d417536903dcdedd674d634e13ebc19fc79/http_handlers.go#L33).

## Why is this needed
This bug mainly affects the users who needs both the `packet.pb.go` and the EC2 endpoint. Because the EC2 endpoint in Hegel uses the field name `operating_system` to be backwards compatible with Kant, users using the `Metadata` object defined in `packet.pb.go` will face a problem with parsing the operating system field since it was defined as `operating_system_version` there. 
A user could have worked around this by specifying two fields `operating_system` and `operating_system_version` with the same value, inside the same piece of hardware, but this introduces some redundancy and just isn't ideal.

<!--- Link to issue you have raised -->

Related PR: https://github.com/tinkerbell/tink/pull/275

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
