### PR TITLE
docs: answer 'is it safe?' question for local networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This services handles DHCP, PXE, tftp, and iPXE for provisions.
 This repository is [Experimental](https://github.com/packethost/standards/blob/master/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style!
 This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.
 
+## Running Boots
+
+As boots runs a DHCP server, it's often asked if it is safe to run without any network isolation; the answer is yes. While boots does run a DHCP server, it only allocates an IP address when it recognizes the mac address of the requesting device.
+
 ### Local Setup
 
 First, you need to make sure you have [git-lfs](https://github.com/git-lfs/git-lfs/wiki/Installation) installed:


### PR DESCRIPTION
## Description

Add helper description to README to assure people that running boots on their local networks is OK

closes #10

## Why is this needed

I was curious if this would be a problem and happened to find Alex's issue about the same thing.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
