### PR TITLE
Allow PXE booting regardless of an existing workflow:

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -36,6 +36,12 @@ type Job struct {
 	instance *packet.Instance
 }
 
+// AllowPxe returns the value from the hardware data
+// in tink server defined at network.interfaces[].netboot.allow_pxe
+func (j Job) AllowPxe() bool {
+	return j.hardware.HardwareAllowPXE(j.mac)
+}
+
 // HasActiveWorkflow fetches workflows for the given hardware and returns
 // the status true if there is a pending (active) workflow
 func HasActiveWorkflow(hwID packet.HardwareID) (bool, error) {


### PR DESCRIPTION
## Description

Currently, a machine will only PXE boot if it has an existing tink workflow.
To do any other type of PXE boot (custom ipxe, osie, hook, etc) you have to create a workflow that will never actually be run.
This commit allows machines to PXE into OSIE, hook, OSIE alternative, custom ipxe, etc without needing a workflow.
PXE booting will be gated by the tink hardware data field: `network.interfaces[].netboot.allow_pxe`

## Why is this needed

Allows machines to PXE boot without a workflow.

Fixes: https://github.com/tinkerbell/boots/issues/114

## How Has This Been Tested?

I built the boots image and ran it with the vagrant sandbox locally to test. It worked as intended there. 


## How are existing users impacted? What migration steps/scripts do we need?

no migrations.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
