### PR TITLE
Refactor all table driven tests to use t.Run

### DIFF
--- a/installers/custom_ipxe/ipxe_script_test.go
+++ b/installers/custom_ipxe/ipxe_script_test.go
@@ -19,22 +19,22 @@ var facility = func() string {
 
 func TestScript(t *testing.T) {
 	for typ, script := range type2Script {
-		t.Log(typ)
+		t.Run(typ, func(t *testing.T) {
+			m := job.NewMock(t, typ, facility)
+			m.SetIPXEScriptURL("http://127.0.0.1/fake_ipxe_url")
 
-		m := job.NewMock(t, typ, facility)
-		m.SetIPXEScriptURL("http://127.0.0.1/fake_ipxe_url")
+			s := ipxe.Script{}
+			s.Echo("Packet.net Baremetal - iPXE boot")
+			s.Set("iface", "eth0").Or("shell")
+			s.Set("tinkerbell", "http://127.0.0.1")
+			s.Set("ipxe_cloud_config", "packet")
 
-		s := ipxe.Script{}
-		s.Echo("Packet.net Baremetal - iPXE boot")
-		s.Set("iface", "eth0").Or("shell")
-		s.Set("tinkerbell", "http://127.0.0.1")
-		s.Set("ipxe_cloud_config", "packet")
-
-		bootScript(m.Job(), &s)
-		got := string(s.Bytes())
-		if script != got {
-			t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(script, got))
-		}
+			bootScript(m.Job(), &s)
+			got := string(s.Bytes())
+			if script != got {
+				t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(script, got))
+			}
+		})
 	}
 }
 

--- a/installers/nixos/ipxe_script_test.go
+++ b/installers/nixos/ipxe_script_test.go
@@ -20,33 +20,34 @@ var facility = func() string {
 
 func TestScript(t *testing.T) {
 	for typ, script := range type2Script {
-		t.Log(typ)
+		t.Run(typ, func(t *testing.T) {
 
-		split := strings.Split(typ, "/")
-		v, typ := split[0], split[1]
-		tag := ""
-		if strings.Contains(typ, ":") {
-			split = strings.Split(typ, ":")
-			typ, tag = split[0], split[1]
-		}
+			split := strings.Split(typ, "/")
+			v, typ := split[0], split[1]
+			tag := ""
+			if strings.Contains(typ, ":") {
+				split = strings.Split(typ, ":")
+				typ, tag = split[0], split[1]
+			}
 
-		m := job.NewMock(t, typ, facility)
-		m.SetOSSlug("nixos_" + v)
-		if tag != "" {
-			m.SetOSImageTag(tag)
-		}
+			m := job.NewMock(t, typ, facility)
+			m.SetOSSlug("nixos_" + v)
+			if tag != "" {
+				m.SetOSImageTag(tag)
+			}
 
-		s := ipxe.Script{}
-		s.Echo("Packet.net Baremetal - iPXE boot")
-		s.Set("iface", "eth0").Or("shell")
-		s.Set("tinkerbell", "http://127.0.0.1")
-		s.Set("ipxe_cloud_config", "packet")
+			s := ipxe.Script{}
+			s.Echo("Packet.net Baremetal - iPXE boot")
+			s.Set("iface", "eth0").Or("shell")
+			s.Set("tinkerbell", "http://127.0.0.1")
+			s.Set("ipxe_cloud_config", "packet")
 
-		bootScript(oshwToInitPath, m.Job(), &s)
-		got := string(s.Bytes())
-		if script != got {
-			t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(script, got))
-		}
+			bootScript(oshwToInitPath, m.Job(), &s)
+			got := string(s.Bytes())
+			if script != got {
+				t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(script, got))
+			}
+		})
 	}
 }
 

--- a/installers/rancher/ipxe_script_test.go
+++ b/installers/rancher/ipxe_script_test.go
@@ -18,21 +18,21 @@ var facility = func() string {
 
 func TestScript(t *testing.T) {
 	for typ, script := range type2Script {
-		t.Log(typ)
+		t.Run(typ, func(t *testing.T) {
+			m := job.NewMock(t, typ, facility)
 
-		m := job.NewMock(t, typ, facility)
+			s := ipxe.Script{}
+			s.Echo("Packet.net Baremetal - iPXE boot")
+			s.Set("iface", "eth0").Or("shell")
+			s.Set("tinkerbell", "http://127.0.0.1")
+			s.Set("ipxe_cloud_config", "packet")
 
-		s := ipxe.Script{}
-		s.Echo("Packet.net Baremetal - iPXE boot")
-		s.Set("iface", "eth0").Or("shell")
-		s.Set("tinkerbell", "http://127.0.0.1")
-		s.Set("ipxe_cloud_config", "packet")
-
-		bootScript(m.Job(), &s)
-		got := string(s.Bytes())
-		if script != got {
-			t.Fatalf("%s bad iPxe script\nwant:\n%s\ngot:\n%s", typ, script, got)
-		}
+			bootScript(m.Job(), &s)
+			got := string(s.Bytes())
+			if script != got {
+				t.Fatalf("%s bad iPxe script\nwant:\n%s\ngot:\n%s", typ, script, got)
+			}
+		})
 	}
 }
 

--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -21,24 +21,27 @@ var facility = func() string {
 
 func TestScriptPerType(t *testing.T) {
 	for typ, script := range type2pxe {
-		for version, bootScript := range versions {
-			t.Log(typ + ":" + version)
+		t.Run(typ, func(t *testing.T) {
+			for version, bootScript := range versions {
+				t.Run(version, func(t *testing.T) {
 
-			m := job.NewMock(t, typ, facility)
-			m.SetMAC("00:00:ba:dd:be:ef")
+					m := job.NewMock(t, typ, facility)
+					m.SetMAC("00:00:ba:dd:be:ef")
 
-			s := ipxe.Script{}
-			bootScript(m.Job(), &s)
-			got := string(s.Bytes())
+					s := ipxe.Script{}
+					bootScript(m.Job(), &s)
+					got := string(s.Bytes())
 
-			want := fmt.Sprintf(script, version)
-			if !strings.Contains(want, version) {
-				t.Fatalf("expected %s to be present in script:%v", version, want)
+					want := fmt.Sprintf(script, version)
+					if !strings.Contains(want, version) {
+						t.Fatalf("expected %s to be present in script:%v", version, want)
+					}
+					if want != got {
+						t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(want, got))
+					}
+				})
 			}
-			if want != got {
-				t.Fatalf("%s bad iPXE script:\n%v", typ, diff.LineDiff(want, got))
-			}
-		}
+		})
 	}
 }
 

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -15,11 +15,11 @@ import (
 func TestDetermineDisk(t *testing.T) {
 	assert := require.New(t)
 	for typ, disk := range kickstartTypes {
-		t.Log(typ)
-
-		m := job.NewMock(t, typ, facility)
-		gotDisk := determineDisk(m.Job())
-		assert.Equal(disk, gotDisk)
+		t.Run(typ, func(t *testing.T) {
+			m := job.NewMock(t, typ, facility)
+			gotDisk := determineDisk(m.Job())
+			assert.Equal(disk, gotDisk)
+		})
 	}
 
 }
@@ -32,24 +32,28 @@ func TestScriptKickstart(t *testing.T) {
 	conf.PublicFQDN = "boots-test.example.com"
 
 	for _, man := range manufacturers {
-		for _, ver := range versions {
-			for typ, disk := range kickstartTypes {
-				t.Log(man, ver, typ)
+		t.Run(man, func(t *testing.T) {
+			for _, ver := range versions {
+				t.Run(ver, func(t *testing.T) {
+					for typ, disk := range kickstartTypes {
+						t.Run(typ, func(t *testing.T) {
+							m := job.NewMock(t, typ, facility)
+							m.SetManufacturer(man)
+							m.SetOSSlug(ver)
+							m.SetIP(net.ParseIP("127.0.0.1"))
+							m.SetPassword("password")
+							m.SetMAC("00:00:ba:dd:be:ef")
 
-				m := job.NewMock(t, typ, facility)
-				m.SetManufacturer(man)
-				m.SetOSSlug(ver)
-				m.SetIP(net.ParseIP("127.0.0.1"))
-				m.SetPassword("password")
-				m.SetMAC("00:00:ba:dd:be:ef")
-
-				var w strings.Builder
-				genKickstart(m.Job(), &w)
-				got := w.String()
-				script := loadKickstart(disk, assert)
-				assert.Equal(script, got, diff.LineDiff(script, got))
+							var w strings.Builder
+							genKickstart(m.Job(), &w)
+							got := w.String()
+							script := loadKickstart(disk, assert)
+							assert.Equal(script, got, diff.LineDiff(script, got))
+						})
+					}
+				})
 			}
-		}
+		})
 	}
 }
 

--- a/packet/endpoints_test.go
+++ b/packet/endpoints_test.go
@@ -106,7 +106,7 @@ func TestGetWorkflowsFromTink(t *testing.T) {
 			hwID: "Hardware-fake-bde9-812726eff314",
 			wcl: &tw.WorkflowContextList{
 				WorkflowContexts: []*tw.WorkflowContext{
-					&tw.WorkflowContext{
+					{
 						WorkflowId:         "active-fake-workflow-bde9-812726eff314",
 						CurrentActionState: 0,
 					},

--- a/packet/util_test.go
+++ b/packet/util_test.go
@@ -6,19 +6,21 @@ import (
 )
 
 func TestMACAddr(t *testing.T) {
-	examples := []string{
-		`{"data":{"mac":"0c:c4:7a:c6:2f:1c"}}`,
-		`{"data":{"mac":null}}`,
-		`{"data":{}}`,
+	examples := map[string]string{
+		"mac":      `{"data":{"mac":"0c:c4:7a:c6:2f:1c"}}`,
+		"null mac": `{"data":{"mac":null}}`,
+		"no data":  `{"data":{}}`,
 	}
-	for _, example := range examples {
-		var res struct {
-			Data struct {
-				MAC *MACAddr `json:"mac"`
-			} `json:"data"`
-		}
-		if err := json.Unmarshal([]byte(example), &res); err != nil {
-			t.Errorf("parsing failed for %s: %v", example, err)
-		}
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			var res struct {
+				Data struct {
+					MAC *MACAddr `json:"mac"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(example), &res); err != nil {
+				t.Errorf("parsing failed for %s: %v", example, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Use `t.Run` in all the table driven tests.

## Why is this needed

Using `t.Run` gives us better selectivity with `go test -run` and also better grouping/splitting when running with `go test -v`.


## How Has This Been Tested?

Just minor test changes, so tested with `go test`.