### PR TITLE
Add logging around DHCP request rejection

### DIFF
--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -31,6 +31,7 @@ func (j Job) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) bool {
 	// If we are not the chosen provisioner for this piece of hardware
 	// do not respond to the DHCP request
 	if !j.areWeProvisioner() {
+		j.With("dhcp", j.ProvisionerEngineName(), "hw", j.hardware.HardwareProvisioner()).Info("We are not the provisioner")
 		return false
 	}
 


### PR DESCRIPTION
## Description

We've found that some additional logging around the provisioner_engine selection logic would aide in debugging.   This PR adds it.

## Why is this needed

When the logic expected doesn't match the result it's hard to know why.   Additional logging will help.
