### PR TITLE
vmware: Add a pause in pre-install to quell network devices

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -363,6 +363,7 @@ sleep 20
 BOOTOPTIONS=$(/sbin/bootOption -o)
 echo $BOOTOPTIONS > /cmdline-bootoption
 echo $BOOTOPTIONS > /tmp/pre-bootoptions
+sleep 30
 `)
 
 var helpers = template.FuncMap{


### PR DESCRIPTION
## Description

Adding a sleep to allow network devices to settle

## Why is this needed

We see a lot of install failures that look to be network interface not settling fast enough

Fixes: #

## How Has This Been Tested?
Custom iPXE test deploy

## How are existing users impacted? What migration steps/scripts do we need?

30 sec longer install time

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
