### PR TITLE
Added link back to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Build Status](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/boots/actions?query=workflow%3A%22For+each+commit+and+PR%22+branch%3Amain)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
-This services handles DHCP, PXE, tftp, and iPXE for provisions.
+This service handles DHCP, PXE, tftp, and iPXE for provisions in the Tinkerbell project.
+For more information about the Tinkerbell project, see: [tinkerbell.org](https://tinkerbell.org).
 
 This repository is [Experimental](https://github.com/packethost/standards/blob/main/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style!
 This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.


### PR DESCRIPTION
We're linking to the GH repos directly in various marketing content, so we need to direct users back to the main site.

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
