### PR TITLE
Back down to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # run `make image` to build the binary + container
 # if you're using `make boots` this Dockerfile will not find the binary
 # and you probably want `make cmd/boots/boots-linux-amd64`
-FROM alpine:3.14
+FROM alpine:3.13
 
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
## Description

Change the Docker container to build from Alpine 3.13 rather than 3.14 to address the build failures.

## Why is this needed

The build is currently broken for arm.
Fixes #186 

## How Has This Been Tested?

The test is the build pipeline.