### PR TITLE
EM specific: VMware installer should respect boot_drive_hint for --firstdisk

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -3,6 +3,7 @@ package vmware
 import (
 	"io"
 	"net/http"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -384,6 +385,10 @@ func rootpw(j job.Job) string {
 // We do not support anything other than ESXi 6.5 and above (os slug "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0" etc)
 // full list of drive settings is listed https://packet.atlassian.net/browse/SWE-2385
 func determineDisk(j job.Job) string {
+	// currently limited to storage plans remove '&&.*"s")' to apply across all plans
+	if j.BootDriveHint() != "" && strings.HasPrefix(j.PlanSlug(), "s") {
+		return "--firstdisk=" + j.BootDriveHint()
+	}
 	switch j.PlanSlug() {
 	case "c1.small.x86",
 		"s1.large.x86",

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -27,6 +27,7 @@ func TestDetermineDisk(t *testing.T) {
 func TestScriptKickstart(t *testing.T) {
 	manufacturers := []string{"supermicro", "dell"}
 	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0"}
+	drive_hints := []string{"", "ST3120814A,mptsas,local"}
 	assert := require.New(t)
 	conf.PublicIPv4 = net.ParseIP("127.0.0.1")
 	conf.PublicFQDN = "boots-test.example.com"
@@ -35,20 +36,34 @@ func TestScriptKickstart(t *testing.T) {
 		t.Run(man, func(t *testing.T) {
 			for _, ver := range versions {
 				t.Run(ver, func(t *testing.T) {
-					for typ, disk := range kickstartTypes {
-						t.Run(typ, func(t *testing.T) {
-							m := job.NewMock(t, typ, facility)
-							m.SetManufacturer(man)
-							m.SetOSSlug(ver)
-							m.SetIP(net.ParseIP("127.0.0.1"))
-							m.SetPassword("password")
-							m.SetMAC("00:00:ba:dd:be:ef")
+					for _, driveHint := range drive_hints {
+						t.Run(driveHint, func(t *testing.T) {
+							for typ, disk := range kickstartTypes {
+								t.Run(typ, func(t *testing.T) {
+									m := job.NewMock(t, typ, facility)
+									m.SetManufacturer(man)
+									m.SetOSSlug(ver)
+									m.SetIP(net.ParseIP("127.0.0.1"))
+									m.SetPassword("password")
+									m.SetMAC("00:00:ba:dd:be:ef")
+									// Set the hint
+									if driveHint != "" {
+										m.SetBootDriveHint(driveHint)
+									}
+									// expect the hint
+									//   currently limited to storage plans
+									//   remove '&&.*"s")' to apply across all plans
+									if driveHint != "" && strings.HasPrefix(typ, "s") {
+										disk = "--firstdisk=" + driveHint
+									}
 
-							var w strings.Builder
-							genKickstart(m.Job(), &w)
-							got := w.String()
-							script := loadKickstart(disk, assert)
-							assert.Equal(script, got, diff.LineDiff(script, got))
+									var w strings.Builder
+									genKickstart(m.Job(), &w)
+									got := w.String()
+									script := loadKickstart(disk, assert)
+									assert.Equal(script, got, diff.LineDiff(script, got))
+								})
+							}
 						})
 					}
 				})

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -30,6 +30,13 @@ func (j Job) Arch() string {
 	return ""
 }
 
+func (j Job) BootDriveHint() string {
+	if i := j.instance; i != nil {
+		return i.BootDriveHint
+	}
+	return ""
+}
+
 func (j Job) PArch() string {
 	var parch string
 

--- a/job/mock.go
+++ b/job/mock.go
@@ -120,6 +120,10 @@ func (m *Mock) SetState(state string) {
 	h.State = packet.HardwareState(state)
 }
 
+func (m *Mock) SetBootDriveHint(drive string) {
+	m.instance.BootDriveHint = drive
+}
+
 func MakeHardwareWithInstance() (*packet.DiscoveryCacher, []packet.MACAddr, string) {
 	macIPMI := packet.MACAddr([6]byte{0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00})
 	mac0 := packet.MACAddr([6]byte{0x00, 0xBA, 0xDD, 0xBE, 0xEF, 0x00})

--- a/packet/models.go
+++ b/packet/models.go
@@ -129,6 +129,8 @@ type Instance struct {
 	SSHKeys []string `json:"ssh_keys,omitempty"`
 	// CustomData
 	NetworkReady bool `json:"network_ready,omitempty"`
+	// BootDriveHint defines what the VMware installer should pass as the argument to "--firstdisk=".
+	BootDriveHint string `json:"boot_drive_hint,omitempty"`
 }
 
 // Device Full device result from /devices endpoint


### PR DESCRIPTION
## Description

When installing VMware, it can be helpful to provide a detailed hint as to which disk the VMware installer should use.
This commit adds support for `instance.boot_drive_hint` in the hardware metadata which will be read when generating the VMware kickstart file.

## Why is this needed

On some of our hardware types (our storage nodes in particular) the VMware installer will sometimes choose the wrong disk. Providing a better hint to the installer should prevent those issues.

Fixes: Internal ticket: PROV-16

## How Has This Been Tested?

- [x] Updated unit tests show that this works as expected
- [x] Manual retrieval of the kickstart file when running in a sandbox both with and without the `boot_drive_hint` also works as expected.

## How are existing users impacted? What migration steps/scripts do we need?

This currently only affects hardware whose plan slug starts with "s" which corresponds to EM storage hardware nodes.

To change that to affect all plans
```shell
git grep -l -E '& strings.HasPrefix(.*, "s")' | xargs sed -e 's|&& strings.HasPrefix(.*, "s") ||' -i
```
and verify that tests still pass and clean up any errors (e.g. unused import of "strings")

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade