### PR TITLE
Update vmware installer:

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -377,7 +377,7 @@ func vmnic(j job.Job) string {
 }
 
 func rootpw(j job.Job) string {
-	return j.CryptedPassword()
+	return j.GetPasswordHash()
 }
 
 // We do not support anything other than ESXi 6.5 and above (os slug "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0" etc)

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -89,6 +89,14 @@ func (j Job) CryptedPassword() string {
 	return ""
 }
 
+// GetPasswordHash returns the password hash or an empty string from the job instance
+func (j Job) GetPasswordHash() string {
+	if j.instance != nil {
+		return j.instance.PasswordHash
+	}
+	return ""
+}
+
 func (j Job) OperatingSystem() *packet.OperatingSystem {
 	if i := j.instance; i != nil {
 		if i.Rescue {

--- a/job/helpers_test.go
+++ b/job/helpers_test.go
@@ -1,0 +1,49 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tinkerbell/boots/packet"
+)
+
+func TestGetPasswordHash(t *testing.T) {
+	tests := map[string]struct {
+		input Job
+		want  string
+	}{
+		"job instance is nil": {input: Job{}, want: ""},
+		"password hash has a value": {input: Job{instance: &packet.Instance{PasswordHash: "supersecret"}}, want: "supersecret"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.input.GetPasswordHash()
+			diff := cmp.Diff(tc.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+
+func TestCryptedPassword(t *testing.T) {
+	tests := map[string]struct {
+		input Job
+		want  string
+	}{
+		"job instance is nil": {input: Job{}, want: ""},
+		"CryptedRootPassword has a value": {input: Job{instance: &packet.Instance{CryptedRootPassword: "supersecret"}}, want: "supersecret"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.input.CryptedPassword()
+			diff := cmp.Diff(tc.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}

--- a/job/helpers_test.go
+++ b/job/helpers_test.go
@@ -12,7 +12,7 @@ func TestGetPasswordHash(t *testing.T) {
 		input Job
 		want  string
 	}{
-		"job instance is nil": {input: Job{}, want: ""},
+		"job instance is nil":       {input: Job{}, want: ""},
 		"password hash has a value": {input: Job{instance: &packet.Instance{PasswordHash: "supersecret"}}, want: "supersecret"},
 	}
 
@@ -27,13 +27,12 @@ func TestGetPasswordHash(t *testing.T) {
 	}
 }
 
-
 func TestCryptedPassword(t *testing.T) {
 	tests := map[string]struct {
 		input Job
 		want  string
 	}{
-		"job instance is nil": {input: Job{}, want: ""},
+		"job instance is nil":             {input: Job{}, want: ""},
 		"CryptedRootPassword has a value": {input: Job{instance: &packet.Instance{CryptedRootPassword: "supersecret"}}, want: "supersecret"},
 	}
 

--- a/job/mock.go
+++ b/job/mock.go
@@ -111,6 +111,7 @@ func (m *Mock) SetOSImageTag(tag string) {
 
 func (m *Mock) SetPassword(password string) {
 	m.instance.CryptedRootPassword = "insecure"
+	m.instance.PasswordHash = "insecure"
 }
 
 func (m *Mock) SetState(state string) {

--- a/packet/models.go
+++ b/packet/models.go
@@ -119,6 +119,8 @@ type Instance struct {
 
 	// Only returned in the first 24 hours
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`
+	// Same as CryptedRootPassword. sorry, not my choice. i just work here
+	PasswordHash string `json:"password_hash,omitempty"`
 
 	Tags []string `json:"tags,omitempty"`
 	// Project


### PR DESCRIPTION
## Description

Have the vmware boots installer use a new `PasswordHash` field for its root password.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
