### PR TITLE
Use builtin go embed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,11 @@ jobs:
         with:
           go-version: "1.16.3"
       - name: Generate all files
-        run: nix-shell --run 'make gen'
+        run: nix-shell --run 'make gen && make ipxe'
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
       - name: go vet
-        run: go vet ./...
+        run: go mod tidy && go vet ./...
       - name: golangci-lint brought to you by Nix
         run: nix-shell --run 'GOROOT= golangci-lint run -v -D errcheck'
       - name: go test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15.5"
+          go-version: "1.16.3"
       - name: Generate all files
         run: nix-shell --run 'make gen'
       - name: goimports

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /cmd/boots/boots
 /cmd/boots/boots-*-*
 coverage.txt
+tftp/ipxe/
+

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: help
 
 boots: cmd/boots/boots ## Compile boots for host OS and Architecture
 
-bindata: bindata_by_os ## Build and generate embedded iPXE binaries
+ipxe: build_all_ipxe ## Build all iPXE binaries 
 
 crosscompile: $(crossbinaries) ## Compile boots for all architectures
 	

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinkerbell/boots
 
-go 1.13
+go 1.16
 
 require (
 	bou.ke/monkey v1.0.2

--- a/ipxe/ipxe.go
+++ b/ipxe/ipxe.go
@@ -1,3 +1,0 @@
-package ipxe
-
-//go:generate go-bindata -pkg ipxe -o bindata.go bin/

--- a/ipxe/ipxe/build.sh
+++ b/ipxe/ipxe/build.sh
@@ -15,9 +15,14 @@ sed -i '/#define OCSP_CHECK/ d' "$topdir/src/config/crypto.h"
 
 set -x
 case $build in
-bin/undionly.kpxe | bin/ipxe.lkrn)
+bin/undionly.kpxe)
 	rm "$topdir/src/config/local/isa.h"
 	cp "$topdir/src/config/local/general.undionly.h" "$topdir/src/config/local/general.h"
+	;;
+bin-test/ipxe.lkrn)
+	rm "$topdir/src/config/local/isa.h"
+	cp "$topdir/src/config/local/general.undionly.h" "$topdir/src/config/local/general.h"
+	build=bin/ipxe.lkrn
 	;;
 bin-x86_64-efi/ipxe.efi)
 	cp "$topdir/src/config/local/general.efi.h" "$topdir/src/config/local/general.h"

--- a/rules.mk
+++ b/rules.mk
@@ -88,9 +88,9 @@ ipxe/ipxe/build/${ipxev}.tar.gz: ipxev.mk ## Download iPXE source tarball
 # and   $@=ipxe/ipxe/build/*/*
 # t       =                */*
 OSFLAG:= $(shell go env GOHOSTOS)
-ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe ipxe/ipxe/build/bin/ipxe.lkrn: ipxe/ipxe/build/${ipxev}.tar.gz ipxe/ipxe/build.sh ${ipxeconfigs}
+ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe ipxe/ipxe/build/bin-test/ipxe.lkrn: ipxe/ipxe/build/${ipxev}.tar.gz ipxe/ipxe/build.sh ${ipxeconfigs}
 ifeq (${OSFLAG},darwin)
-	docker run -it --rm -v ${PWD}:/code -w /code nixos/nix nix-shell --command "make ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe ipxe/ipxe/build/bin/ipxe.lkrn"
+	docker run -it --rm -v ${PWD}:/code -w /code nixos/nix nix-shell --command "make -j2 ipxe/ipxe/build/bin-arm64-efi/snp.efi ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi ipxe/ipxe/build/bin/undionly.kpxe ipxe/ipxe/build/bin-test/ipxe.lkrn"
 else
 	+t=$(patsubst ipxe/ipxe/build/%,%,$@)
 	rm -rf $(@D)
@@ -103,5 +103,5 @@ endif
 .PHONY: ipxe/tests ipxe/test-%
 ipxe/tests: ipxe/test-sanboot
 # order of dependencies matters here
-ipxe/test-%: ipxe/test/%.expect ipxe/ipxe/build/bin/ipxe.lkrn ipxe/test/ ipxe/test/%.pxe
+ipxe/test-%: ipxe/test/%.expect ipxe/ipxe/build/bin-test/ipxe.lkrn ipxe/test/ ipxe/test/%.pxe
 	expect -f $^

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,19 @@ in { pkgs ? import (_pkgs.fetchFromGitHub {
 
 with pkgs;
 
-mkShell {
+let
+  custom_pkgs = import (_pkgs.fetchFromGitHub {
+    # go 1.16.3
+    owner = "NixOS";
+    repo = "nixpkgs";
+    #branch@date: nixpkgs-unstable@2021-04-19
+    rev = "c92ca95afb5043bc6faa0d526460584eccff2277";
+    sha256 = "14vmijjjypd4b3fcvxzi53n7i5g3l5x9ih0ci1j6h1m9j5fkh9iv";
+  }) { };
+
+  go_1_16_3 = custom_pkgs.go;
+
+in mkShell {
   buildInputs = [
     curl
     expect
@@ -17,7 +29,7 @@ mkShell {
     git
     git-lfs
     gnumake
-    go
+    go_1_16_3
     golangci-lint
     nixfmt
     nodePackages.prettier
@@ -30,3 +42,4 @@ mkShell {
   ] ++ lib.optionals stdenv.isLinux
     [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ];
 }
+

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -1,6 +1,7 @@
 package tftp
 
 import (
+	_ "embed"
 	"io"
 	"net"
 	"os"
@@ -8,14 +9,25 @@ import (
 
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
-	"github.com/tinkerbell/boots/ipxe"
 )
 
+//go:embed ipxe/ipxe.efi
+var ipxeEFI []byte
+
+//go:embed ipxe/undionly.kpxe
+var undionly []byte
+
+//go:embed ipxe/snp.efi
+var snpNolacp []byte
+
+//go:embed ipxe/snp-hua.efi
+var snpHua []byte
+
 var tftpFiles = map[string][]byte{
-	"undionly.kpxe":  ipxe.MustAsset("bin/undionly.kpxe"),
-	"snp-nolacp.efi": ipxe.MustAsset("bin/snp-nolacp.efi"),
-	"ipxe.efi":       ipxe.MustAsset("bin/ipxe.efi"),
-	"snp-hua.efi":    ipxe.MustAsset("bin/snp-hua.efi"),
+	"undionly.kpxe":  undionly,
+	"snp-nolacp.efi": snpNolacp,
+	"ipxe.efi":       ipxeEFI,
+	"snp-hua.efi":    snpHua,
 }
 
 type tftpTransfer struct {

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -17,7 +17,7 @@ var ipxeEFI []byte
 //go:embed ipxe/undionly.kpxe
 var undionly []byte
 
-//go:embed ipxe/snp.efi
+//go:embed ipxe/snp-nolacp.efi
 var snpNolacp []byte
 
 //go:embed ipxe/snp-hua.efi

--- a/tools.go
+++ b/tools.go
@@ -4,7 +4,6 @@ package tools
 
 import (
 	_ "github.com/golang/mock/mockgen"
-	_ "github.com/kevinburke/go-bindata/go-bindata"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/tools/cmd/stringer"
 )


### PR DESCRIPTION
## Description

This PR removes the dependency on `go-bindata` and uses the builtin `embed` package of Go >1.16.
Go is being pinned in the nix-shell because moving all the dependencies to the same rev as the Go dependency caused ipxe builds to fail.

```bash
drivers/bus/isa.c: In function 'isabus_probe':
drivers/bus/isa.c:52:4: error: array subscript [-1073741824, 1073741823] is outside array bounds of 'isa_probe_addr_t[0]' {aka 'short unsigned int[0]'} [-Werror=array-bounds]
   52 |    *( isa_extra_probe_addrs + (ioidx) + ISA_EXTRA_PROBE_ADDR_COUNT ) )
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/bus/isa.c:113:18: note: in expansion of macro 'ISA_IOADDR'
  113 |    isa->ioaddr = ISA_IOADDR ( driver, ioidx );
      |                  ^~~~~~~~~~
drivers/bus/isa.c:34:25: note: while referencing 'isa_extra_probe_addrs'
   34 | static isa_probe_addr_t isa_extra_probe_addrs[] = {
      |                         ^~~~~~~~~~~~~~~~~~~~~
  [BUILD] bin/isapnp.o
cc1: all warnings being treated as errors
make[1]: *** [Makefile.housekeeping:943: bin/isa.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/code/ipxe/ipxe/build/bin-test/ipxe-a5fb41873dc1dcce5dcc817bf53a0649c01f8cac/src'
make: *** [rules.mk:95: ipxe/ipxe/build/bin-test/ipxe.lkrn] Error 2
make: *** [rules.mk:93: ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi] Error 2
make: *** Deleting file 'ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi'
```

## Why is this needed

Simplifies embedding ipxe binaries.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
