### PR TITLE
NixOS: Look for config from OSV imagetag if not in env

### DIFF
--- a/installers/nixos/main.go
+++ b/installers/nixos/main.go
@@ -54,9 +54,14 @@ func bootScript(paths map[string]string, j job.Job, s *ipxe.Script) {
 	key := j.OperatingSystem().Slug + "/" + j.PlanSlug()
 	init := paths[key]
 	if init == "" {
-		j.With("slug", j.OperatingSystem().Slug, "class", j.PlanSlug()).Error(errors.New("unknown os/class combo"))
-		s.Shell()
-		return
+		tag := j.OperatingSystem().ImageTag
+		if tag == "" {
+			j.With("slug", j.OperatingSystem().Slug, "class", j.PlanSlug()).Error(errors.New("unknown os/class combo and no OSV ImageTag set"))
+			s.Shell()
+			return
+		}
+		key = j.OperatingSystem().Slug + "/" + tag
+		init = "/nix/store/" + tag + "/init"
 	}
 
 	s.PhoneHome("provisioning.104.01")

--- a/job/mock.go
+++ b/job/mock.go
@@ -105,6 +105,10 @@ func (m *Mock) SetOSVersion(version string) {
 	m.hardware.OperatingSystem().Version = version
 }
 
+func (m *Mock) SetOSImageTag(tag string) {
+	m.hardware.OperatingSystem().ImageTag = tag
+}
+
 func (m *Mock) SetPassword(password string) {
 	m.instance.CryptedRootPassword = "insecure"
 }


### PR DESCRIPTION
## Description

Use EM OSV imagetag as a possible store of the NixOS store path values.

## Why is this needed

Better support for @grahamc and NixOS for EM provisions.

## How Has This Been Tested?

Unit tests so far.

## Checklist:

I have:
- [x] added unit or e2e tests
