### PR TITLE
Add OSIE secrets required by Hollow

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -33,6 +33,9 @@ var (
 
 	// Eclypsium registration token, passed into osie
 	EclypsiumToken = env.Get("ECLYPSIUM_TOKEN")
+	// Hollow auth secrets, passed into osie
+	HollowClientId            = env.Get("HOLLOW_CLIENT_ID")
+	HollowClientRequestSecret = env.Get("HOLLOW_CLIENT_REQUEST_SECRET")
 )
 
 func mustPublicIPv4() net.IP {

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -72,6 +72,12 @@ func kernelParams(action, state string, j job.Job, s *ipxe.Script) {
 	s.Args("packet_action=${action}")
 	s.Args("packet_state=${state}")
 
+	// Only provide the Hollow secrets for deprovisions
+	if j.HardwareState() == "deprovisioning" && conf.HollowClientId != "" && conf.HollowClientRequestSecret != "" {
+		s.Args("hollow_client_id=" + conf.HollowClientId)
+		s.Args("hollow_client_request_secret=" + conf.HollowClientRequestSecret)
+	}
+
 	// Don't bother including eclypsium_token if none is provided
 	if conf.EclypsiumToken != "" && j.HardwareState() == "deprovisioning" {
 		s.Args("eclypsium_token=" + conf.EclypsiumToken)


### PR DESCRIPTION
In order for OSIE to write data to Hollow, we need to use these secrets
to request a temporary auth token.
    
We recognize that Equinix Metal specific code needs to be extracted from
Boots, and are looking into general solutions that will allow users to
specify secrets or custom kernel boot parameters.