### PR TITLE
support the provisioner_engine metadata value

### DIFF
--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -90,7 +90,11 @@ func (j Job) isPXEAllowed() bool {
 }
 
 func (j Job) areWeProvisioner() bool {
-	return j.hardware.HardwareProvisioner() == j.ProvisioningEngineName()
+	if len(j.hardware.HardwareProvisioner()) > 0 {
+		return j.hardware.HardwareProvisioner() == j.ProvisionerEngineName()
+	}
+
+	return true
 }
 
 func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -90,7 +90,7 @@ func (j Job) isPXEAllowed() bool {
 }
 
 func (j Job) areWeProvisioner() bool {
-	if j.hardware.HardwareProvisioner() == j.provisioningEngineName {
+	if j.hardware.HardwareProvisioner() == j.ProvisioningEngineName() {
 		return true
 	}
 

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -28,6 +28,12 @@ func IsSpecialOS(i *packet.Instance) bool {
 // ServeDHCP responds to DHCP packets
 func (j Job) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) bool {
 
+	// If we are not the chosen provisioner for this piece of hardware
+	// do not respond to the DHCP request
+	if !j.areWeProvisioner() {
+		return false
+	}
+
 	// setup reply
 	reply := dhcp.NewReply(w, req)
 	if reply == nil {
@@ -81,6 +87,14 @@ func (j Job) isPXEAllowed() bool {
 		return false
 	}
 	return j.instance.AllowPXE
+}
+
+func (j Job) areWeProvisioner() bool {
+	if j.hardware.HardwareProvisioner() == j.provisioningEngineName {
+		return true
+	}
+
+	return false
 }
 
 func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -90,11 +90,11 @@ func (j Job) isPXEAllowed() bool {
 }
 
 func (j Job) areWeProvisioner() bool {
-	if len(j.hardware.HardwareProvisioner()) > 0 {
-		return j.hardware.HardwareProvisioner() == j.ProvisionerEngineName()
+	if j.hardware.HardwareProvisioner() == "" {
+		return true
 	}
 
-	return true
+	return j.hardware.HardwareProvisioner() == j.ProvisionerEngineName()
 }
 
 func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -90,11 +90,7 @@ func (j Job) isPXEAllowed() bool {
 }
 
 func (j Job) areWeProvisioner() bool {
-	if j.hardware.HardwareProvisioner() == j.ProvisioningEngineName() {
-		return true
-	}
-
-	return false
+	return j.hardware.HardwareProvisioner() == j.ProvisioningEngineName()
 }
 
 func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -117,6 +117,34 @@ func TestAllowPXE(t *testing.T) {
 	}
 }
 
+func TestAreWeProvisioner(t *testing.T) {
+	for _, tt := range []struct {
+		want              bool
+		ProvisionerEngine string
+		env               string
+	}{
+		{want: true, ProvisionerEngine: "tinkerbell", env: "tinkerbell"},
+		{want: false, ProvisionerEngine: "tinkerbell", env: "packet"},
+		{want: true, ProvisionerEngine: "", env: "packet"},
+		{want: false, ProvisionerEngine: "tinkerbell", env: ""},
+	} {
+		t.Logf("want=%t, ProvisionerEngine=%s env=%s",
+			tt.want, tt.ProvisionerEngine, tt.env)
+		j := Job{
+			hardware: &packet.HardwareTinkerbellV1{
+				Metadata: packet.Metadata{
+					ProvisionerEngine: tt.ProvisionerEngine,
+				},
+			},
+		}
+		SetProvisionerEngineName(tt.env)
+		got := j.areWeProvisioner()
+		if got != tt.want {
+			t.Fatalf("unexpected return, want: %t, got %t", tt.want, got)
+		}
+	}
+}
+
 func TestIsSpecialOS(t *testing.T) {
 	t.Run("nil instance", func(t *testing.T) {
 		special := IsSpecialOS(nil)

--- a/job/job.go
+++ b/job/job.go
@@ -49,6 +49,12 @@ func (j Job) AllowPxe() bool {
 	return j.hardware.HardwareAllowPXE(j.mac)
 }
 
+// ProvisioningEngineName returns the current provisioning engine name
+// as defined by the env var PROVISIONING_ENGINE_NAME supplied at runtime
+func (j Job) ProvisioningEngineName() string {
+	return provisioningEngineName
+}
+
 // HasActiveWorkflow fetches workflows for the given hardware and returns
 // the status true if there is a pending (active) workflow
 func HasActiveWorkflow(hwID packet.HardwareID) (bool, error) {

--- a/job/job.go
+++ b/job/job.go
@@ -14,17 +14,17 @@ import (
 )
 
 var client *packet.Client
-var provisioningEngineName string
+var provisionerEngineName string
 
 // SetClient sets the client used to interact with the api.
 func SetClient(c *packet.Client) {
 	client = c
 }
 
-// SetProvisioningEngineName sets the provisioning engine name used
+// SetProvisionerEngineName sets the provisioning engine name used
 // for this instance of boots
-func SetProvisioningEngineName(engineName string) {
-	provisioningEngineName = engineName
+func SetProvisionerEngineName(engineName string) {
+	provisionerEngineName = engineName
 }
 
 // Job this comment is useless
@@ -49,10 +49,10 @@ func (j Job) AllowPxe() bool {
 	return j.hardware.HardwareAllowPXE(j.mac)
 }
 
-// ProvisioningEngineName returns the current provisioning engine name
-// as defined by the env var PROVISIONING_ENGINE_NAME supplied at runtime
-func (j Job) ProvisioningEngineName() string {
-	return provisioningEngineName
+// ProvisionerEngineName returns the current provisioning engine name
+// as defined by the env var PROVISIONER_ENGINE_NAME supplied at runtime
+func (j Job) ProvisionerEngineName() string {
+	return provisionerEngineName
 }
 
 // HasActiveWorkflow fetches workflows for the given hardware and returns

--- a/job/job.go
+++ b/job/job.go
@@ -14,10 +14,17 @@ import (
 )
 
 var client *packet.Client
+var provisioningEngineName string
 
 // SetClient sets the client used to interact with the api.
 func SetClient(c *packet.Client) {
 	client = c
+}
+
+// SetProvisioningEngineName sets the provisioning engine name used
+// for this instance of boots
+func SetProvisioningEngineName(engineName string) {
+	provisioningEngineName = engineName
 }
 
 // Job this comment is useless

--- a/main.go
+++ b/main.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	client     *packet.Client
-	apiBaseURL = env.URL("API_BASE_URL", "https://api.packet.net")
+	client                 *packet.Client
+	apiBaseURL             = env.URL("API_BASE_URL", "https://api.packet.net")
+	provisioningEngineName = env.String("PROVISIONING_ENGINE_NAME", "packet")
 
 	mainlog log.Logger
 
@@ -73,6 +74,7 @@ func main() {
 		mainlog.Fatal(err)
 	}
 	job.SetClient(client)
+	job.SetProvisioningEngineName(provisioningEngineName)
 
 	go func() {
 		mainlog.Info("serving syslog")

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ import (
 )
 
 var (
-	client                 *packet.Client
-	apiBaseURL             = env.URL("API_BASE_URL", "https://api.packet.net")
-	provisioningEngineName = env.Get("PROVISIONING_ENGINE_NAME", "packet")
+	client                *packet.Client
+	apiBaseURL            = env.URL("API_BASE_URL", "https://api.packet.net")
+	provisionerEngineName = env.Get("PROVISIONER_ENGINE_NAME", "packet")
 
 	mainlog log.Logger
 
@@ -74,7 +74,7 @@ func main() {
 		mainlog.Fatal(err)
 	}
 	job.SetClient(client)
-	job.SetProvisioningEngineName(provisioningEngineName)
+	job.SetProvisionerEngineName(provisionerEngineName)
 
 	go func() {
 		mainlog.Info("serving syslog")

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	client                 *packet.Client
 	apiBaseURL             = env.URL("API_BASE_URL", "https://api.packet.net")
-	provisioningEngineName = env.String("PROVISIONING_ENGINE_NAME", "packet")
+	provisioningEngineName = env.Get("PROVISIONING_ENGINE_NAME", "packet")
 
 	mainlog log.Logger
 

--- a/packet/models.go
+++ b/packet/models.go
@@ -62,6 +62,7 @@ type Hardware interface {
 	HardwareIPs() []IP
 	Interfaces() []Port // TODO: to be updated
 	HardwareManufacturer() string
+	HardwareProvisioner() string
 	HardwarePlanSlug() string
 	HardwarePlanVersionSlug() string
 	HardwareState() HardwareState

--- a/packet/models.go
+++ b/packet/models.go
@@ -297,8 +297,8 @@ type Metadata struct {
 		PreinstalledOS OperatingSystem `json:"preinstalled_operating_system_version"`
 		PrivateSubnets []string        `json:"private_subnets"`
 	} `json:"custom"`
-	Facility           Facility `json:"facility"`
-	ProvisioningEngine string   `json:"provisioning_engine"`
+	Facility          Facility `json:"facility"`
+	ProvisionerEngine string   `json:"provisioner_engine"`
 }
 
 // Facility represents the facilty in use

--- a/packet/models.go
+++ b/packet/models.go
@@ -296,7 +296,8 @@ type Metadata struct {
 		PreinstalledOS OperatingSystem `json:"preinstalled_operating_system_version"`
 		PrivateSubnets []string        `json:"private_subnets"`
 	} `json:"custom"`
-	Facility Facility `json:"facility"`
+	Facility           Facility `json:"facility"`
+	ProvisioningEngine string   `json:"provisioning_engine"`
 }
 
 // Facility represents the facilty in use

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -22,23 +22,23 @@ type HardwareCacher struct {
 	Name  string        `json:"name"`
 	State HardwareState `json:"state"`
 
-	BondingMode        BondingMode     `json:"bonding_mode"`
-	NetworkPorts       []Port          `json:"network_ports"`
-	Manufacturer       Manufacturer    `json:"manufacturer"`
-	PlanSlug           string          `json:"plan_slug"`
-	PlanVersionSlug    string          `json:"plan_version_slug"`
-	Arch               string          `json:"arch"`
-	FacilityCode       string          `json:"facility_code"`
-	IPMI               IP              `json:"management"`
-	IPs                []IP            `json:"ip_addresses"`
-	PreinstallOS       OperatingSystem `json:"preinstalled_operating_system_version"`
-	PrivateSubnets     []string        `json:"private_subnets,omitempty"`
-	UEFI               bool            `json:"efi_boot"`
-	AllowPXE           bool            `json:"allow_pxe"`
-	AllowWorkflow      bool            `json:"allow_workflow"`
-	ServicesVersion    ServicesVersion `json:"services"`
-	Instance           *Instance       `json:"instance"`
-	ProvisioningEngine string          `json:"provisioning_engine"`
+	BondingMode       BondingMode     `json:"bonding_mode"`
+	NetworkPorts      []Port          `json:"network_ports"`
+	Manufacturer      Manufacturer    `json:"manufacturer"`
+	PlanSlug          string          `json:"plan_slug"`
+	PlanVersionSlug   string          `json:"plan_version_slug"`
+	Arch              string          `json:"arch"`
+	FacilityCode      string          `json:"facility_code"`
+	IPMI              IP              `json:"management"`
+	IPs               []IP            `json:"ip_addresses"`
+	PreinstallOS      OperatingSystem `json:"preinstalled_operating_system_version"`
+	PrivateSubnets    []string        `json:"private_subnets,omitempty"`
+	UEFI              bool            `json:"efi_boot"`
+	AllowPXE          bool            `json:"allow_pxe"`
+	AllowWorkflow     bool            `json:"allow_workflow"`
+	ServicesVersion   ServicesVersion `json:"services"`
+	Instance          *Instance       `json:"instance"`
+	ProvisionerEngine string          `json:"provisioner_engine"`
 }
 
 func (d DiscoveryCacher) Hardware() Hardware {
@@ -310,7 +310,7 @@ func (h HardwareCacher) HardwareManufacturer() string {
 }
 
 func (h HardwareCacher) HardwareProvisioner() string {
-	return h.ProvisioningEngine
+	return h.ProvisionerEngine
 }
 
 func (h HardwareCacher) HardwarePlanSlug() string {

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -22,22 +22,23 @@ type HardwareCacher struct {
 	Name  string        `json:"name"`
 	State HardwareState `json:"state"`
 
-	BondingMode     BondingMode     `json:"bonding_mode"`
-	NetworkPorts    []Port          `json:"network_ports"`
-	Manufacturer    Manufacturer    `json:"manufacturer"`
-	PlanSlug        string          `json:"plan_slug"`
-	PlanVersionSlug string          `json:"plan_version_slug"`
-	Arch            string          `json:"arch"`
-	FacilityCode    string          `json:"facility_code"`
-	IPMI            IP              `json:"management"`
-	IPs             []IP            `json:"ip_addresses"`
-	PreinstallOS    OperatingSystem `json:"preinstalled_operating_system_version"`
-	PrivateSubnets  []string        `json:"private_subnets,omitempty"`
-	UEFI            bool            `json:"efi_boot"`
-	AllowPXE        bool            `json:"allow_pxe"`
-	AllowWorkflow   bool            `json:"allow_workflow"`
-	ServicesVersion ServicesVersion `json:"services"`
-	Instance        *Instance       `json:"instance"`
+	BondingMode        BondingMode     `json:"bonding_mode"`
+	NetworkPorts       []Port          `json:"network_ports"`
+	Manufacturer       Manufacturer    `json:"manufacturer"`
+	PlanSlug           string          `json:"plan_slug"`
+	PlanVersionSlug    string          `json:"plan_version_slug"`
+	Arch               string          `json:"arch"`
+	FacilityCode       string          `json:"facility_code"`
+	IPMI               IP              `json:"management"`
+	IPs                []IP            `json:"ip_addresses"`
+	PreinstallOS       OperatingSystem `json:"preinstalled_operating_system_version"`
+	PrivateSubnets     []string        `json:"private_subnets,omitempty"`
+	UEFI               bool            `json:"efi_boot"`
+	AllowPXE           bool            `json:"allow_pxe"`
+	AllowWorkflow      bool            `json:"allow_workflow"`
+	ServicesVersion    ServicesVersion `json:"services"`
+	Instance           *Instance       `json:"instance"`
+	ProvisioningEngine string          `json:"provisioning_engine"`
 }
 
 func (d DiscoveryCacher) Hardware() Hardware {
@@ -306,6 +307,10 @@ func (h HardwareCacher) HardwareIPMI() IP {
 
 func (h HardwareCacher) HardwareManufacturer() string {
 	return h.Manufacturer.Slug
+}
+
+func (h HardwareCacher) HardwareProvisioner() string {
+	return h.ProvisioningEngine
 }
 
 func (h HardwareCacher) HardwarePlanSlug() string {

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -249,6 +249,7 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("metadata state: %v", d.Metadata.State)
 			t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
 			t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
+			t.Logf("metadata provisioning_engine: %v", d.Metadata.ProvisioningEngine)
 			if d.Instance() != nil {
 				t.Logf("instance: %v", d.Instance())
 				t.Logf("instance id: %s", d.Instance().ID)
@@ -578,6 +579,7 @@ const (
 {
   "id": "fde7c87c-d154-447e-9fce-7eb7bdec90c0",
   "metadata": {
+    "provisioning_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -634,6 +636,7 @@ const (
 {
   "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
   "metadata": {
+    "provisioning_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -749,6 +752,7 @@ const (
 	discovered = `
 {
   "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
+  "provisioning_engine": "packet",
   "management": {
     "address": "10.250.142.74",
     "gateway": "10.250.142.1",
@@ -772,6 +776,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
+  "provisioning_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -863,6 +868,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "provisioning_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -980,6 +986,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
+  "provisioning_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1099,6 +1106,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "provisioning_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1228,6 +1236,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "provisioning_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1367,6 +1376,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
+  "provisioning_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1510,6 +1520,7 @@ const (
   "efi_boot": false,
   "facility_code": "dfw2",
   "id": "55639911-2278-498c-b364-8b2a62f5493c",
+  "provisioning_engine": "packet",
   "instance": {
     "allow_pxe": false,
     "always_pxe": false,

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -249,7 +249,6 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("metadata state: %v", d.Metadata.State)
 			t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
 			t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
-			t.Logf("metadata provisioner_engine: %v", d.Metadata.ProvisioningEngine)
 			if d.Instance() != nil {
 				t.Logf("instance: %v", d.Instance())
 				t.Logf("instance id: %s", d.Instance().ID)
@@ -579,7 +578,6 @@ const (
 {
   "id": "fde7c87c-d154-447e-9fce-7eb7bdec90c0",
   "metadata": {
-    "provisioner_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -636,7 +634,6 @@ const (
 {
   "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
   "metadata": {
-    "provisioner_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -752,7 +749,6 @@ const (
 	discovered = `
 {
   "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
-  "provisioner_engine": "packet",
   "management": {
     "address": "10.250.142.74",
     "gateway": "10.250.142.1",
@@ -776,7 +772,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
-  "provisioner_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -868,7 +863,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioner_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -986,7 +980,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
-  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1106,7 +1099,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1236,7 +1228,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1376,7 +1367,6 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1520,7 +1510,6 @@ const (
   "efi_boot": false,
   "facility_code": "dfw2",
   "id": "55639911-2278-498c-b364-8b2a62f5493c",
-  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": false,
     "always_pxe": false,

--- a/packet/models_test.go
+++ b/packet/models_test.go
@@ -249,7 +249,7 @@ func TestDiscoveryTinkerbell(t *testing.T) {
 			t.Logf("metadata state: %v", d.Metadata.State)
 			t.Logf("metadata bonding_mode: %v", d.Metadata.BondingMode)
 			t.Logf("metadata manufacturer: %v", d.Metadata.Manufacturer)
-			t.Logf("metadata provisioning_engine: %v", d.Metadata.ProvisioningEngine)
+			t.Logf("metadata provisioner_engine: %v", d.Metadata.ProvisioningEngine)
 			if d.Instance() != nil {
 				t.Logf("instance: %v", d.Instance())
 				t.Logf("instance id: %s", d.Instance().ID)
@@ -579,7 +579,7 @@ const (
 {
   "id": "fde7c87c-d154-447e-9fce-7eb7bdec90c0",
   "metadata": {
-    "provisioning_engine": "tinkerbell",
+    "provisioner_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -636,7 +636,7 @@ const (
 {
   "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
   "metadata": {
-    "provisioning_engine": "tinkerbell",
+    "provisioner_engine": "tinkerbell",
     "bonding_mode": 5,
     "custom": {
       "preinstalled_operating_system_version": {},
@@ -752,7 +752,7 @@ const (
 	discovered = `
 {
   "id": "1a02e6c4-43e5-4be6-aa00-a8b42e4c770d",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "management": {
     "address": "10.250.142.74",
     "gateway": "10.250.142.1",
@@ -776,7 +776,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "d7e1feaf-d6d5-4d6c-8d16-5c6913be2dea",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -868,7 +868,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {},
   "ip_addresses": [
     {
@@ -986,7 +986,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "506ad180-8692-480d-b6c2-3ec7f8d719ac",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1106,7 +1106,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1236,7 +1236,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1376,7 +1376,7 @@ const (
   "efi_boot": true,
   "facility_code": "lab1",
   "id": "6300b237-c417-4264-8a0a-58bce33c303f",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": true,
     "always_pxe": false,
@@ -1520,7 +1520,7 @@ const (
   "efi_boot": false,
   "facility_code": "dfw2",
   "id": "55639911-2278-498c-b364-8b2a62f5493c",
-  "provisioning_engine": "packet",
+  "provisioner_engine": "packet",
   "instance": {
     "allow_pxe": false,
     "always_pxe": false,

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -146,6 +146,10 @@ func (h HardwareTinkerbellV1) HardwareIPs() []IP {
 //	return h.DHCP.IP // is this correct?
 //}
 
+func (h HardwareTinkerbellV1) HardwareProvisioner() string {
+	return h.Metadata.ProvisioningEngine
+}
+
 func (h HardwareTinkerbellV1) HardwareManufacturer() string {
 	return h.Metadata.Manufacturer.Slug
 }

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -147,7 +147,7 @@ func (h HardwareTinkerbellV1) HardwareIPs() []IP {
 //}
 
 func (h HardwareTinkerbellV1) HardwareProvisioner() string {
-	return h.Metadata.ProvisioningEngine
+	return h.Metadata.ProvisionerEngine
 }
 
 func (h HardwareTinkerbellV1) HardwareManufacturer() string {


### PR DESCRIPTION
## Description

Boots should check the provisioiner_engine metadata value against the PROVISIONER_ENGINE_NAME runtime environment to decide if it should be handling DHCP requests for a given piece of hardware.

## Why is this needed

To allow for multiple differing versions of boots to be running in an environment, with DHCP relayed to both simultaneously to aid in blue/green deployment testing.