### PR TITLE
http: Only check for HasActiveWorkflow if CanWorkflow is true

### DIFF
--- a/http.go
+++ b/http.go
@@ -147,16 +147,18 @@ func serveHardware(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
-	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
-		return
-	}
-	if !activeWorkflows {
-		w.WriteHeader(http.StatusNotFound)
-		mainlog.With("client", req.RemoteAddr).Info("no active workflows")
-		return
+	if j.CanWorkflow() {
+		activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			j.With("error", err).Info("failed to get workflows")
+			return
+		}
+		if !activeWorkflows {
+			w.WriteHeader(http.StatusNotFound)
+			j.Info("no active workflows")
+			return
+		}
 	}
 
 	j.AddHardware(w, req)
@@ -194,16 +196,18 @@ func serveProblem(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
-	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		mainlog.With("client", req.RemoteAddr, "error", err).Info("failed to get workflows")
-		return
-	}
-	if !activeWorkflows {
-		w.WriteHeader(http.StatusNotFound)
-		mainlog.With("client", req.RemoteAddr).Info("no active workflows")
-		return
+	if j.CanWorkflow() {
+		activeWorkflows, err := job.HasActiveWorkflow(j.HardwareID())
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			j.With("error", err).Info("failed to get workflows")
+			return
+		}
+		if !activeWorkflows {
+			w.WriteHeader(http.StatusNotFound)
+			j.Info("no active workflows")
+			return
+		}
 	}
 
 	j.ServeProblemEndpoint(w, req)


### PR DESCRIPTION
## Description

Only checks for workflows if we're in tinkerbell mode and setup for workflows.

## Why is this needed

Would break EM provisions for legacy sites.

## How Has This Been Tested?

Locally via docker-compose.

## How are existing users impacted? What migration steps/scripts do we need?

EM users get a fancy new boots release.
