### PR TITLE
Replace Drone badge with GitHub Action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boots
 
-[![Build Status](https://cloud.drone.io/api/badges/tinkerbell/boots/status.svg)](https://cloud.drone.io/tinkerbell/boots)
+[![Build Status](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This services handles DHCP, PXE, tftp, and iPXE for provisions.


### PR DESCRIPTION
Change build status badge in README from Drone to GitHub Actions

## Why is this needed

We don't use Drone any more.