### PR TITLE
CI: Run tests and builds in two parallel jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: For each commit and PR
+name: Test and Build Images Each Commit and PR
 on:
   push:
   pull_request:
@@ -30,7 +30,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15.5"
+          go-version: 1.15.5
 
       - name: Generate all files
         run: nix-shell --run 'make gen'
@@ -52,6 +52,37 @@ jobs:
 
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
+
+  images:
+    runs-on: [self-hosted, X64]
+    env:
+      CGO_ENABLED: 0
+    steps:
+      - name: Setup Dynamic Env
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Install nix
+        uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.4.1
+
+      - name: Generate all files
+        run: nix-shell --run 'make gen'
 
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Install nix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,40 +12,54 @@ jobs:
       - name: Setup Dynamic Env
         run: |
           echo "MAKEFLAGS=-j$(nproc)" | tee $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           lfs: true
+
       - name: Install nix
         uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.15.5"
+
       - name: Generate all files
         run: nix-shell --run 'make gen'
+
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+
       - name: go vet
         run: go vet ./...
+
       - name: golangci-lint brought to you by Nix
         run: nix-shell --run 'GOROOT= golangci-lint run -v -D errcheck'
+
       - name: go test
         run: go test -v ./... -gcflags=-l
+
       - name: go test coverage
         run: go test -coverprofile=coverage.txt ./... -gcflags=-l
+
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
+
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'
+
       - name: Docker Image Tag for Sha
         id: docker-image-tag
         run: |
           echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
+
       - name: Login to quay.io
         uses: docker/login-action@v1
         if: ${{ startsWith(github.ref, 'refs/heads/master') }}
@@ -53,6 +67,7 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: quay.io/tinkerbell/boots
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
## Description

Split ci.yaml so build and tests are two different jobs to get some better parallelism.

## Why is this needed

Hopefully makes builds a little faster (iPXE build still takes up most of the time though :( ).

## How Has This Been Tested?

CI

## How are existing users impacted? What migration steps/scripts do we need?

NA

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
