### PR TITLE
Docker image does not contain the right binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,18 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: "v0.4.1"
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.15.5"
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
       - name: go vet
@@ -35,24 +41,12 @@ jobs:
         run: go test -coverprofile=coverage.txt ./...
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
-  docker-images:
-    runs-on: ubuntu-latest
-    needs: [validation]
-    steps:
+      - name: compile binaries
+        run: nix-shell --run 'make crosscompile'
       - name: Docker Image Tag for Sha
         id: docker-image-tag
         run: |
           echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: "v0.4.1"
       - name: Login to quay.io
         uses: docker/login-action@v1
         if: ${{ startsWith(github.ref, 'refs/heads/master') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
-FROM nixos/nix:2.3.6
-
-COPY . /usr/myapp
-WORKDIR /usr/myapp
-
-RUN nix-shell --run 'make boots'
-
 FROM alpine:3.11
-
 ENTRYPOINT ["/usr/bin/boots"]
-# ENV GIN_MODE release
 EXPOSE 67 69 80
-
 RUN apk add --update --upgrade --no-cache ca-certificates socat
-COPY --from=0 /usr/myapp/boots /usr/bin/boots
+COPY . /usr/myapp
+RUN cp /usr/myapp/boots-linux-$(uname -m) /usr/bin/boots
+RUN rm -fr /usr/myapp

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,18 @@ MAKEFLAGS += --no-builtin-rules
 binary := boots
 all: ${binary}
 
+crosscompile: $(shell git ls-files | grep -v -e vendor -e '_test.go' | grep '.go$$' )
+	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -v -o ./boots-linux-x86_64 -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./boots-linux-amd64 -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -v -o ./boots-linux-aarch64 -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -v -o ./boots-linux-armv7l -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v -o ./boots-linux-arm64 -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+
+
 # this is quick and its really only for rebuilding when dev'ing, I wish go would
 # output deps in make syntax like gcc does... oh well this is good enough
 ${binary}: $(shell git ls-files | grep -v -e vendor -e '_test.go' | grep '.go$$' )
-	CGO_ENABLED=0 GOOS=$$GOOS go build -v -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
+	CGO_ENABLED=0 go build -v -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)"
 
 ifeq ($(origin GOBIN), undefined)
 GOBIN := ${PWD}/bin

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs";
-  #branch@date: nixpkgs@2020-10-25
-  rev = "1920b371c870f4e939e1e73ee83db9d8b6e0b217";
-  sha256 = "0riyyxvygc7dbz2jh1n0gss1x03m0wh7dwqldczisx15hws3w3nm";
+  #branch@date: nixpkgs@2020-11-24
+  rev = "6625284c397b44bc9518a5a1567c1b5aae455c08";
+  sha256 = "1w0czzv53sg35gp7sr506facbmzd33jm34p6cg23fb9kz5rf5c89";
 }) { } }:
 
 with pkgs;


### PR DESCRIPTION
## Description

The docker images we built are multi-arch, but for some reason the boots binary inside is x86 for all of them.

## Why is this needed

We need the right binary with the right architecture 

## How Has This Been Tested?

Not tested yet but it will be locally.

## How are existing users impacted? What migration steps/scripts do we need?

The user is currently impacted because Docker images and binaries released as part of sandbox only works for x86.
