### PR TITLE
Fix password look up to look in both possible locations

### DIFF
--- a/installers/nixos/main.go
+++ b/installers/nixos/main.go
@@ -85,7 +85,7 @@ func kernelParams(j job.Job, s *ipxe.Script, init string) {
 		s.Args("console=ttyS1,115200")
 	}
 	s.Args("loglevel=7")
-	if j.CryptedPassword() != "" {
-		s.Args("pwhash=" + j.CryptedPassword())
+	if j.PasswordHash() != "" {
+		s.Args("pwhash=" + j.PasswordHash())
 	}
 }

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -114,8 +114,8 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 			s.Args("slug=" + slug)
 		}
 
-		if j.CryptedPassword() != "" {
-			s.Args("pwhash=" + j.CryptedPassword())
+		if j.PasswordHash() != "" {
+			s.Args("pwhash=" + j.PasswordHash())
 		}
 	}
 

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -377,7 +377,7 @@ func vmnic(j job.Job) string {
 }
 
 func rootpw(j job.Job) string {
-	return j.GetPasswordHash()
+	return j.PasswordHash()
 }
 
 // We do not support anything other than ESXi 6.5 and above (os slug "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0" etc)

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -89,12 +89,17 @@ func (j Job) CryptedPassword() string {
 	return ""
 }
 
-// PasswordHash returns the password hash or an empty string from the job instance
+// PasswordHash will return the password hash from the job instance if it exists
+// PasswordHash first tries returning CryptedRootPassword if it exists and falls back to returning PasswordHash
 func (j Job) PasswordHash() string {
-	if j.instance != nil {
-		return j.instance.PasswordHash
+	if j.instance == nil {
+		return ""
 	}
-	return ""
+	// TODO: remove this EMism
+	if j.instance.CryptedRootPassword != "" {
+		return j.instance.CryptedRootPassword
+	}
+	return j.instance.PasswordHash
 }
 
 func (j Job) OperatingSystem() *packet.OperatingSystem {

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -82,13 +82,6 @@ func (j Job) InstanceIPs() []packet.IP {
 	return nil
 }
 
-func (j Job) CryptedPassword() string {
-	if j.instance != nil {
-		return j.instance.CryptedRootPassword
-	}
-	return ""
-}
-
 // PasswordHash will return the password hash from the job instance if it exists
 // PasswordHash first tries returning CryptedRootPassword if it exists and falls back to returning PasswordHash
 func (j Job) PasswordHash() string {

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -89,8 +89,8 @@ func (j Job) CryptedPassword() string {
 	return ""
 }
 
-// GetPasswordHash returns the password hash or an empty string from the job instance
-func (j Job) GetPasswordHash() string {
+// PasswordHash returns the password hash or an empty string from the job instance
+func (j Job) PasswordHash() string {
 	if j.instance != nil {
 		return j.instance.PasswordHash
 	}

--- a/job/helpers_test.go
+++ b/job/helpers_test.go
@@ -12,8 +12,35 @@ func TestPasswordHash(t *testing.T) {
 		input Job
 		want  string
 	}{
-		"job instance is nil":       {input: Job{}, want: ""},
-		"password hash has a value": {input: Job{instance: &packet.Instance{PasswordHash: "supersecret"}}, want: "supersecret"},
+		"job instance is nil": {
+			want:  "",
+			input: Job{},
+		},
+		"only CryptedRootPassword is populated": {
+			want: "supersecret",
+			input: Job{
+				instance: &packet.Instance{
+					CryptedRootPassword: "supersecret",
+				},
+			},
+		},
+		"only PasswordHash is populated": {
+			want: "supersecret",
+			input: Job{
+				instance: &packet.Instance{
+					PasswordHash: "supersecret",
+				},
+			},
+		},
+		"CryptedRootPassword is preferred over PasswordHash": {
+			want: "cryptedrootpassword",
+			input: Job{
+				instance: &packet.Instance{
+					CryptedRootPassword: "cryptedrootpassword",
+					PasswordHash:        "passwordhash",
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/job/helpers_test.go
+++ b/job/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tinkerbell/boots/packet"
 )
 
-func TestGetPasswordHash(t *testing.T) {
+func TestPasswordHash(t *testing.T) {
 	tests := map[string]struct {
 		input Job
 		want  string
@@ -18,7 +18,7 @@ func TestGetPasswordHash(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := tc.input.GetPasswordHash()
+			got := tc.input.PasswordHash()
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
 				t.Fatalf(diff)

--- a/job/helpers_test.go
+++ b/job/helpers_test.go
@@ -53,23 +53,3 @@ func TestPasswordHash(t *testing.T) {
 		})
 	}
 }
-
-func TestCryptedPassword(t *testing.T) {
-	tests := map[string]struct {
-		input Job
-		want  string
-	}{
-		"job instance is nil":             {input: Job{}, want: ""},
-		"CryptedRootPassword has a value": {input: Job{instance: &packet.Instance{CryptedRootPassword: "supersecret"}}, want: "supersecret"},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := tc.input.CryptedPassword()
-			diff := cmp.Diff(tc.want, got)
-			if diff != "" {
-				t.Fatalf(diff)
-			}
-		})
-	}
-}

--- a/packet/models.go
+++ b/packet/models.go
@@ -117,9 +117,11 @@ type Instance struct {
 	UserData        string           `json:"userdata,omitempty"`
 	servicesVersion ServicesVersion
 
-	// Only returned in the first 24 hours
+	// Same as PasswordHash
+	// Duplicated here, because CryptedRootPassword is in cacher/legacy mode
+	// which is soon to go away as Tinkerbell/PasswordHash is the future
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`
-	// Same as CryptedRootPassword. sorry, not my choice. i just work here
+	// Only returned in the first 24 hours of a provision
 	PasswordHash string `json:"password_hash,omitempty"`
 
 	Tags []string `json:"tags,omitempty"`


### PR DESCRIPTION
## Description

Combines the 2 separate password getters (CryptedRootPassword and GetPasswordHash) into just one (PasswordHash).

## Why is this needed

Deploying without this breaks the legacy production system for ESXi deployments. The vmware
installer was changed to grab the password from where we'd expect it in tinkerbell mode only.

## How Has This Been Tested?

Unit tests.
