### PR TITLE
Add support for VMWare VCF on ESXi 6.x and 7.x

### DIFF
--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -12,6 +12,9 @@ func init() {
 	job.RegisterSlug("vmware_esxi_6_5", bootScriptVmwareEsxi65)
 	job.RegisterSlug("vmware_esxi_6_7", bootScriptVmwareEsxi67)
 	job.RegisterSlug("vmware_esxi_7_0", bootScriptVmwareEsxi70)
+	job.RegisterSlug("vmware_esxi_6_5_vcf", bootScriptVmwareEsxi65)
+	job.RegisterSlug("vmware_esxi_6_7_vcf", bootScriptVmwareEsxi67)
+	job.RegisterSlug("vmware_esxi_7_0_vcf", bootScriptVmwareEsxi70)
 	job.RegisterDistro("vmware", bootScriptDefault)
 }
 


### PR DESCRIPTION
## Description

Enable a VCF specific install path in a future merge

## Why is this needed

Expanding new network modes via VMWare ESXi

Fixes: #

## How Has This Been Tested?
Untested. Need API support to test.


## How are existing users impacted? What migration steps/scripts do we need?

Un-used code path until enabled by an API


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
