### PR TITLE
log discovery requests

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -74,7 +74,7 @@ func main() {
 		mainlog.With("envvar", "API_AUTH_TOKEN").Fatal(err)
 		panic(err)
 	}
-	client, err = packet.NewClient(consumer, auth, apiBaseURL)
+	client, err = packet.NewClient(l, consumer, auth, apiBaseURL)
 	if err != nil {
 		mainlog.Fatal(err)
 	}

--- a/packet/client.go
+++ b/packet/client.go
@@ -13,6 +13,7 @@ import (
 
 	cacherClient "github.com/packethost/cacher/client"
 	"github.com/packethost/pkg/env"
+	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/httplog"
 	tinkClient "github.com/tinkerbell/tink/client"
@@ -52,9 +53,10 @@ type client struct {
 	authToken      string
 	hardwareClient hardwareGetter
 	workflowClient tw.WorkflowServiceClient
+	logger         log.Logger
 }
 
-func NewClient(consumerToken, authToken string, baseURL *url.URL) (Client, error) {
+func NewClient(logger log.Logger, consumerToken, authToken string, baseURL *url.URL) (Client, error) {
 	t, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		return nil, errors.New("unexpected type for http.DefaultTransport")
@@ -136,6 +138,7 @@ func NewClient(consumerToken, authToken string, baseURL *url.URL) (Client, error
 		authToken:      authToken,
 		hardwareClient: hg,
 		workflowClient: wg,
+		logger:         logger,
 	}, nil
 }
 

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -166,6 +166,8 @@ func (c *client) ReportDiscovery(ctx context.Context, mac net.HardwareAddr, giad
 		return nil, errors.Wrap(err, "unmarshalling api discovery")
 	}
 
+	c.logger.With("giaddr", req.GIADDR, "mac", req.MAC).Debug("hardware discovery by mac")
+
 	var res DiscoveryCacher
 	if err := c.Post(ctx, "/staff/cacher/hardware-discovery", mimeJSON, bytes.NewReader(b), &res); err != nil {
 		return nil, err

--- a/packet/endpoints_test.go
+++ b/packet/endpoints_test.go
@@ -29,6 +29,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestDiscoverHardwareFromDHCP(t *testing.T) {
+	logger, _ := log.Init("tests")
+
 	for _, test := range []struct {
 		name      string
 		err       error
@@ -79,6 +81,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 				baseURL:        u,
 				http:           s.Client(),
 				hardwareClient: cMock,
+				logger:         logger,
 			}
 			m, _ := net.ParseMAC("00:00:ba:dd:be:ef")
 			d, err := c.DiscoverHardwareFromDHCP(context.Background(), m, net.ParseIP("127.0.0.1"), "")


### PR DESCRIPTION
Discovery requests call an external service, by logging this, it's
easier to track a request when it takes this path.