### PR TITLE
ci: Run builds on our self hosted builders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,6 @@ jobs:
         uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: "v0.4.1"
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
       - name: Install Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Setup Dynamic Env
         run: |
-          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" | tee $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           lfs: true
       - name: Install nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Set up QEMU

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validation:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, X64]
     env:
       CGO_ENABLED: 0
     steps:


### PR DESCRIPTION
## Description

Run ci builds on our self hosted, bare metal runners.

## Why is this needed

Faster builds/results especially for the iPXE builds.

## How Has This Been Tested?

GitHub Actions

## How are existing users impacted? What migration steps/scripts do we need?

Faster test cycles

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
