### PR TITLE
Re-enable HTTP sanboot

### DIFF
--- a/ipxe/.gitignore
+++ b/ipxe/.gitignore
@@ -1,1 +1,4 @@
 bindata.go
+bin/ipxe.efi
+bin/snp-nolacp.efi
+bin/undionly.kpxe

--- a/ipxe/bin/.gitignore
+++ b/ipxe/bin/.gitignore
@@ -1,3 +1,0 @@
-ipxe.efi
-snp-nolacp.efi
-undionly.kpxe

--- a/ipxe/ipxe/common.h
+++ b/ipxe/ipxe/common.h
@@ -7,6 +7,7 @@
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
 #define REBOOT_CMD            /* Reboot command */
+#define SANBOOT_PROTO_HTTP    /* HTTP SAN protocol */
 #define VLAN_CMD              /* VLAN commands */
 
 #undef CRYPTO_80211_WEP       /* WEP encryption (deprecated and insecure!) */
@@ -25,7 +26,6 @@
 //defined in config/defaults/{efi,pcbios}.h and we don't want
 #undef SANBOOT_PROTO_AOE      /* AoE protocol */
 #undef SANBOOT_PROTO_FCP      /* Fibre Channel protocol */
-#undef SANBOOT_PROTO_HTTP     /* HTTP SAN protocol */
 #undef SANBOOT_PROTO_IB_SRP   /* Infiniband SCSI RDMA protocol */
 #undef SANBOOT_PROTO_ISCSI    /* iSCSI protocol */
 #undef USB_EFI                /* Provide EFI_USB_IO_PROTOCOL interface */


### PR DESCRIPTION
## Description

Explicitly enable HTTP sanboot per #157

## Why is this needed

It seems that the binaries stored in git-lfs likely were built with sanboot enabled and apparently some people seem to have been depending on that functionality.

Fixes: #157

## How Has This Been Tested?
I manually booted qemu, had it chainload to `undionly.kpxe`, and verified that I could drop to the ipxe shell and run
```
dhcp
sanboot http://boot.ipxe.org/freedos/fdfullcd.iso
``` 

## How are existing users impacted? What migration steps/scripts do we need?

Fixes #157

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade