### PR TITLE
Add Docker Buildx back into the ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
         uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
       - name: Install Go


### PR DESCRIPTION
## Description

Fix the docker-buildx ci workflow. This is a revert of one of the changes in #148.

## Why is this needed

#165 fails to build without this change
#159's build is also failing, likely for the same reason. 
Also #126 is probably blocked for the same reason...

## How Has This Been Tested?

Applied this commit to #165 and the builds then succeeded.