### PR TITLE
ipxe: Do not vendor binaries in git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-ipxe/bin/ipxe.efi filter=lfs diff=lfs merge=lfs -text
 ipxe/bin/snp-hua.efi filter=lfs diff=lfs merge=lfs -text
-ipxe/bin/snp-nolacp.efi filter=lfs diff=lfs merge=lfs -text
-ipxe/bin/undionly.kpxe filter=lfs diff=lfs merge=lfs -text
-ipxe/bindata.go filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "1.15.5"
+      - name: generate bindata.go
+        run: nix-shell --run 'make ipxe/bindata.go'
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
       - name: go vet
@@ -44,8 +46,6 @@ jobs:
         run: go test -coverprofile=coverage.txt ./...
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
-      - name: compile iPXE binaries
-        run: nix-shell --run 'make ipxe/bin/ipxe.efi ipxe/bin/snp-hua.efi ipxe/bin/snp-nolacp.efi ipxe/bin/undionly.kpxe'
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'
       - name: Docker Image Tag for Sha

--- a/ipxe/.gitignore
+++ b/ipxe/.gitignore
@@ -1,0 +1,1 @@
+bindata.go

--- a/ipxe/bin/.gitignore
+++ b/ipxe/bin/.gitignore
@@ -1,0 +1,3 @@
+ipxe.efi
+snp-nolacp.efi
+undionly.kpxe

--- a/ipxe/bin/ipxe.efi
+++ b/ipxe/bin/ipxe.efi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27ca0b1b6aacc517a9de7b5090a8fa2ed79c9504e086a035f59faeacd2939b78
-size 983680

--- a/ipxe/bin/snp-nolacp.efi
+++ b/ipxe/bin/snp-nolacp.efi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6eb236bffae2566d38a57e43d51e94187d8be36d06af52519fd5c0fb4d2531aa
-size 220384

--- a/ipxe/bin/undionly.kpxe
+++ b/ipxe/bin/undionly.kpxe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b803f3de51fe8ebf7bee38d3d888463f6e102a32f04438124f90af6f77a42a9
-size 84183

--- a/ipxe/bindata.go
+++ b/ipxe/bindata.go
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:142264cb98024abfea531a1af9eafc784f05035d6616f695126debcd86da6adb
-size 2793149


### PR DESCRIPTION
## Description

Removes the iPXE binaries we can actually build out of GitLFS.

## Why is this needed

This makes it easier for contributors to contribute since we
don't have to reproduce or over write the ixpe builds they
contribute. This does mean the project isn't `go get`able but
I guess we'll just have to live with that.

Closes #116

## How Has This Been Tested?

N/A
