### PR TITLE
add 'operating_system' field into Instance for tinkerbell mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	google.golang.org/genproto v0.0.0-20200921165018-b9da36f5f452 // indirect
 	google.golang.org/grpc v1.32.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gotest.tools v2.2.0+incompatible
 )
 
 replace github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35 => github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -15,7 +15,13 @@ func IsSpecialOS(i *packet.Instance) bool {
 	if i == nil {
 		return false
 	}
-	slug := i.OS.Slug
+	var slug string
+	if i.OSV.Slug != "" {
+		slug = i.OSV.Slug
+	}
+	if i.OS.Slug != "" {
+		slug = i.OS.Slug
+	}
 	return slug == "custom_ipxe" || slug == "custom" || strings.HasPrefix(slug, "vmware") || strings.HasPrefix(slug, "nixos")
 }
 
@@ -91,9 +97,9 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {
 
 		// ignore custom_ipxe because we always do dhcp for it and we'll want to do /nonexistent filename so
 		// nics don't timeout.... but why though?
-		if !j.isPXEAllowed() && j.instance.OS.OsSlug != "custom_ipxe" {
+		if !j.isPXEAllowed() && j.hardware.OperatingSystem().OsSlug != "custom_ipxe" {
 			err := errors.New("device should NOT be trying to PXE boot")
-			j.With("hardware.state", j.HardwareState(), "allow_pxe", j.isPXEAllowed(), "os", j.instance.OS.OsSlug).Info(err)
+			j.With("hardware.state", j.HardwareState(), "allow_pxe", j.isPXEAllowed(), "os", j.hardware.OperatingSystem().OsSlug).Info(err)
 			return
 		}
 		// custom_ipxe or rescue

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -58,21 +58,23 @@ func TestSetPXEFilename(t *testing.T) {
 			tt.plan = "0"
 		}
 
+		instance := &packet.Instance{
+			ID:       tt.id,
+			State:    packet.InstanceState(tt.iState),
+			AllowPXE: tt.allowPXE,
+			OSV: &packet.OperatingSystem{
+				OsSlug: tt.slug,
+			},
+		}
 		j := Job{
-			Logger: joblog.With("index", i, "hStahe", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
-			hardware: packet.HardwareCacher{
+			Logger: joblog.With("index", i, "hState", tt.hState, "id", tt.id, "iState", tt.iState, "slug", tt.slug, "plan", tt.plan, "allowPXE", tt.allowPXE, "packet", tt.packet, "arm", tt.arm, "uefi", tt.uefi, "filename", tt.filename),
+			hardware: &packet.HardwareCacher{
 				ID:       "$hardware_id",
 				State:    packet.HardwareState(tt.hState),
 				PlanSlug: "baremetal_" + tt.plan,
+				Instance: instance,
 			},
-			instance: &packet.Instance{
-				ID:       tt.id,
-				State:    packet.InstanceState(tt.iState),
-				AllowPXE: tt.allowPXE,
-				OS: packet.OperatingSystem{
-					OsSlug: tt.slug,
-				},
-			},
+			instance: instance,
 		}
 		rep := dhcp4.NewPacket(42)
 		j.setPXEFilename(&rep, tt.packet, tt.arm, tt.uefi)
@@ -99,7 +101,7 @@ func TestAllowPXE(t *testing.T) {
 		t.Logf("want=%t, hardware=%t, instance=%t, instance_id=%s",
 			tt.want, tt.hw, tt.instance, tt.iid)
 		j := Job{
-			hardware: packet.HardwareCacher{
+			hardware: &packet.HardwareCacher{
 				AllowPXE: tt.hw,
 			},
 			instance: &packet.Instance{

--- a/job/events.go
+++ b/job/events.go
@@ -85,7 +85,7 @@ func (j Job) phoneHome(body []byte) bool {
 		post = p.postInstance
 		if p.kind() == "provisioning.104.01" {
 			disablePXE = true
-			if j.instance.OS.OsSlug == "custom_ipxe" {
+			if j.hardware.OperatingSystem().OsSlug == "custom_ipxe" {
 				defer j.CustomPXEDone()
 			}
 		}

--- a/job/events_test.go
+++ b/job/events_test.go
@@ -42,19 +42,22 @@ func TestPhoneHome(t *testing.T) {
 		fmt.Println("test:", name)
 		t.Log("test:", name)
 		reqs = nil
+
+		instance := &packet.Instance{
+			ID: test.id,
+			OSV: &packet.OperatingSystem{
+				OsSlug: test.os,
+			},
+		}
 		j := Job{
 			Logger: joblog.With("test", name),
 			mode:   modeInstance,
-			hardware: packet.HardwareCacher{
-				ID:    "$hardware_id",
-				State: packet.HardwareState(test.state),
+			hardware: &packet.HardwareCacher{
+				ID:       "$hardware_id",
+				State:    packet.HardwareState(test.state),
+				Instance: instance,
 			},
-			instance: &packet.Instance{
-				ID: test.id,
-				OS: packet.OperatingSystem{
-					OsSlug: test.os,
-				},
-			},
+			instance: instance,
 		}
 		bad := !j.phoneHome([]byte(test.event))
 		if bad != test.bad {

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -94,7 +94,7 @@ func (j Job) OperatingSystem() *packet.OperatingSystem {
 		if i.Rescue {
 			return rescueOS
 		}
-		return &i.OS
+		return j.hardware.OperatingSystem()
 	}
 	return nil
 }

--- a/job/ipxe.go
+++ b/job/ipxe.go
@@ -74,11 +74,11 @@ func auto(j Job, s *ipxe.Script) {
 		shell(j, s)
 		return
 	}
-	if f, ok := bySlug[j.instance.OS.Slug]; ok {
+	if f, ok := bySlug[j.hardware.OperatingSystem().Slug]; ok {
 		f(j, s)
 		return
 	}
-	if f, ok := byDistro[j.instance.OS.Distro]; ok {
+	if f, ok := byDistro[j.hardware.OperatingSystem().Distro]; ok {
 		f(j, s)
 		return
 	}
@@ -86,7 +86,7 @@ func auto(j Job, s *ipxe.Script) {
 		defaultInstaller(j, s)
 		return
 	}
-	j.With("slug", j.instance.OS.Slug, "distro", j.instance.OS.Distro).Error(errors.New("unsupported slug/distro"))
+	j.With("slug", j.hardware.OperatingSystem().Slug, "distro", j.hardware.OperatingSystem().Distro).Error(errors.New("unsupported slug/distro"))
 	shell(j, s)
 }
 

--- a/job/mock.go
+++ b/job/mock.go
@@ -93,16 +93,16 @@ func (m *Mock) SetManufacturer(slug string) {
 }
 
 func (m *Mock) SetOSDistro(distro string) {
-	m.instance.OS.Distro = distro
+	m.hardware.OperatingSystem().Distro = distro
 }
 
 func (m *Mock) SetOSSlug(slug string) {
-	m.instance.OS.Slug = slug
-	m.instance.OS.OsSlug = slug
+	m.hardware.OperatingSystem().Slug = slug
+	m.hardware.OperatingSystem().OsSlug = slug
 }
 
 func (m *Mock) SetOSVersion(version string) {
-	m.instance.OS.Version = version
+	m.hardware.OperatingSystem().Version = version
 }
 
 func (m *Mock) SetPassword(password string) {

--- a/packet/models.go
+++ b/packet/models.go
@@ -64,6 +64,7 @@ type Hardware interface {
 	OSIEBaseURL(mac net.HardwareAddr) string
 	KernelPath(mac net.HardwareAddr) string
 	InitrdPath(mac net.HardwareAddr) string
+	OperatingSystem() *OperatingSystem
 }
 
 // NewDiscovery instantiates a Discovery struct from the json argument
@@ -101,11 +102,12 @@ type Instance struct {
 	AllowPXE bool          `json:"allow_pxe"`
 	Rescue   bool          `json:"rescue"`
 
-	OS              OperatingSystem `json:"operating_system_version"`
-	AlwaysPXE       bool            `json:"always_pxe,omitempty"`
-	IPXEScriptURL   string          `json:"ipxe_script_url,omitempty"`
-	IPs             []IP            `json:"ip_addresses"`
-	UserData        string          `json:"userdata,omitempty"`
+	OS              *OperatingSystem `json:"operating_system"`
+	OSV             *OperatingSystem `json:"operating_system_version"`
+	AlwaysPXE       bool             `json:"always_pxe,omitempty"`
+	IPXEScriptURL   string           `json:"ipxe_script_url,omitempty"`
+	IPs             []IP             `json:"ip_addresses"`
+	UserData        string           `json:"userdata,omitempty"`
 	servicesVersion ServicesVersion
 
 	// Only returned in the first 24 hours

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -342,3 +342,18 @@ func (h HardwareCacher) KernelPath(mac net.HardwareAddr) string {
 func (h HardwareCacher) InitrdPath(mac net.HardwareAddr) string {
 	return ""
 }
+
+func (h *HardwareCacher) OperatingSystem() *OperatingSystem {
+	i := h.instance()
+	if i.OSV == (*OperatingSystem)(nil) {
+		i.OSV = &OperatingSystem{}
+	}
+	return i.OSV
+}
+
+func (h *HardwareCacher) instance() *Instance {
+	if h.Instance == nil {
+		h.Instance = &Instance{}
+	}
+	return h.Instance
+}

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -188,3 +188,18 @@ func (h HardwareTinkerbellV1) KernelPath(mac net.HardwareAddr) string {
 func (h HardwareTinkerbellV1) InitrdPath(mac net.HardwareAddr) string {
 	return h.Network.InterfaceByMac(mac).Netboot.OSIE.Initrd
 }
+
+func (h *HardwareTinkerbellV1) OperatingSystem() *OperatingSystem {
+	i := h.instance()
+	if i.OS == nil {
+		i.OS = &OperatingSystem{}
+	}
+	return i.OS
+}
+
+func (h *HardwareTinkerbellV1) instance() *Instance {
+	if h.Metadata.Instance == nil {
+		h.Metadata.Instance = &Instance{}
+	}
+	return h.Metadata.Instance
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This PR fixes the mismatch in field names [`operating_system_version`](https://github.com/tinkerbell/tink/blob/master/protos/packet/packet.proto#L86) vs [`operating_system`](https://github.com/tinkerbell/hegel/blob/a3138d417536903dcdedd674d634e13ebc19fc79/http_handlers.go#L33).

v2 of https://github.com/tinkerbell/boots/pull/104

## Why is this needed
This bug mainly affects the users who needs both the `packet.pb.go` and the EC2 endpoint. Because the EC2 endpoint in Hegel uses the field name `operating_system` to be backwards compatible with Kant, users using the `Metadata` object defined in `packet.pb.go` will face a problem with parsing the operating system field since it was defined as `operating_system_version` there. 
The reason for the mismatch is because in the "old" cacher mode, `operating_system_version`, but Kant uses `operating_system` (which we have to be backwards compatible with) so we decided move away from `operating_system_version` and go with `operating_system` for "tink mode".
A user could have worked around this by specifying two fields `operating_system` and `operating_system_version` with the same value, inside the same piece of hardware, but this introduces some redundancy and just isn't ideal.

<!--- Link to issue you have raised -->

Related PR: https://github.com/tinkerbell/tink/pull/275


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
