### PR TITLE
Link to action runs, not the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boots
 
-[![Build Status](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)
+[![Build Status](https://github.com/tinkerbell/boots/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/boots/actions?query=workflow%3A%22For+each+commit+and+PR%22+branch%3Amaster)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This services handles DHCP, PXE, tftp, and iPXE for provisions.


### PR DESCRIPTION
No need to link to the badge itself, it is already being displayed.
Instead it makes more sense to see all the actual builds.