### PR TITLE
packet: Move the Discover* structs to respective models_* file

### DIFF
--- a/packet/models.go
+++ b/packet/models.go
@@ -33,18 +33,6 @@ type Discovery interface {
 	SetMAC(mac net.HardwareAddr)
 }
 
-// DiscoveryCacher presents the structure for old data model
-type DiscoveryCacher struct {
-	*HardwareCacher
-	mac net.HardwareAddr
-}
-
-// DiscoveryTinkerbellV1 presents the structure for tinkerbell's new data model, version 1
-type DiscoveryTinkerbellV1 struct {
-	*HardwareTinkerbellV1
-	mac net.HardwareAddr
-}
-
 // Interface is the base for cacher and tinkerbell hardware (network) interface
 type Interface interface {
 }

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -10,6 +10,12 @@ import (
 
 // models_cacher.go contains the interface methods specific to DiscoveryCacher and HardwareCacher structs
 
+// DiscoveryCacher presents the structure for old data model
+type DiscoveryCacher struct {
+	*HardwareCacher
+	mac net.HardwareAddr
+}
+
 // HardwareCacher represents the old hardware data model for backward compatibility
 type HardwareCacher struct {
 	ID    string        `json:"id"`

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -11,6 +11,12 @@ import (
 
 // models_tinkerbell.go contains the interface methods specific to DiscoveryTinkerbell and HardwareTinkerbell structs
 
+// DiscoveryTinkerbellV1 presents the structure for tinkerbell's new data model, version 1
+type DiscoveryTinkerbellV1 struct {
+	*HardwareTinkerbellV1
+	mac net.HardwareAddr
+}
+
 // HardwareTinkerbellV1 represents the new hardware data model for tinkerbell, version 1
 type HardwareTinkerbellV1 struct {
 	ID       string   `json:"id"`


### PR DESCRIPTION
## Description

I missed this in the last PR that moved things around.