### PR TITLE
Build IPXE on darwin easier:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: help
 
 boots: cmd/boots/boots ## Compile boots for host OS and Architecture
 
-bindata: ipxe/bindata.go ## Build and generate embedded iPXE binaries
+bindata: bindata_by_os ## Build and generate embedded iPXE binaries
 
 crosscompile: $(crossbinaries) ## Compile boots for all architectures
 	

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -104,7 +104,6 @@ The IPXE binaries are built from source and then embedded into the Boots Go bina
 
 ### Building the IPXE binary
 
-The scripts in this repo to build the IPXE binaries only work on Linux.
 The IPXE binaries from [https://github.com/ipxe/ipxe](https://github.com/ipxe/ipxe) are built via a Make target.
 
 ```make

--- a/rules.mk
+++ b/rules.mk
@@ -84,3 +84,14 @@ ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ip
 	tar -xzf $< -C $(@D)
 	cp ${ipxeconfigs} $(@D)
 	cd $(@D) && ../../build.sh $$t ${ipxev}
+
+OSFLAG:= $(shell go env GOHOSTOS)
+# Build and generate embedded iPXE binaries based on OS
+bindata_by_os:
+ifeq (${OSFLAG},darwin)
+	rm -rf bin/go-bindata bin/goimports
+	docker run -it --rm -v ${PWD}:/code -w /code nixos/nix nix-shell --command "make ipxe/bindata.go"
+	rm -rf bin/go-bindata bin/goimports
+else
+	@$(MAKE) ipxe/bindata.go
+endif

--- a/shell.nix
+++ b/shell.nix
@@ -11,13 +11,16 @@ with pkgs;
 
 mkShell {
   buildInputs = [
+    curl
     gcc
+    git
     git-lfs
     gnumake
     go
     golangci-lint
     nixfmt
     nodePackages.prettier
+    perl
     protobuf
     shfmt
     shellcheck


### PR DESCRIPTION
## Description

Currently building IPXE on a Mac is difficult and almost entirely manual, if not impossible even with the nix shell.nix.
This will leverage docker to make building IPXE on Mac just as easy as on Linux with the `make bindata` target call.

## Why is this needed

Building iPXE on Mac seems to not be a straightforward process.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
