### PR TITLE
fix: ensure nix-shell works with Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ Build/Run Boots
 You can use NixOS shell, which will have the Git-LFS, Go and others
 
 `nix-shell`
-
-Note: for mac users, you will need to comment out the line `pkgsCross.aarch64-multiplatform.buildPackages.gcc` in order for the build to work

--- a/shell.nix
+++ b/shell.nix
@@ -18,10 +18,12 @@ mkShell {
     golangci-lint
     nixfmt
     nodePackages.prettier
-    pkgsCross.aarch64-multiplatform.buildPackages.gcc
     protobuf
     shfmt
     shellcheck
     xz
-  ];
+  ] ++ (if pkgs.stdenv.isDarwin then
+    [ ]
+  else
+    [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ]);
 }

--- a/shell.nix
+++ b/shell.nix
@@ -22,8 +22,6 @@ mkShell {
     shfmt
     shellcheck
     xz
-  ] ++ (if pkgs.stdenv.isDarwin then
-    [ ]
-  else
-    [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ]);
+  ] ++ lib.optionals stdenv.isLinux
+    [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ];
 }


### PR DESCRIPTION
## Description

This change allows `nix-shell` to work on Linux and macOS, without changes.

## Why is this needed

Currently, the `README.md` suggests macOS users should modify the `shell.nix` file to get it to work.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
