### PR TITLE
Automated test of ipxe config to confirm sanboot functionality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
         run: nix-shell --run 'GOROOT= golangci-lint run -v -D errcheck'
       - name: go test
         run: go test -v ./... -gcflags=-l
+      - name: Run iPXE tests
+        run: nix-shell --run 'make test-ipxe'
       - name: go test coverage
         run: go test -coverprofile=coverage.txt ./... -gcflags=-l
       - name: upload codecov

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ image: cmd/boots/boots-linux-amd64 ## Build docker image
 test: gen ## Run go test
 	CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic -gcflags=-l ${TEST_ARGS} ./...
 
+test-ipxe: ipxe/tests ## Run iPXE feature tests
+
 coverage: test ## Show test coverage
 	go tool cover -func=coverage.txt
 

--- a/ipxe/ipxe/build.sh
+++ b/ipxe/ipxe/build.sh
@@ -15,7 +15,7 @@ sed -i '/#define OCSP_CHECK/ d' "$topdir/src/config/crypto.h"
 
 set -x
 case $build in
-bin/undionly.kpxe)
+bin/undionly.kpxe | bin/ipxe.lkrn)
 	rm "$topdir/src/config/local/isa.h"
 	cp "$topdir/src/config/local/general.undionly.h" "$topdir/src/config/local/general.h"
 	;;

--- a/ipxe/test/sanboot.expect
+++ b/ipxe/test/sanboot.expect
@@ -1,0 +1,18 @@
+set timeout 30
+set kernel [lindex $argv 0]
+set tftpdir [lindex $argv 1]
+spawn qemu-system-x86_64 -nographic -m 512 -smp 1 \
+-kernel $kernel \
+-net nic,model=virtio \
+-net user,tftp=$tftpdir,bootfile=sanboot.pxe \
+
+expect {
+  "ISOLINUX" {
+    exit 0
+  }
+  "Operation not supported" {
+    exit 1
+  }
+}
+
+exit 1

--- a/ipxe/test/sanboot.pxe
+++ b/ipxe/test/sanboot.pxe
@@ -1,0 +1,3 @@
+#!ipxe
+echo sanboot http://boot.ipxe.org/freedos/fdfullcd.iso
+sanboot http://boot.ipxe.org/freedos/fdfullcd.iso

--- a/rules.mk
+++ b/rules.mk
@@ -77,13 +77,19 @@ ipxe/ipxe/build/${ipxev}.tar.gz: ipxev.mk ## Download iPXE source tarball
 # given  t=$(patsubst ipxe/ipxe/build/%,%,$@)
 # and   $@=ipxe/ipxe/build/*/*
 # t       =                */*
-ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe: ipxe/ipxe/build/${ipxev}.tar.gz ipxe/ipxe/build.sh ${ipxeconfigs}
+ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe ipxe/ipxe/build/bin/ipxe.lkrn: ipxe/ipxe/build/${ipxev}.tar.gz ipxe/ipxe/build.sh ${ipxeconfigs}
 	+t=$(patsubst ipxe/ipxe/build/%,%,$@)
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	tar -xzf $< -C $(@D)
 	cp ${ipxeconfigs} $(@D)
 	cd $(@D) && ../../build.sh $$t ${ipxev}
+
+.PHONY: ipxe/tests ipxe/test-%
+ipxe/tests: ipxe/test-sanboot
+# order of dependencies matters here
+ipxe/test-%: ipxe/test/%.expect ipxe/ipxe/build/bin/ipxe.lkrn ipxe/test/ ipxe/test/%.pxe
+	expect -f $^
 
 OSFLAG:= $(shell go env GOHOSTOS)
 # Build and generate embedded iPXE binaries based on OS

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ with pkgs;
 mkShell {
   buildInputs = [
     curl
+    expect
     gcc
     git
     git-lfs
@@ -22,8 +23,9 @@ mkShell {
     nodePackages.prettier
     perl
     protobuf
-    shfmt
+    qemu
     shellcheck
+    shfmt
     xz
   ] ++ lib.optionals stdenv.isLinux
     [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ];


### PR DESCRIPTION
## Description

While this doesn't directly exercise the ipxe binaries we bake into boots,
it does use the ipxe configs to build an `ipxe.lkrn` binary to use for testing features.
This test uses expect and qemu to exercise the sanboot feature.

## Why is this needed

Related to #157

## How Has This Been Tested?

`make test-sanboot` succeeds.
Additionally, cherry-picking this commit onto 5d563d8 fails as expected.

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade