### PR TITLE
Fix use of HasActiveWorkflow

### DIFF
--- a/http.go
+++ b/http.go
@@ -118,7 +118,7 @@ func serveJobFile(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
+	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
@@ -148,7 +148,7 @@ func serveHardware(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
+	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
@@ -195,7 +195,7 @@ func serveProblem(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
+	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")

--- a/http.go
+++ b/http.go
@@ -120,10 +120,13 @@ func serveJobFile(w http.ResponseWriter, req *http.Request) {
 
 	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
 	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
 		return
 	}
-
 	if !activeWorkflows {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr).Info("no active workflows")
 		return
 	}
 
@@ -147,10 +150,13 @@ func serveHardware(w http.ResponseWriter, req *http.Request) {
 
 	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
 	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
 		return
 	}
-
 	if !activeWorkflows {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr).Info("no active workflows")
 		return
 	}
 
@@ -191,10 +197,13 @@ func serveProblem(w http.ResponseWriter, req *http.Request) {
 
 	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
 	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
 		return
 	}
-
 	if !activeWorkflows {
+		w.WriteHeader(http.StatusNotFound)
+		mainlog.With("client", req.RemoteAddr).Info("no active workflows")
 		return
 	}
 

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -90,7 +90,7 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 		s.Args("registry_username=" + registryUsername)
 		s.Args("registry_password=" + registryPassword)
 		s.Args("packet_base_url=" + workflowBaseURL())
-		s.Args("worker_id=" + j.HardwareID())
+		s.Args("worker_id=" + j.HardwareID().String())
 	}
 
 	s.Args("packet_bootdev_mac=${bootdevmac}")

--- a/job/events.go
+++ b/job/events.go
@@ -94,7 +94,7 @@ func (j Job) phoneHome(body []byte) bool {
 			j.With("state", j.HardwareState()).Info("ignoring hardware phone-home when state is not preinstalling")
 			return false
 		}
-		id = j.hardware.HardwareID()
+		id = j.hardware.HardwareID().String()
 		typ = "hardware"
 		post = p.postHardware
 	}

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -124,7 +124,7 @@ func (j Job) InterfaceMAC(i int) net.HardwareAddr {
 	return nil
 }
 
-func (j Job) HardwareID() string {
+func (j Job) HardwareID() packet.HardwareID {
 	if h := j.hardware; h != nil {
 		return h.HardwareID()
 	}

--- a/job/job.go
+++ b/job/job.go
@@ -36,9 +36,8 @@ type Job struct {
 	instance *packet.Instance
 }
 
-// HasActiveWorkflow fetches workflows for a given hwID and returns
-// the status true if there is a pending (active) workflow for hwID
-// hwID is the hardware/worker ID corresponding to the MAC
+// HasActiveWorkflow fetches workflows for the given hardware and returns
+// the status true if there is a pending (active) workflow
 func HasActiveWorkflow(hwID string) (bool, error) {
 	wcl, err := client.GetWorkflowsFromTink(hwID)
 	if err != nil {

--- a/job/job.go
+++ b/job/job.go
@@ -38,7 +38,7 @@ type Job struct {
 
 // HasActiveWorkflow fetches workflows for the given hardware and returns
 // the status true if there is a pending (active) workflow
-func HasActiveWorkflow(hwID string) (bool, error) {
+func HasActiveWorkflow(hwID packet.HardwareID) (bool, error) {
 	wcl, err := client.GetWorkflowsFromTink(hwID)
 	if err != nil {
 		return false, err

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -35,7 +35,7 @@ type ComponentsResponse struct {
 }
 
 // GetWorkflowsFromTink fetches the list of workflows from tink
-func (c *Client) GetWorkflowsFromTink(hwID string) (result *tw.WorkflowContextList, err error) {
+func (c *Client) GetWorkflowsFromTink(hwID HardwareID) (result *tw.WorkflowContextList, err error) {
 	if hwID == "" {
 		return result, errors.New("missing hardware id")
 	}
@@ -45,7 +45,7 @@ func (c *Client) GetWorkflowsFromTink(hwID string) (result *tw.WorkflowContextLi
 	metrics.CacherRequestsInProgress.With(labels).Inc()
 	metrics.CacherTotal.With(labels).Inc()
 
-	result, err = c.workflowClient.GetWorkflowContextList(context.Background(), &tw.WorkflowContextRequest{WorkerId: hwID})
+	result, err = c.workflowClient.GetWorkflowContextList(context.Background(), &tw.WorkflowContextRequest{WorkerId: hwID.String()})
 
 	cacherTimer.ObserveDuration()
 	metrics.CacherRequestsInProgress.With(labels).Dec()
@@ -220,10 +220,10 @@ func (c *Client) GetInstanceIDFromIP(dip net.IP) (string, error) {
 }
 
 // PostHardwareComponent - POSTs a HardwareComponent to the API
-func (c *Client) PostHardwareComponent(hardwareID string, body io.Reader) (*ComponentsResponse, error) {
+func (c *Client) PostHardwareComponent(hardwareID HardwareID, body io.Reader) (*ComponentsResponse, error) {
 	var response ComponentsResponse
 
-	if err := c.Post("/hardware/"+hardwareID+"/components", mimeJSON, body, &response); err != nil {
+	if err := c.Post("/hardware/"+hardwareID.String()+"/components", mimeJSON, body, &response); err != nil {
 		return nil, err
 	}
 
@@ -244,11 +244,11 @@ func (c *Client) PostHardwarePhoneHome(id string) error {
 func (c *Client) PostHardwareFail(id string, body io.Reader) error {
 	return c.Post("/hardware/"+id+"/fail", mimeJSON, body, nil)
 }
-func (c *Client) PostHardwareProblem(id string, body io.Reader) (string, error) {
+func (c *Client) PostHardwareProblem(id HardwareID, body io.Reader) (string, error) {
 	var res struct {
 		ID string `json:"id"`
 	}
-	if err := c.Post("/hardware/"+id+"/problems", mimeJSON, body, &res); err != nil {
+	if err := c.Post("/hardware/"+id.String()+"/problems", mimeJSON, body, &res); err != nil {
 		return "", err
 	}
 	return res.ID, nil

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -51,7 +51,7 @@ func (c *Client) GetWorkflowsFromTink(hwID string) (result *tw.WorkflowContextLi
 	metrics.CacherRequestsInProgress.With(labels).Dec()
 
 	if err != nil {
-		return result, errors.New("error while fetching the workflow")
+		return result, errors.Wrap(err, "error while fetching the workflow")
 	}
 
 	return result, nil

--- a/packet/endpoints_test.go
+++ b/packet/endpoints_test.go
@@ -34,7 +34,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 		gResponse string
 		code      int
 		hResponse string
-		id        string
+		id        HardwareID
 	}{
 		{name: "has grpc error",
 			err: errors.New("some error"),
@@ -90,7 +90,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, d)
 			assert.IsType(t, &DiscoveryCacher{}, d)
-			assert.Equal(t, id.String(), d.Hardware().HardwareID())
+			assert.Equal(t, HardwareID(id.String()), d.Hardware().HardwareID())
 		})
 	}
 }
@@ -98,7 +98,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 func TestGetWorkflowsFromTink(t *testing.T) {
 	for _, test := range []struct {
 		name string
-		hwID string
+		hwID HardwareID
 		wcl  *tw.WorkflowContextList
 		err  error
 	}{

--- a/packet/models.go
+++ b/packet/models.go
@@ -45,6 +45,12 @@ type InterfaceTinkerbell struct {
 	*NetworkInterface
 }
 
+type HardwareID string
+
+func (hid HardwareID) String() string {
+	return string(hid)
+}
+
 // Hardware interface holds primary hardware methods
 type Hardware interface {
 	HardwareAllowPXE(mac net.HardwareAddr) bool
@@ -52,7 +58,7 @@ type Hardware interface {
 	HardwareArch(mac net.HardwareAddr) string
 	HardwareBondingMode() BondingMode
 	HardwareFacilityCode() string
-	HardwareID() string
+	HardwareID() HardwareID
 	HardwareIPs() []IP
 	Interfaces() []Port // TODO: to be updated
 	HardwareManufacturer() string

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -292,8 +292,8 @@ func (h HardwareCacher) HardwareFacilityCode() string {
 	return h.FacilityCode
 }
 
-func (h HardwareCacher) HardwareID() string {
-	return h.ID
+func (h HardwareCacher) HardwareID() HardwareID {
+	return HardwareID(h.ID)
 }
 
 func (h HardwareCacher) HardwareIPs() []IP {

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -132,8 +132,8 @@ func (h HardwareTinkerbellV1) HardwareFacilityCode() string {
 	return h.Metadata.Facility.FacilityCode
 }
 
-func (h HardwareTinkerbellV1) HardwareID() string {
-	return h.ID
+func (h HardwareTinkerbellV1) HardwareID() HardwareID {
+	return HardwareID(h.ID)
 }
 
 func (h HardwareTinkerbellV1) HardwareIPs() []IP {

--- a/tftp.go
+++ b/tftp.go
@@ -58,7 +58,7 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 		return serveFakeReader(l, filename)
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
+	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
 	if err != nil {
 		l.With("error", errors.WithMessage(err, "unable to fetch workflows")).Info()
 		return serveFakeReader(l, filename)

--- a/tftp.go
+++ b/tftp.go
@@ -55,10 +55,11 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 
 	activeWorkflows, err := job.HasActiveWorkflow(j.ID())
 	if err != nil {
+		mainlog.With("client", c.RemoteAddr(), "error", err).Info("failed to get workflows")
 		return nil, err
 	}
-
 	if !activeWorkflows {
+		mainlog.With("client", c.RemoteAddr(), "error", err).Info("no active workflows")
 		return nil, err
 	}
 

--- a/tftp.go
+++ b/tftp.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/avast/retry-go"
+	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tinkerbell/boots/conf"
@@ -69,6 +70,10 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 	l := mainlog.With("client", ip, "event", "open", "filename", filename)
 	l.With("error", err).Info()
 
+	return serveFakeReader(l, filename)
+}
+
+func serveFakeReader(l log.Logger, filename string) (tftp.ReadCloser, error) {
 	switch filename {
 	case "test.1mb":
 		l.With("tftp_fake_read", true).Info()

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
 	"time"
 
 	"github.com/packethost/pkg/log"
@@ -29,7 +28,7 @@ type tftpTransfer struct {
 func Open(mac net.HardwareAddr, filename, client string) (*tftpTransfer, error) {
 	l := tftplog.With("mac", mac, "client", client, "filename", filename)
 
-	content, ok := tftpFiles[path.Base(filename)]
+	content, ok := tftpFiles[filename]
 	if !ok {
 		err := errors.Wrap(os.ErrNotExist, "unknown file")
 		l.With("event", "open", "error", err).Info()


### PR DESCRIPTION
## Description

Provided the correct ID to `job.HasActiveWorkflow` along with better error handling and logging.

## Why is this needed

We were passing the job.ID() to HasActiveWorkflow which is the machine's primary mac address, this
is not what the gRPC call actually wants. There was also an error where we'd send back success/0 content
instead of an error if there's a problem fetching workflows or if there is no workflow active.

This PR changes the HardwareID from a string to a type so that we can avoid using and passing the wrong strings around.

## How Has This Been Tested?

Unit tests, and running it.


## How are existing users impacted? What migration steps/scripts do we need?

Bug is fixed.
