### PR TITLE
hasActiveWorkflow should consider workflows in state PENDING and RUNNING

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -41,7 +41,7 @@ type Job struct {
 // hwID is the hardware/worker ID corresponding to the MAC
 func hasActiveWorkflow(wcl *tw.WorkflowContextList) (bool, error) {
 	for _, wf := range (*wcl).WorkflowContexts {
-		if wf.CurrentActionState == tw.State_STATE_PENDING {
+		if wf.CurrentActionState == tw.State_STATE_PENDING || wf.CurrentActionState == tw.State_STATE_RUNNING {
 			joblog.With("workflowID", wf.WorkflowId).Info("found active workflow for hardware")
 			return true, nil
 		}

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -183,12 +183,23 @@ func TestHasActiveWorkflow(t *testing.T) {
 		wcl    *tw.WorkflowContextList
 		status bool
 	}{
-		{name: "test active workflow",
+		{name: "test pending workflow",
 			wcl: &tw.WorkflowContextList{
 				WorkflowContexts: []*tw.WorkflowContext{
 					&tw.WorkflowContext{
-						WorkflowId:         "active-fake-workflow-bde9-812726eff314",
+						WorkflowId:         "pending-fake-workflow-bde9-812726eff314",
 						CurrentActionState: 0,
+					},
+				},
+			},
+			status: true,
+		},
+		{name: "test running workflow",
+			wcl: &tw.WorkflowContextList{
+				WorkflowContexts: []*tw.WorkflowContext{
+					&tw.WorkflowContext{
+						WorkflowId:         "running-fake-workflow-bde9-812726eff314",
+						CurrentActionState: 1,
 					},
 				},
 			},
@@ -199,7 +210,7 @@ func TestHasActiveWorkflow(t *testing.T) {
 				WorkflowContexts: []*tw.WorkflowContext{
 					&tw.WorkflowContext{
 						WorkflowId:         "inactive-fake-workflow-bde9-812726eff314",
-						CurrentActionState: 1,
+						CurrentActionState: 4,
 					},
 				},
 			},


### PR DESCRIPTION
## Description

When checking for the status of a 'job' boots currently only considers PENDING workflows.   This change makes it consider RUNNING workflows to be 'active' as well.

## Why is this needed

During workflow execution we pass status updates back to our central API by way of boots.   As-is, the hasActiveWorkflow function will reject those status updates as it only considers 'PENDING' workflows to be active.