### PR TITLE
boots/ipxe/ipxe/common.h: enable ipxe sanboot http and VLAN

### DIFF
--- a/ipxe/ipxe/common.h
+++ b/ipxe/ipxe/common.h
@@ -7,7 +7,7 @@
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
 #define REBOOT_CMD            /* Reboot command */
-define VLAN_CMD              /* VLAN commands */
+#define VLAN_CMD              /* VLAN commands */
 
 #undef CRYPTO_80211_WEP       /* WEP encryption (deprecated and insecure!) */
 #undef CRYPTO_80211_WPA2      /* Add support for stronger WPA cryptography */
@@ -25,7 +25,7 @@ define VLAN_CMD              /* VLAN commands */
 //defined in config/defaults/{efi,pcbios}.h and we don't want
 #undef SANBOOT_PROTO_AOE      /* AoE protocol */
 #undef SANBOOT_PROTO_FCP      /* Fibre Channel protocol */
-undef SANBOOT_PROTO_HTTP     /* HTTP SAN protocol */
+//#undef SANBOOT_PROTO_HTTP     /* HTTP SAN protocol */
 #undef SANBOOT_PROTO_IB_SRP   /* Infiniband SCSI RDMA protocol */
 #undef SANBOOT_PROTO_ISCSI    /* iSCSI protocol */
 #undef USB_EFI                /* Provide EFI_USB_IO_PROTOCOL interface */

--- a/ipxe/ipxe/common.h
+++ b/ipxe/ipxe/common.h
@@ -7,7 +7,7 @@
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
 #define REBOOT_CMD            /* Reboot command */
-#define VLAN_CMD              /* VLAN commands */
+define VLAN_CMD              /* VLAN commands */
 
 #undef CRYPTO_80211_WEP       /* WEP encryption (deprecated and insecure!) */
 #undef CRYPTO_80211_WPA2      /* Add support for stronger WPA cryptography */
@@ -25,7 +25,7 @@
 //defined in config/defaults/{efi,pcbios}.h and we don't want
 #undef SANBOOT_PROTO_AOE      /* AoE protocol */
 #undef SANBOOT_PROTO_FCP      /* Fibre Channel protocol */
-#undef SANBOOT_PROTO_HTTP     /* HTTP SAN protocol */
+undef SANBOOT_PROTO_HTTP     /* HTTP SAN protocol */
 #undef SANBOOT_PROTO_IB_SRP   /* Infiniband SCSI RDMA protocol */
 #undef SANBOOT_PROTO_ISCSI    /* iSCSI protocol */
 #undef USB_EFI                /* Provide EFI_USB_IO_PROTOCOL interface */


### PR DESCRIPTION
## Description

* Enables iPXE `sanboot` context for [HTTP fetching](https://ipxe.org/cmd/sanboot) and booting of binary images (ISOs).
* Enables iPXE `VLAN` context, enabling for iPXE to interact with [VLAN tagged traffic](https://ipxe.org/cmd/vcreate)


## Why is this needed

* iPXE sanboot is a uniquely useful context for booting into binary images, namely ISO's
* Tinkerbell / Metal environments are *likely* to be VLAN-networking centric environments and having the iPXE namespace be VLAN aware is useful

Fixes: #

## How Has This Been Tested?
- [ ] CI



## How are existing users impacted? What migration steps/scripts do we need?

No changes to non-involved code paths/workflows should be expected. Users have to make platform / deploy choices to opt into this code path.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)