### PR TITLE
Fix tftp ReadFile, Add tests:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,9 @@ jobs:
       - name: golangci-lint brought to you by Nix
         run: nix-shell --run 'GOROOT= golangci-lint run -v -D errcheck'
       - name: go test
-        run: go test -v ./...
+        run: go test -v ./... -gcflags=-l
       - name: go test coverage
-        run: go test -coverprofile=coverage.txt ./...
+        run: go test -coverprofile=coverage.txt ./... -gcflags=-l
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
       - name: compile binaries

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,24 @@ run: ${binary}
 test:
 	docker-compose up -d --build cacher
 endif
+
+vet: # go vet
+	go vet ./...
+
+go-test: # go test
+	go test -gcflags=-l -coverprofile=cover.out ./...
+	go tool cover -func=cover.out
+	rm -rf cover.out
+
+goimports: # goimports
+	@echo be sure goimports is installed
+	goimports -w .
+
+golangci-lint: # golangci-lint 
+	@echo be sure golangci-lint is installed: https://golangci-lint.run/usage/install/
+	golangci-lint run
+
+.PHONY: validate-local
+validate-local: vet go-test goimports golangci-lint # validate-local runs all the same validations and tests that CI run
+	
+	

--- a/dhcp_test.go
+++ b/dhcp_test.go
@@ -1,9 +1,19 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
 	"testing"
 
+	"bou.ke/monkey"
+	"github.com/google/go-cmp/cmp"
 	"github.com/packethost/dhcp4-go"
+	"github.com/packethost/pkg/log"
+	"github.com/tinkerbell/boots/job"
+	"github.com/tinkerbell/boots/metrics"
 )
 
 func TestGetCircuitID(t *testing.T) {
@@ -54,5 +64,55 @@ func TestGetCircuitID(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestMain(m *testing.M) {
+	l, err := log.Init("github.com/tinkerbell/boots")
+	if err != nil {
+		panic(nil)
+	}
+	defer l.Close()
+	mainlog = l.Package("main")
+	metrics.Init(l)
+	os.Exit(m.Run())
+}
+
+func TestServeJobFile(t *testing.T) {
+	tests := map[string]struct {
+		expectedResp       []byte
+		expectedStatusCode int
+		allowPxe           bool
+		err                error
+	}{
+		"success":                   {expectedResp: []byte("success"), expectedStatusCode: http.StatusOK, allowPxe: true},
+		"fail createFromRemoteAddr": {expectedStatusCode: http.StatusNotFound, err: fmt.Errorf("failed")},
+		"fail allowPxe is false":    {expectedStatusCode: http.StatusNotFound},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			monkey.Patch(job.CreateFromRemoteAddr, func(_ string) (job.Job, error) {
+				return job.Job{}, tc.err
+			})
+			var jb job.Job
+			monkey.PatchInstanceMethod(reflect.TypeOf(jb), "AllowPxe", func(_ job.Job) bool {
+				return tc.allowPxe
+			})
+			monkey.PatchInstanceMethod(reflect.TypeOf(jb), "ServeFile", func(_ job.Job, w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.expectedStatusCode)
+				_, _ = w.Write(tc.expectedResp)
+			})
+
+			w := httptest.NewRecorder()
+			req := http.Request{RemoteAddr: "127.0.0.1:80"}
+			serveJobFile(w, &req)
+			if diff := cmp.Diff(tc.expectedResp, w.Body.Bytes()); diff != "" {
+				t.Fatal(diff)
+			}
+			if tc.expectedStatusCode != w.Result().StatusCode {
+				t.Fatalf("expected: %v, got: %v", tc.expectedStatusCode, w.Result().StatusCode)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/tinkerbell/boots
 go 1.13
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/avast/retry-go v2.2.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gammazero/workerpool v0.0.0-20200311205957-7b00833861c6
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 	github.com/golang/mock v1.4.4
+	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/packethost/cacher v0.0.0-20200825140532-0b62e6726807
 	github.com/packethost/dhcp4-go v0.0.0-20190402165401-39c137f31ad3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/tftp.go
+++ b/tftp.go
@@ -66,7 +66,7 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 	// without a tink workflow present.
 	if !j.AllowPxe() {
 		l.Info("the hardware data for this machine, or lack there of, does not allow it to pxe; allow_pxe: false")
-		serveFakeReader(l, filename)
+		return serveFakeReader(l, filename)
 	}
 
 	return j.ServeTFTP(filename, ip.String())

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/google/go-cmp/cmp"
+	"github.com/tinkerbell/boots/job"
+	"github.com/tinkerbell/tftp-go"
+)
+
+type tftpConnTester struct{}
+
+func (t tftpConnTester) LocalAddr() net.Addr {
+	return &net.IPAddr{IP: []byte("127.0.0.1")}
+}
+
+func (t tftpConnTester) RemoteAddr() net.Addr {
+	return &net.IPAddr{IP: []byte("127.0.0.1")}
+}
+
+func TestReadFile(t *testing.T) {
+	fileContents := "you downloaded a tftp file"
+	tests := map[string]struct {
+		expectedResp     string
+		allowPxe         bool
+		failCreateFromIP bool
+		err              error
+	}{
+		"success":                {expectedResp: fileContents, allowPxe: true},
+		"fail failCreateFromIP":  {failCreateFromIP: true, err: fmt.Errorf("permission denied")},
+		"fail allowPxe is false": {err: fmt.Errorf("permission denied")},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			monkey.Patch(job.CreateFromIP, func(_ net.IP) (job.Job, error) {
+				var err error
+				if tc.failCreateFromIP {
+					err = tc.err
+				}
+				return job.Job{}, err
+			})
+			var jb job.Job
+			monkey.PatchInstanceMethod(reflect.TypeOf(jb), "AllowPxe", func(_ job.Job) bool {
+				return tc.allowPxe
+			})
+			monkey.PatchInstanceMethod(reflect.TypeOf(jb), "ServeTFTP", func(_ job.Job, _, _ string) (tftp.ReadCloser, error) {
+				r := ioutil.NopCloser(bytes.NewReader([]byte(fileContents)))
+				return r, nil
+			})
+
+			tf := tftpHandler{}
+			tftpConn := tftpConnTester{}
+			f, err := tf.ReadFile(tftpConn, "nofile")
+			if err != nil {
+				if tc.err != nil {
+					if diff := cmp.Diff(tc.err.Error(), err.Error()); diff != "" {
+						t.Fatal(diff)
+					}
+				} else {
+					t.Fatal(err)
+				}
+			} else {
+				buf := new(bytes.Buffer)
+				buf.ReadFrom(f)
+				if diff := cmp.Diff(tc.expectedResp, buf.String()); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

tftp ReadFile was missing a return if AllowPxe was false.
This adds the return and adds tests for the AllowPxe
gate that was just recently added.
this library: https://github.com/bouk/monkey, was used in the unit tests and requires running tests with `-gcflags=-l`.
the github actions were updated to accommodate this.
a few testing helpers were added to the makefile.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
