### PR TITLE
Enable the iPXE ping command

### DIFF
--- a/docs/IPXE.md
+++ b/docs/IPXE.md
@@ -22,3 +22,4 @@ See the `.h` files in the [ipxe/ipxe/](../ipxe/ipxe/) directory for the exact de
 - console syslog support
 - ISA_PROBE_ONLY (bios only)
 - Non-volatile option storage commands
+- [ping](https://ipxe.org/cmd/ping) command support

--- a/ipxe/ipxe/common.h
+++ b/ipxe/ipxe/common.h
@@ -6,6 +6,7 @@
 #define NTP_CMD               /* NTP commands */
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
+#define PING_CMD              /* Ping command */
 #define REBOOT_CMD            /* Reboot command */
 #define SANBOOT_PROTO_HTTP    /* HTTP SAN protocol */
 #define VLAN_CMD              /* VLAN commands */

--- a/ipxe/test/ping.expect
+++ b/ipxe/test/ping.expect
@@ -1,0 +1,20 @@
+set timeout 30
+set kernel [lindex $argv 0]
+set tftpdir [lindex $argv 1]
+spawn qemu-system-x86_64 -nographic -m 512 -smp 1 \
+-kernel $kernel \
+-net nic,model=virtio \
+-net user,tftp=$tftpdir,bootfile=ping.pxe \
+
+expect {
+  "64 bytes from" {
+    send_user "\nPass\n"
+    exit 0
+  }
+  "ping: command not found" {
+    send_user "\nFail\n"
+    exit 1
+  }
+}
+
+exit 1

--- a/ipxe/test/ping.pxe
+++ b/ipxe/test/ping.pxe
@@ -1,0 +1,3 @@
+#!ipxe
+echo ping github.com
+ping github.com

--- a/rules.mk
+++ b/rules.mk
@@ -104,7 +104,7 @@ else
 endif
 
 .PHONY: ipxe/tests ipxe/test-%
-ipxe/tests: ipxe/test-sanboot
+ipxe/tests: ipxe/test-sanboot ipxe/test-ping
 # order of dependencies matters here
 ipxe/test-%: ipxe/test/%.expect ipxe/ipxe/build/bin-test/ipxe.lkrn ipxe/test/ ipxe/test/%.pxe
-	expect -f $^
+	expect -f $^ | sed "s|^|test-$*: |"


### PR DESCRIPTION
## Description

Enable the built in ping command inside of the iPXE environment.

## Why is this needed

Operators debugging network issues sometimes find it useful to be able to issue ping commands from the iPXE environment to verify network configuration.

## How Has This Been Tested?
The added test exercises the change.

## How are existing users impacted? What migration steps/scripts do we need?
No impact

## Checklist:

I have:

- [x] added unit or e2e tests
