### PR TITLE
add docker compose configuration and test container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # run `make image` to build the binary + container
 # if you're using `make boots` this Dockerfile will not find the binary
-# and you probably want `make cmd/boots/boots-linux-amd64
+# and you probably want `make cmd/boots/boots-linux-amd64`
 FROM alpine:3.14
 
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ You can use NixOS shell, which will have the Git-LFS, Go and others
 
 ### Developing with Standalone Mode
 
+The quickest way to get started is `docker-compose up`. This will start boots in
+standalone mode using the example JSON in the `test/` directory. It also starts
+a client container that runs some tests.
+
+```sh
+docker-compose build # build containers
+docker-compose up    # start the network & services
+# it's fine to hit control-C twice for fast shutdown
+docker-compose down  # stop the network & clean up Docker processes
+```
+
+Alternatively you can run boots standalone manually. It requires a few
+environment variables for configuration.
+
+`test/standalone-hardware.json` should be safe enough for most developers to
+use on the command line locally without getting a call from your network
+administrator. That said, you might want to contact them before running a DHCP
+server on their network. Best to isolate it in Docker or a VM if you're not
+sure.
+
 ```sh
 export DATA_MODEL_VERSION=standalone
 export API_CONSUMER_TOKEN=none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# Provides a docker-compose configuration for local fast iteration when
+# hacking on boots alone.
+# TODO: figure out if NET_ADMIN capability is really necessary
+
+version: "3.8"
+
+# use a custom network configuration to enable macvlan mode and set explicit
+# IPs and MACs as well as support mainstream DHCP clients for easier testing
+# standalone-hardware.json references these IPs and MACs so we can write
+# (simpler) assertions against behavior on the client side.
+networks:
+  boots-test:
+    # enables a more realistic L2 network for the containers
+    driver: macvlan
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.99.0/24
+          gateway: 192.168.99.1
+
+services:
+  boots:
+    build: .
+    #entrypoint: ["/usr/bin/boots", "--dhcp-addr", "0.0.0.0:67"]
+    entrypoint: ["/start-boots.sh"]
+    networks:
+      boots-test:
+        ipv4_address: 192.168.99.42
+    mac_address: 02:00:00:00:00:01
+    environment:
+      DATA_MODEL_VERSION: standalone
+      API_CONSUMER_TOKEN: none
+      API_AUTH_TOKEN: none
+      FACILITY_CODE: onprem
+      BOOTS_STANDALONE_JSON: /test-standalone-hardware.json
+    volumes:
+      - ./test/standalone-hardware.json:/test-standalone-hardware.json
+      - ./test/start-boots.sh:/start-boots.sh
+    cap_add:
+      - NET_ADMIN
+  # eventually want to add more client containers, including one that boots will
+  # not recognize so we can validate it won't serve content to IPs it's not
+  # managing
+  client:
+    depends_on:
+      - boots
+    build: test
+    networks:
+      boots-test:
+        ipv4_address: 192.168.99.43
+    mac_address: 02:00:00:00:00:ff
+    cap_add:
+      - NET_ADMIN
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 # Provides a docker-compose configuration for local fast iteration when
 # hacking on boots alone.
 # TODO: figure out if NET_ADMIN capability is really necessary
@@ -21,7 +22,7 @@ networks:
 services:
   boots:
     build: .
-    #entrypoint: ["/usr/bin/boots", "--dhcp-addr", "0.0.0.0:67"]
+    # entrypoint: ["/usr/bin/boots", "--dhcp-addr", "0.0.0.0:67"]
     entrypoint: ["/start-boots.sh"]
     networks:
       boots-test:
@@ -51,4 +52,3 @@ services:
     mac_address: 02:00:00:00:00:ff
     cap_add:
       - NET_ADMIN
-

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.14
+EXPOSE 67 69
+
+RUN apk add --update --upgrade --no-cache net-tools dhclient dhcpcd tftp-hpa curl tcpdump
+
+COPY test-boots.sh /test-boots.sh
+
+ENTRYPOINT /test-boots.sh

--- a/test/start-boots.sh
+++ b/test/start-boots.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# the docker-compose overrides the boots container's ENTRYPOINT
+# with this script so it's a little easier to debug things
+#
+# configuration environment variables are provided by docker-compose
+
+# for example, to see the DHCP packets coming from the DHCP client
+# container, uncomment these.
+#apk update && apk add --no-cache tcpdump
+#tcpdump -ni eth0 &
+
+# start boots and explicitly bind DHCP to broadcast address otherwise
+# boots will start up fine but not see the DHCP requests
+/usr/bin/boots --dhcp-addr 0.0.0.0:67

--- a/test/test-boots.sh
+++ b/test/test-boots.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "starting DHCP in 5 seconds"
+
+# useful for debugging sometimes
+#tcpdump -ni eth0 &
+
+sleep 5
+
+# run a mainstream DHCP client in debug mode
+#dhclient -4 -d
+dhcpcd -d -4 --nobackground --noipv4ll -T
+
+# over time we can add some tests here, including stepping through tftp and http
+# requests to boots
+

--- a/test/test-boots.sh
+++ b/test/test-boots.sh
@@ -13,4 +13,3 @@ dhcpcd -d -4 --nobackground --noipv4ll -T
 
 # over time we can add some tests here, including stepping through tftp and http
 # requests to boots
-


### PR DESCRIPTION
## Description

Adds a docker-compose.yml with a custom network config that simulates an L2 network well enough that we can validate DHCP requests.

This PR is just the basics of what we can do. It runs boots in standalone mode and dhcpcd in debug mode so a developer can visually confirm their code hasn't broken things.

Down the road we can use something like Bats and write automated tests for DHCP, tftp, and HTTP using standard clients.

With this in place I need to move onto the otel work, but will probably come up with some follow-on PRs to add tests as I lace otel into boots.

## Why is this needed

It makes smoke testing and local iteration more accessible.

## How Has This Been Tested?

```sh
docker-compose down
docker-compose build --no-cache
docker-compose up
```

The output currently looks like this:

```
tobert@linux ~/src/boots $ docker-compose up
Creating network "boots_boots-test" with driver "macvlan"
Creating boots_boots_1 ... done
Creating boots_client_1 ... done
Attaching to boots_boots_1, boots_client_1
boots_1   | {"level":"info","ts":1627583852.2129014,"caller":"boots/main.go:58","msg":"starting","service":"github.com/tinkerbell/boots","pkg":"main","version":"6d27fc8"}
boots_1   | {"level":"info","ts":1627583852.2134936,"caller":"boots/main.go:92","msg":"serving tftp","service":"github.com/tinkerbell/boots","pkg":"main"}
boots_1   | {"level":"info","ts":1627583852.2135487,"caller":"boots/main.go:94","msg":"serving dhcp","service":"github.com/tinkerbell/boots","pkg":"main"}
boots_1   | {"level":"info","ts":1627583852.213613,"caller":"boots/main.go:97","msg":"serving http","service":"github.com/tinkerbell/boots","pkg":"main"}
boots_1   | {"level":"info","ts":1627583852.2136657,"caller":"boots/main.go:80","msg":"serving syslog","service":"github.com/tinkerbell/boots","pkg":"main"}
client_1  | starting DHCP in 5 seconds
client_1  | dhcpcd-8.1.9 starting
client_1  | DUID 00:04:cf:9b:4d:98:00:00:00:00:80:f2:4d:d6:70:b6:7e:47
client_1  | eth0: IAID 00:00:00:ff
client_1  | eth0: delaying IPv4 for 0.9 seconds
client_1  | eth0: soliciting a DHCP lease
client_1  | eth0: sending DISCOVER (xid 0x60a2ab1d), next in 4.8 seconds
boots_1   | {"level":"info","ts":1627583858.6968393,"caller":"dhcp4-go@v0.0.0-20190402165401-39c137f31ad3/handler.go:105","msg":"","service":"github.com/tinkerbell/boots","pkg":"dhcp","pkg":"dhcp","event":"recv","mac":"02:00:00:00:00:ff","via":"0.0.0.0","iface":"eth0","xid":"\"60:a2:ab:1d\"","type":"DHCPDISCOVER","option(145)":"AQ=="}
boots_1   | {"level":"info","ts":1627583858.6978893,"caller":"boots/dhcp.go:71","msg":"parsed option82/circuitid","service":"github.com/tinkerbell/boots","pkg":"main","mac":"02:00:00:00:00:ff","circuitID":""}
client_1  | eth0: offered 192.168.99.43 from 192.168.99.42
client_1  | eth0: executing `/usr/lib/dhcpcd/dhcpcd-run-hooks' TEST
boots_1   | {"level":"info","ts":1627583858.6990287,"caller":"dhcp4-go@v0.0.0-20190402165401-39c137f31ad3/handler.go:61","msg":"","service":"github.com/tinkerbell/boots","pkg":"dhcp","pkg":"dhcp","event":"send","mac":"02:00:00:00:00:ff","dst":"255.255.255.255","iface":"eth0","xid":"\"60:a2:ab:1d\"","type":"DHCPOFFER","address":"192.168.99.43"}
client_1  | interface='eth0'
client_1  | pid='9'
client_1  | protocol='dhcp'
client_1  | reason='TEST'
client_1  | ifcarrier='up'
client_1  | ifflags='4163'
client_1  | ifmtu='1500'
client_1  | ifwireless='0'
client_1  | new_broadcast_address='192.168.99.255'
client_1  | new_dhcp_lease_time='60'
client_1  | new_dhcp_message_type='2'
client_1  | new_dhcp_server_identifier='192.168.99.42'
client_1  | new_domain_name_servers='8.8.8.8'
client_1  | new_host_name='boots-test-client'
client_1  | new_ip_address='192.168.99.43'
client_1  | new_network_number='192.168.99.0'
client_1  | new_routers='192.168.99.1'
client_1  | new_subnet_cidr='24'
client_1  | new_subnet_mask='255.255.255.0'
client_1  | dhcpcd exited
boots_client_1 exited with code 0
^CGracefully stopping... (press Ctrl+C again to force)
Stopping boots_boots_1  ...
Killing boots_boots_1   ... done
```

## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Checklist:

I have:

- [x] updated the documentation (will do)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
