### PR TITLE
Fix nlreturn linting:

### DIFF
--- a/cmd/boots/dhcp.go
+++ b/cmd/boots/dhcp.go
@@ -49,12 +49,14 @@ func (d dhcpHandler) serveDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) {
 	mac := req.GetCHAddr()
 	if conf.ShouldIgnoreOUI(mac.String()) {
 		mainlog.With("mac", mac).Info("mac is in ignore list")
+
 		return
 	}
 
 	gi := req.GetGIAddr()
 	if conf.ShouldIgnoreGI(gi.String()) {
 		mainlog.With("giaddr", gi).Info("giaddr is in ignore list")
+
 		return
 	}
 
@@ -76,6 +78,7 @@ func (d dhcpHandler) serveDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) {
 		mainlog.With("type", req.GetMessageType(), "mac", mac, "err", err).Info("retrieved job is empty")
 		metrics.JobsInProgress.With(labels).Dec()
 		timer.ObserveDuration()
+
 		return
 	}
 	go func() {
@@ -99,5 +102,6 @@ func getCircuitID(req *dhcp4.Packet) (string, error) {
 			return circuitID, errors.New("option82 option1 out of bounds (check eightytwo[1])")
 		}
 	}
+
 	return circuitID, nil
 }

--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -81,6 +81,7 @@ func main() {
 		err = retry.Do(
 			func() error {
 				_, err := syslog.StartReceiver(1)
+
 				return err
 			},
 		)

--- a/cmd/boots/tftp.go
+++ b/cmd/boots/tftp.go
@@ -55,6 +55,7 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 	j, err := job.CreateFromIP(ip)
 	if err != nil {
 		l.With("error", errors.WithMessage(err, "retrieved job is empty")).Info()
+
 		return serveFakeReader(l, filename)
 	}
 
@@ -66,6 +67,7 @@ func (tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, erro
 	// without a tink workflow present.
 	if !j.AllowPxe() {
 		l.Info("the hardware data for this machine, or lack there of, does not allow it to pxe; allow_pxe: false")
+
 		return serveFakeReader(l, filename)
 	}
 
@@ -76,12 +78,15 @@ func serveFakeReader(l log.Logger, filename string) (tftp.ReadCloser, error) {
 	switch filename {
 	case "test.1mb":
 		l.With("tftp_fake_read", true).Info()
+
 		return &fakeReader{1 * 1024 * 1024}, nil
 	case "test.8mb":
 		l.With("tftp_fake_read", true).Info()
+
 		return &fakeReader{8 * 1024 * 1024}, nil
 	}
 	l.With("error", errors.Wrap(os.ErrPermission, "access_violation")).Info()
+
 	return nil, os.ErrPermission
 }
 
@@ -89,6 +94,7 @@ func (tftpHandler) WriteFile(c tftp.Conn, filename string) (tftp.WriteCloser, er
 	ip := tftpClientIP(c.RemoteAddr())
 	err := errors.Wrap(os.ErrPermission, "access_violation")
 	mainlog.With("client", ip, "event", "create", "filename", filename, "error", err).Info()
+
 	return nil, os.ErrPermission
 }
 
@@ -106,6 +112,7 @@ func tftpClientIP(addr net.Addr) net.IP {
 	if err != nil {
 		err = errors.Wrap(err, "parse host:port")
 		mainlog.Error(err)
+
 		return nil
 	}
 	l := mainlog.With("host", host)
@@ -115,9 +122,11 @@ func tftpClientIP(addr net.Addr) net.IP {
 		if v4 := ip.To4(); v4 != nil {
 			ip = v4
 		}
+
 		return ip
 	}
 	l.Info("returning nil")
+
 	return nil
 }
 
@@ -148,5 +157,6 @@ func (r *fakeReader) Read(p []byte) (n int, err error) {
 	if r.N == 0 {
 		err = io.EOF
 	}
+
 	return
 }

--- a/cmd/boots/tftp_test.go
+++ b/cmd/boots/tftp_test.go
@@ -44,6 +44,7 @@ func TestReadFile(t *testing.T) {
 				if tc.failCreateFromIP {
 					err = tc.err
 				}
+
 				return job.Job{}, err
 			})
 			var jb job.Job
@@ -52,6 +53,7 @@ func TestReadFile(t *testing.T) {
 			})
 			monkey.PatchInstanceMethod(reflect.TypeOf(jb), "ServeTFTP", func(_ job.Job, _, _ string) (tftp.ReadCloser, error) {
 				r := ioutil.NopCloser(bytes.NewReader([]byte(fileContents)))
+
 				return r, nil
 			})
 

--- a/conf/config.go
+++ b/conf/config.go
@@ -60,6 +60,7 @@ func mustPublicIPv4() net.IP {
 		if v4 == nil || !v4.IsGlobalUnicast() {
 			continue
 		}
+
 		return v4
 	}
 	err = errors.New("unable to auto-detect public IPv4")
@@ -74,6 +75,7 @@ func mustPublicSyslogIPv4() net.IP {
 		err := errors.New("PUBLIC_SYSLOG_IP must be an IPv4 address")
 		panic(err)
 	}
+
 	return PublicIPv4
 }
 
@@ -85,6 +87,7 @@ func ParseIPv4s(str string) (ips []net.IP) {
 		}
 		ips = append(ips, ip)
 	}
+
 	return
 }
 
@@ -109,6 +112,7 @@ func getIgnoredMACs() map[string]struct{} {
 		ignore[oui] = struct{}{}
 
 	}
+
 	return ignore
 }
 
@@ -118,6 +122,7 @@ func ShouldIgnoreOUI(mac string) bool {
 	}
 	oui := strings.ToLower(mac[:8])
 	_, ok := ignoredOUIs[oui]
+
 	return ok
 }
 
@@ -140,6 +145,7 @@ func getIgnoredGIs() map[string]struct{} {
 		ignore[ip] = struct{}{}
 
 	}
+
 	return ignore
 }
 
@@ -148,6 +154,7 @@ func ShouldIgnoreGI(ip string) bool {
 		return false
 	}
 	_, ok := ignoredGIs[ip]
+
 	return ok
 }
 
@@ -174,5 +181,6 @@ func parseTrustedProxies() (result []string) {
 		}
 		result = append(result, cidr)
 	}
+
 	return result
 }

--- a/conf/mirror.go
+++ b/conf/mirror.go
@@ -36,12 +36,14 @@ func buildMirrorURL() (*url.URL, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid MIRROR_PATH %s", s)
 		}
+
 		return u, nil
 	}
 	u, err := base.Parse(defaultMirrorPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid default mirror path %q", defaultMirrorPath)
 	}
+
 	return u, nil
 }
 
@@ -54,6 +56,7 @@ func buildMirrorBaseURL() (*url.URL, error) {
 		if u.Path != "" && u.Path != "/" {
 			return nil, errors.Errorf("MIRROR_BASE_URL must not include a path component: %s", u.Path)
 		}
+
 		return u, nil
 	}
 	if s, ok := os.LookupEnv("MIRROR_HOST"); ok {
@@ -64,6 +67,7 @@ func buildMirrorBaseURL() (*url.URL, error) {
 		if u.Path != "" && u.Path != "/" {
 			return nil, errors.New("MIRROR_HOST must not include a path component")
 		}
+
 		return u, nil
 	}
 	mirror := fmt.Sprintf("http://install.%s.packet.net", FacilityCode)
@@ -71,6 +75,7 @@ func buildMirrorBaseURL() (*url.URL, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid default mirror host: %s", mirror)
 	}
+
 	return u, nil
 }
 
@@ -79,6 +84,7 @@ func mustBuildMirrorURL() *url.URL {
 	if err != nil {
 		panic(err)
 	}
+
 	return u
 }
 
@@ -87,5 +93,6 @@ func mustBuildMirrorBaseURL() *url.URL {
 	if err != nil {
 		panic(err)
 	}
+
 	return u
 }

--- a/conf/mirror_test.go
+++ b/conf/mirror_test.go
@@ -106,6 +106,7 @@ func Test_buildMirrorBaseURL(t *testing.T) {
 			got, err := buildMirrorBaseURL()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildMirrorBaseURL() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
@@ -251,6 +252,7 @@ func Test_buildMirrorURL(t *testing.T) {
 			got, err := buildMirrorURL()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildMirrorURL() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/dhcp/config.go
+++ b/dhcp/config.go
@@ -22,6 +22,7 @@ func (c *Config) ApplyTo(rep *dhcp4.Packet) bool {
 	for o, v := range c.opts {
 		rep.SetOption(o, v)
 	}
+
 	return true
 }
 
@@ -34,6 +35,7 @@ func (c *Config) Netmask() net.IP {
 	if !ok {
 		return nil
 	}
+
 	return nm
 }
 
@@ -42,6 +44,7 @@ func (c *Config) Gateway() net.IP {
 	if !ok {
 		return nil
 	}
+
 	return gw
 }
 
@@ -50,6 +53,7 @@ func (c *Config) Hostname() string {
 	if !ok {
 		return ""
 	}
+
 	return hn
 }
 
@@ -88,6 +92,7 @@ func (c *Config) SetDHCPServer(ip net.IP) {
 	v4 := ip.To4()
 	if v4 == nil {
 		dhcplog.With("address", ip).Error(errors.New("address is not an IPv4 address"))
+
 		return
 	}
 	c.opts.SetOption(dhcp4.OptionDHCPServerID, []byte(v4))
@@ -102,12 +107,14 @@ func (c *Config) SetDNSServers(ips []net.IP) {
 		v4 := ip.To4()
 		if v4 == nil {
 			dhcplog.With("address", ip).Info("skipping non IPv4 dns server address")
+
 			continue
 		}
 		b = append(b, v4...)
 	}
 	if len(b) == 0 {
 		dhcplog.Error(errors.New("no IPv4 dns server address supplied"))
+
 		return
 	}
 	c.opts.SetOption(dhcp4.OptionDomainServer, b)

--- a/dhcp/dhcp.go
+++ b/dhcp/dhcp.go
@@ -17,6 +17,7 @@ func NewReply(w dhcp4.ReplyWriter, req *dhcp4.Packet) Reply {
 	case dhcp4.MessageTypeRequest:
 		return NewAck(w, req)
 	}
+
 	return nil
 }
 
@@ -28,6 +29,7 @@ type Ack struct {
 func NewAck(w dhcp4.ReplyWriter, req *dhcp4.Packet) *Ack {
 	ack := dhcp4.CreateAck(req)
 	includeOption82(req, ack)
+
 	return &Ack{ack, w}
 }
 
@@ -47,6 +49,7 @@ type Offer struct {
 func NewOffer(w dhcp4.ReplyWriter, req *dhcp4.Packet) *Offer {
 	offer := dhcp4.CreateOffer(req)
 	includeOption82(req, offer)
+
 	return &Offer{offer, w}
 }
 

--- a/dhcp/pxe.go
+++ b/dhcp/pxe.go
@@ -54,6 +54,7 @@ func ProcessorArchType(req *dhcp4.Packet) string {
 	if !ok || int(v) >= len(procArchTypes) {
 		return ""
 	}
+
 	return procArchTypes[v]
 }
 
@@ -83,6 +84,7 @@ func IsPXE(req *dhcp4.Packet) bool {
 		return ok
 	}
 	class, ok := req.GetString(dhcp4.OptionClassID)
+
 	return ok && strings.HasPrefix(class, "PXEClient")
 }
 
@@ -94,6 +96,7 @@ func SetupPXE(rep, req *dhcp4.Packet) bool {
 		dhcplog.With("mac", req.GetCHAddr(), "xid", req.GetXID()).Info("no client GUID provided")
 	}
 	rep.SetOption(dhcp4.OptionVendorSpecific, pxeVendorOptions)
+
 	return true
 }
 
@@ -117,8 +120,10 @@ func copyGUID(rep, req *dhcp4.Packet) bool {
 			dhcplog.With("mac", req.GetCHAddr(), "xid", req.GetXID()).Error(errors.New("unsupported or malformed client GUID"))
 		} else {
 			rep.SetOption(dhcp4.OptionUUIDGUID, guid)
+
 			return true
 		}
 	}
+
 	return false
 }

--- a/files/ignition/networkd.go
+++ b/files/ignition/networkd.go
@@ -12,6 +12,7 @@ type NetworkUnits []*unit.Unit
 func (us *NetworkUnits) Add(name string) *unit.Unit {
 	u := unit.New(name)
 	*us = append(*us, u)
+
 	return u
 }
 
@@ -29,5 +30,6 @@ func (us NetworkUnits) MarshalJSON() ([]byte, error) {
 	v.Units = us
 
 	b, err := json.Marshal(&v)
+
 	return b, errors.Wrap(err, "marshaling network unit as json")
 }

--- a/files/ignition/systemd.go
+++ b/files/ignition/systemd.go
@@ -17,22 +17,26 @@ type SystemdUnit struct {
 func NewSystemdUnit(name string) *SystemdUnit {
 	u := new(SystemdUnit)
 	u.Name = name
+
 	return u
 }
 
 func (u *SystemdUnit) AddDropin(name string) *unit.Unit {
 	d := unit.New(name)
 	u.Dropins = append(u.Dropins, d)
+
 	return d
 }
 
 func (u *SystemdUnit) Enable() *SystemdUnit {
 	u.Enabled = true
+
 	return u
 }
 
 func (u *SystemdUnit) Mask() *SystemdUnit {
 	u.Masked = true
+
 	return u
 }
 
@@ -41,6 +45,7 @@ type SystemdUnits []*SystemdUnit
 func (us *SystemdUnits) Add(name string) *SystemdUnit {
 	u := NewSystemdUnit(name)
 	*us = append(*us, u)
+
 	return u
 }
 
@@ -54,5 +59,6 @@ func (us SystemdUnits) MarshalJSON() ([]byte, error) {
 	v.Units = us
 
 	b, err := json.Marshal(&v)
+
 	return b, errors.Wrap(err, "marshalling unit as json")
 }

--- a/files/tarball/tarball.go
+++ b/files/tarball/tarball.go
@@ -18,6 +18,7 @@ type File struct {
 func (f File) Close() (err error) {
 	err = f.t.flush()
 	f.t = nil
+
 	return
 }
 
@@ -35,6 +36,7 @@ func (f File) Writef(format string, args ...interface{}) {
 
 func (f File) WriteString(s string) (int, error) {
 	l, err := f.t.buf.WriteString(s)
+
 	return l, errors.Wrap(err, "write string to file")
 }
 
@@ -75,6 +77,7 @@ func (t *Tarball) Close() error {
 	if errTar != nil {
 		return errors.Wrap(errTar, "flushing and closing tar writer")
 	}
+
 	return errors.Wrap(errGZ, "flushing and closing gzip writer")
 }
 
@@ -87,5 +90,6 @@ func (t *Tarball) flush() error {
 	t.tw.WriteHeader(&t.hdr)
 
 	_, err := t.tw.Write(t.buf.Bytes())
+
 	return errors.Wrap(err, "flush tarball")
 }

--- a/files/unit/builder.go
+++ b/files/unit/builder.go
@@ -7,6 +7,7 @@ type Builder struct {
 func (b *Builder) AddSection(name string, lines ...string) *SectionBuilder {
 	s := new(SectionBuilder).Reset(name).AddLines(lines...)
 	b.sections = append(b.sections, s)
+
 	return s
 }
 
@@ -17,6 +18,7 @@ func (b *Builder) Len() (sum int) {
 		}
 		sum += s.Len()
 	}
+
 	return
 }
 
@@ -28,11 +30,13 @@ func (b *Builder) MarshalText() ([]byte, error) {
 		}
 		buf = append(buf, s.buf...)
 	}
+
 	return buf, nil
 }
 
 func (b *Builder) Bytes() []byte {
 	buf, _ := b.MarshalText()
+
 	return buf
 }
 
@@ -44,6 +48,7 @@ func (s *SectionBuilder) Add(key, value string) *SectionBuilder {
 	// TODO: Validate key.
 	// TODO: Handle multiline values.
 	s.buf = append(append(append(append(s.buf, key...), '='), value...), '\n')
+
 	return s // for chaining
 }
 
@@ -51,12 +56,14 @@ func (s *SectionBuilder) AddLines(lines ...string) *SectionBuilder {
 	for _, line := range lines {
 		s.buf = append(append(s.buf, line...), '\n')
 	}
+
 	return s
 }
 
 func (s *SectionBuilder) AddComment(comment string) *SectionBuilder {
 	// TODO: Handle multiline comments.
 	s.buf = append(append(append(s.buf, "# "...), comment...), '\n')
+
 	return s // for chaining
 }
 
@@ -67,5 +74,6 @@ func (s *SectionBuilder) Len() int {
 func (s *SectionBuilder) Reset(name string) *SectionBuilder {
 	// TODO: Validate name.
 	s.buf = append(append(append(s.buf[:0], '['), name...), "]\n"...)
+
 	return s // for chaining
 }

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -48,6 +48,7 @@ func (w *ResponseWriter) Write(b []byte) (int, error) {
 		w.StatusCode = 200
 	}
 	n, err := w.ResponseWriter.Write(b)
+
 	return n, errors.Wrap(err, "writing response")
 }
 
@@ -76,6 +77,7 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if res != nil {
 		httplog.With("event", "cr", "method", method, "uri", uri, "duration", d, "status", res.StatusCode).Info()
 	}
+
 	return
 }
 
@@ -84,5 +86,6 @@ func clientIP(str string) string {
 	if err != nil {
 		return "?"
 	}
+
 	return host
 }

--- a/installers/coreos/ignition.go
+++ b/installers/coreos/ignition.go
@@ -26,6 +26,7 @@ func buildNetworkUnits(j job.Job) (nu ignition.NetworkUnits) {
 			nu.Append(u)
 		}
 	}
+
 	return
 }
 
@@ -33,6 +34,7 @@ func buildSystemdUnits(j job.Job) (su ignition.SystemdUnits) {
 	configureNetworkService(j, su.Add("systemd-networkd.service"))
 	configureNetworkService(j, su.Add("systemd-networkd-wait-online.service"))
 	configureInstaller(j, su.Add("install.service"))
+
 	return
 }
 
@@ -42,6 +44,7 @@ func serveIgnitionConfig(distro string) func(w http.ResponseWriter, req *http.Re
 		if err != nil {
 			installers.Logger(distro).With("client", req.RemoteAddr).Error(err)
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 		c := ignition.Config{

--- a/installers/coreos/installer_test.go
+++ b/installers/coreos/installer_test.go
@@ -83,6 +83,7 @@ func replacer(l []string, replacements ...string) []string {
 	for i := 0; i < len(replacements); i = i + 2 {
 		script = strings.ReplaceAll(script, replacements[i], replacements[i+1])
 	}
+
 	return strings.Split(script, "\n")
 }
 

--- a/installers/coreos/ipxe_script_test.go
+++ b/installers/coreos/ipxe_script_test.go
@@ -15,6 +15,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/coreos/main.go
+++ b/installers/coreos/main.go
@@ -57,6 +57,7 @@ func kernelPath(j job.Job) string {
 	if j.IsARM() {
 		return distro + "-arm.vmlinuz"
 	}
+
 	return distro + "_production_pxe.vmlinuz"
 }
 
@@ -65,5 +66,6 @@ func initrdPath(j job.Job) string {
 	if j.IsARM() {
 		return distro + "-arm.cpio.gz"
 	}
+
 	return distro + "_production_pxe_image.cpio.gz"
 }

--- a/installers/coreos/networkd.go
+++ b/installers/coreos/networkd.go
@@ -85,5 +85,6 @@ func formatCIDR(ip net.IP, mask net.IPMask) string {
 		IP:   ip,
 		Mask: mask,
 	}
+
 	return n.String()
 }

--- a/installers/custom_ipxe/ipxe_script_test.go
+++ b/installers/custom_ipxe/ipxe_script_test.go
@@ -14,6 +14,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/logging.go
+++ b/installers/logging.go
@@ -21,5 +21,6 @@ func Logger(os string) log.Logger {
 		logger = installerslog.Package("installers/" + os)
 		logger, _ = loggers.LoadOrStore(os, logger)
 	}
+
 	return logger.(log.Logger)
 }

--- a/installers/nixos/ipxe_script_test.go
+++ b/installers/nixos/ipxe_script_test.go
@@ -15,6 +15,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/nixos/main.go
+++ b/installers/nixos/main.go
@@ -58,6 +58,7 @@ func bootScript(paths map[string]string, j job.Job, s *ipxe.Script) {
 		if tag == "" {
 			j.With("slug", j.OperatingSystem().Slug, "class", j.PlanSlug()).Error(errors.New("unknown os/class combo and no OSV ImageTag set"))
 			s.Shell()
+
 			return
 		}
 		key = j.OperatingSystem().Slug + "/" + tag

--- a/installers/osie/ipxe_script_test.go
+++ b/installers/osie/ipxe_script_test.go
@@ -27,6 +27,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -156,6 +156,7 @@ func kernelPath(j job.Job) string {
 	if j.KernelPath() != "" {
 		return j.KernelPath()
 	}
+
 	return "vmlinuz-${parch}"
 }
 
@@ -163,6 +164,7 @@ func initrdPath(j job.Job) string {
 	if j.InitrdPath() != "" {
 		return j.InitrdPath()
 	}
+
 	return "initramfs-${parch}"
 }
 
@@ -178,6 +180,7 @@ func osieBaseURL(j job.Job) string {
 	if isCustomOSIE(j) {
 		return osieURL + "/" + j.OSIEVersion()
 	}
+
 	return osieURL + "/current"
 }
 

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -31,12 +31,14 @@ func buildOSIEURL() (*url.URL, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid OSIE_PATH: %s", s)
 		}
+
 		return u, nil
 	}
 	u, err := base.Parse(defaultOSIEPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid default osie path: %s", defaultOSIEPath)
 	}
+
 	return u, nil
 }
 
@@ -45,6 +47,7 @@ func mustBuildOSIEURL() *url.URL {
 	if err != nil {
 		panic(err)
 	}
+
 	return u
 }
 
@@ -61,5 +64,6 @@ func getParam(key string) string {
 	if value == "" {
 		installers.Logger("osie").With("key", key).Fatal(errors.New("invalid key"))
 	}
+
 	return value
 }

--- a/installers/rancher/ipxe_script_test.go
+++ b/installers/rancher/ipxe_script_test.go
@@ -13,6 +13,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -16,6 +16,7 @@ var facility = func() string {
 	if fac == "" {
 		fac = "ewr1"
 	}
+
 	return fac
 }()
 

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -21,6 +21,7 @@ func serveKickstart(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		installers.Logger("vmware").With("client", req.RemoteAddr).Error(err, "retrieved job is empty")
 		w.WriteHeader(http.StatusNotFound)
+
 		return
 	}
 	if err := genKickstart(j, w); err != nil {

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -75,6 +75,7 @@ func TestScriptKickstart(t *testing.T) {
 func loadKickstart(disk string, assert *require.Assertions) string {
 	data, err := ioutil.ReadFile("testdata/vmware_base.txt")
 	assert.Nil(err)
+
 	return strings.Replace(string(data), "<DISK>", disk, 1)
 }
 

--- a/ipxe/dhcp_options.go
+++ b/ipxe/dhcp_options.go
@@ -108,6 +108,7 @@ func FormatOptions(opts dhcp4.OptionMap) []interface{} {
 		k, v := info.Format(&info, v)
 		fields = append(fields, k, v)
 	}
+
 	return fields
 }
 
@@ -118,6 +119,7 @@ func GetEncapsulatedOptions(opts dhcp4.OptionGetter) dhcp4.OptionMap {
 	if x, ok := opts.GetOption(EncapsulatedOptions); ok {
 		return ParseOptions(x)
 	}
+
 	return nil
 }
 
@@ -126,6 +128,7 @@ func HasFeature(opts dhcp4.OptionGetter, feature dhcp4.Option) bool {
 		return false
 	}
 	v, ok := opts.GetUint8(feature)
+
 	return ok && v == 1
 }
 
@@ -135,6 +138,7 @@ func ParseOptions(b []byte) dhcp4.OptionMap {
 		// clog.Warning(err)
 		return nil
 	}
+
 	return nested
 }
 
@@ -156,6 +160,7 @@ func formatFeature(info *optionInfo, b []byte) (string, string) {
 			return info.Name, "true"
 		}
 	}
+
 	return info.Name, fmt.Sprintf("%d", v)
 }
 
@@ -176,12 +181,14 @@ func formatOption(info *optionInfo, b []byte) (string, string) {
 		if len(b) == 1 && b[0] == 1 {
 			return info.Name, "true"
 		}
+
 		fallthrough
 	case "uint8", "int8":
 		if len(b) == 1 {
 			return info.Name, fmt.Sprintf("%d", b[0])
 		}
 	}
+
 	return info.Name, fmt.Sprintf("%v", b)
 }
 
@@ -189,6 +196,7 @@ func formatVersion(info *optionInfo, b []byte) (string, string) {
 	if len(b) != 3 {
 		return info.Name, string(b)
 	}
+
 	return info.Name, fmt.Sprintf("%d.%d.%d", b[0], b[1], b[2])
 }
 

--- a/ipxe/script.go
+++ b/ipxe/script.go
@@ -18,6 +18,7 @@ func (s *Script) Args(args ...string) *Script {
 	}
 
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
@@ -25,6 +26,7 @@ func (s *Script) Args(args ...string) *Script {
 func (s *Script) AppendString(s_script string) *Script {
 	s.buf = append(s.buf, s_script...)
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
@@ -38,6 +40,7 @@ imgfetch ${tinkerbell}/phone-home##params
 imgfree
 
 `...)
+
 	return s
 }
 
@@ -45,16 +48,19 @@ imgfree
 func (s *Script) Chain(uri string) *Script {
 	s.buf = append(append(s.buf, "chain --autofree "...), uri...)
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
 func (s *Script) DHCP() *Script {
 	s.buf = append(s.buf, "dhcp\n"...)
+
 	return s
 }
 
 func (s *Script) Boot() *Script {
 	s.buf = append(s.buf, "boot\n"...)
+
 	return s
 }
 
@@ -70,6 +76,7 @@ func (s *Script) Initrd(uri string, args ...string) *Script {
 	}
 
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
@@ -81,6 +88,7 @@ func (s *Script) Kernel(uri string, args ...string) *Script {
 	}
 
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
@@ -88,11 +96,13 @@ func (s *Script) Or(line string) *Script {
 	s.buf = append(s.buf[:len(s.buf)-1], " || "...)
 	s.buf = append(s.buf, line...)
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
 func (s *Script) Reset() *Script {
 	s.buf = append(s.buf[:0], "#!ipxe\n\n"...)
+
 	return s
 }
 
@@ -100,6 +110,7 @@ func (s *Script) Reset() *Script {
 func (s *Script) Echo(message string) *Script {
 	s.buf = append(append(s.buf, "echo "...), message...)
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
@@ -107,15 +118,18 @@ func (s *Script) Set(name, value string) *Script {
 	s.buf = append(append(s.buf, "set "...), name...)
 	s.buf = append(append(s.buf, ' '), value...)
 	s.buf = append(s.buf, '\n')
+
 	return s
 }
 
 func (s *Script) Shell() *Script {
 	s.buf = append(s.buf, "shell\n"...)
+
 	return s
 }
 
 func (s *Script) Sleep(value int) *Script {
 	s.buf = append(s.buf, fmt.Sprintf("sleep %d\n", value)...)
+
 	return s
 }

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -22,6 +22,7 @@ func IsSpecialOS(i *packet.Instance) bool {
 	if i.OS.Slug != "" {
 		slug = i.OS.Slug
 	}
+
 	return slug == "custom_ipxe" || slug == "custom" || strings.HasPrefix(slug, "vmware") || strings.HasPrefix(slug, "nixos")
 }
 
@@ -43,14 +44,17 @@ func (j Job) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) bool {
 	// configure DHCP
 	if !j.configureDHCP(reply.Packet(), req) {
 		j.Error(errors.New("unable to configure DHCP for yiaddr and DHCP options"))
+
 		return false
 	}
 
 	// send the DHCP response
 	if err := reply.Send(); err != nil {
 		j.Error(errors.WithMessage(err, "unable to send DHCP reply"))
+
 		return false
 	}
+
 	return true
 }
 
@@ -76,6 +80,7 @@ func (j Job) configureDHCP(rep, req *dhcp4.Packet) bool {
 
 		j.setPXEFilename(rep, isPacket, isARM, isUEFI)
 	}
+
 	return true
 }
 
@@ -86,6 +91,7 @@ func (j Job) isPXEAllowed() bool {
 	if j.InstanceID() == "" {
 		return false
 	}
+
 	return j.instance.AllowPXE
 }
 
@@ -101,11 +107,13 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {
 	if j.HardwareState() == "in_use" {
 		if j.InstanceID() == "" {
 			j.Error(errors.New("setPXEFilename called on a job with no instance"))
+
 			return
 		}
 
 		if j.instance.State != "active" {
 			j.With("hardware.state", j.HardwareState(), "instance.state", j.instance.State).Info("device should NOT be trying to PXE boot")
+
 			return
 		}
 
@@ -114,6 +122,7 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {
 		if !j.isPXEAllowed() && j.hardware.OperatingSystem().OsSlug != "custom_ipxe" {
 			err := errors.New("device should NOT be trying to PXE boot")
 			j.With("hardware.state", j.HardwareState(), "allow_pxe", j.isPXEAllowed(), "os", j.hardware.OperatingSystem().OsSlug).Info(err)
+
 			return
 		}
 		// custom_ipxe or rescue
@@ -153,6 +162,7 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isPacket, isARM, isUEFI bool) {
 	if filename == "" {
 		err := errors.New("no filename is set")
 		j.Error(err)
+
 		return
 	}
 

--- a/job/fetch.go
+++ b/job/fetch.go
@@ -19,6 +19,7 @@ func discoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID str
 	if err != nil {
 		return nil, err
 	}
+
 	return v.(packet.Discovery), nil
 }
 
@@ -30,5 +31,6 @@ func discoverHardwareFromIP(ip net.IP) (packet.Discovery, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return v.(packet.Discovery), nil
 }

--- a/job/hardware.go
+++ b/job/hardware.go
@@ -29,6 +29,7 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		joblog.Error(errors.Wrap(err, "reading hardware component body"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 
@@ -37,6 +38,7 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 	if err := json.Unmarshal(b, &response); err != nil {
 		joblog.Error(errors.Wrap(err, "parsing hardware component as json"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 
@@ -44,12 +46,14 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		joblog.Error(errors.Wrap(err, "marshalling componenents as json"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 
 	if _, err := client.PostHardwareComponent(j.hardware.HardwareID(), bytes.NewReader(jsonBody)); err != nil {
 		joblog.Error(errors.Wrap(err, "posting componenents"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -20,6 +20,7 @@ func (j Job) IsUEFI() bool {
 	if h := j.hardware; h != nil {
 		return h.HardwareUEFI(j.mac)
 	}
+
 	return false
 }
 
@@ -27,6 +28,7 @@ func (j Job) Arch() string {
 	if h := j.hardware; h != nil {
 		return h.HardwareArch(j.mac)
 	}
+
 	return ""
 }
 
@@ -34,6 +36,7 @@ func (j Job) BootDriveHint() string {
 	if i := j.instance; i != nil {
 		return i.BootDriveHint
 	}
+
 	return ""
 }
 
@@ -56,6 +59,7 @@ func (j Job) PArch() string {
 	if parch != "" {
 		return parch
 	}
+
 	return j.Arch()
 }
 
@@ -63,6 +67,7 @@ func (j Job) InstanceID() string {
 	if i := j.instance; i != nil {
 		return i.ID
 	}
+
 	return ""
 }
 
@@ -71,6 +76,7 @@ func (j Job) UserData() string {
 	if i := j.instance; i != nil {
 		return i.UserData
 	}
+
 	return ""
 }
 
@@ -79,6 +85,7 @@ func (j Job) IPXEScriptURL() string {
 	if i := j.instance; i != nil {
 		return i.IPXEScriptURL
 	}
+
 	return ""
 }
 
@@ -86,6 +93,7 @@ func (j Job) InstanceIPs() []packet.IP {
 	if i := j.instance; i != nil {
 		return i.IPs
 	}
+
 	return nil
 }
 
@@ -99,6 +107,7 @@ func (j Job) PasswordHash() string {
 	if j.instance.CryptedRootPassword != "" {
 		return j.instance.CryptedRootPassword
 	}
+
 	return j.instance.PasswordHash
 }
 
@@ -107,8 +116,10 @@ func (j Job) OperatingSystem() *packet.OperatingSystem {
 		if i.Rescue {
 			return rescueOS
 		}
+
 		return j.hardware.OperatingSystem()
 	}
+
 	return nil
 }
 
@@ -120,6 +131,7 @@ func (j Job) Interfaces() []packet.Port {
 	if h := j.hardware; h != nil {
 		return h.Interfaces()
 	}
+
 	return nil
 }
 
@@ -127,6 +139,7 @@ func (j Job) InterfaceName(i int) string {
 	if ifaces := j.Interfaces(); len(ifaces) > i {
 		return ifaces[i].Name
 	}
+
 	return ""
 }
 
@@ -134,6 +147,7 @@ func (j Job) InterfaceMAC(i int) net.HardwareAddr {
 	if ifaces := j.Interfaces(); len(ifaces) > i {
 		return ifaces[i].MAC()
 	}
+
 	return nil
 }
 
@@ -141,6 +155,7 @@ func (j Job) HardwareID() packet.HardwareID {
 	if h := j.hardware; h != nil {
 		return h.HardwareID()
 	}
+
 	return ""
 }
 
@@ -148,6 +163,7 @@ func (j Job) FacilityCode() string {
 	if h := j.hardware; h != nil {
 		return h.HardwareFacilityCode()
 	}
+
 	return ""
 }
 
@@ -155,6 +171,7 @@ func (j Job) PlanSlug() string {
 	if h := j.hardware; h != nil {
 		return h.HardwarePlanSlug()
 	}
+
 	return ""
 }
 
@@ -162,6 +179,7 @@ func (j Job) PlanVersionSlug() string {
 	if h := j.hardware; h != nil {
 		return h.HardwarePlanVersionSlug()
 	}
+
 	return ""
 }
 
@@ -169,6 +187,7 @@ func (j Job) Manufacturer() string {
 	if h := j.hardware; h != nil {
 		return h.HardwareManufacturer()
 	}
+
 	return ""
 }
 
@@ -182,6 +201,7 @@ func (j Job) HardwareState() string {
 	if h := j.hardware; h != nil && h.HardwareID() != "" {
 		return string(h.HardwareState())
 	}
+
 	return ""
 }
 
@@ -210,6 +230,7 @@ func (j Job) OSIEBaseURL() string {
 	if h := j.hardware; h != nil {
 		return j.hardware.OSIEBaseURL(j.mac)
 	}
+
 	return ""
 }
 
@@ -217,6 +238,7 @@ func (j Job) KernelPath() string {
 	if h := j.hardware; h != nil {
 		return j.hardware.KernelPath(j.mac)
 	}
+
 	return ""
 }
 
@@ -224,5 +246,6 @@ func (j Job) InitrdPath() string {
 	if h := j.hardware; h != nil {
 		return j.hardware.InitrdPath(j.mac)
 	}
+
 	return ""
 }

--- a/job/http.go
+++ b/job/http.go
@@ -17,6 +17,7 @@ func (j Job) ServeFile(w http.ResponseWriter, req *http.Request) {
 
 	if name := strings.TrimSuffix(base, ".ipxe"); len(name) < len(base) {
 		j.serveBootScript(w, req, name)
+
 		return
 	}
 
@@ -36,6 +37,7 @@ func (j Job) ServePhoneHomeEndpoint(w http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			j.Error(errors.WithMessage(err, "reading phone-home body"))
 			w.WriteHeader(http.StatusBadRequest)
+
 			return
 		}
 	case "application/x-www-form-urlencoded":
@@ -43,6 +45,7 @@ func (j Job) ServePhoneHomeEndpoint(w http.ResponseWriter, req *http.Request) {
 		if err := req.ParseForm(); err != nil {
 			j.Error(errors.Wrap(err, "parsing http form"))
 			w.WriteHeader(http.StatusBadRequest)
+
 			return
 		}
 
@@ -57,6 +60,7 @@ func (j Job) ServePhoneHomeEndpoint(w http.ResponseWriter, req *http.Request) {
 	default:
 		// Any other content types equal a bad request
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 
@@ -71,6 +75,7 @@ func (j Job) ServeProblemEndpoint(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		j.Error(errors.WithMessage(err, "reading problem body"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 	var v struct {
@@ -79,10 +84,12 @@ func (j Job) ServeProblemEndpoint(w http.ResponseWriter, req *http.Request) {
 	if err := json.Unmarshal(b, &v); err != nil {
 		j.Error(errors.Wrap(err, "parsing problem body as json"))
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 	if !j.PostHardwareProblem(v.Problem) {
 		w.WriteHeader(http.StatusBadGateway)
+
 		return
 	}
 	w.WriteHeader(http.StatusOK)
@@ -92,5 +99,6 @@ func (j Job) ServeProblemEndpoint(w http.ResponseWriter, req *http.Request) {
 func readClose(r io.ReadCloser) (b []byte, err error) {
 	b, err = ioutil.ReadAll(r)
 	r.Close()
+
 	return b, errors.Wrap(err, "reading file")
 }

--- a/job/ipxe.go
+++ b/job/ipxe.go
@@ -49,6 +49,7 @@ func (j Job) serveBootScript(w http.ResponseWriter, req *http.Request, name stri
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		j.With("script", name).Error(errors.New("boot script not found"))
+
 		return
 	}
 
@@ -64,6 +65,7 @@ func (j Job) serveBootScript(w http.ResponseWriter, req *http.Request, name stri
 
 	if _, err := w.Write(s.Bytes()); err != nil {
 		j.With("script", name).Error(errors.Wrap(err, "unable to write boot script"))
+
 		return
 	}
 }
@@ -72,18 +74,22 @@ func auto(j Job, s *ipxe.Script) {
 	if j.instance == nil {
 		j.Info(errors.New("no device to boot, providing an iPXE shell"))
 		shell(j, s)
+
 		return
 	}
 	if f, ok := bySlug[j.hardware.OperatingSystem().Slug]; ok {
 		f(j, s)
+
 		return
 	}
 	if f, ok := byDistro[j.hardware.OperatingSystem().Distro]; ok {
 		f(j, s)
+
 		return
 	}
 	if defaultInstaller != nil {
 		defaultInstaller(j, s)
+
 		return
 	}
 	j.With("slug", j.hardware.OperatingSystem().Slug, "distro", j.hardware.OperatingSystem().Distro).Error(errors.New("unsupported slug/distro"))

--- a/job/job.go
+++ b/job/job.go
@@ -65,9 +65,11 @@ func HasActiveWorkflow(hwID packet.HardwareID) (bool, error) {
 	for _, wf := range (*wcl).WorkflowContexts {
 		if wf.CurrentActionState == tw.State_STATE_PENDING || wf.CurrentActionState == tw.State_STATE_RUNNING {
 			joblog.With("workflowID", wf.WorkflowId).Info("found active workflow for hardware")
+
 			return true, nil
 		}
 	}
+
 	return false, nil
 }
 
@@ -87,6 +89,7 @@ func CreateFromDHCP(mac net.HardwareAddr, giaddr net.IP, circuitID string) (Job,
 	if err != nil {
 		return Job{}, err
 	}
+
 	return j, nil
 }
 
@@ -96,6 +99,7 @@ func CreateFromRemoteAddr(ip string) (Job, error) {
 	if err != nil {
 		return Job{}, errors.Wrap(err, "splitting host:ip")
 	}
+
 	return CreateFromIP(net.ParseIP(host))
 }
 

--- a/job/mock.go
+++ b/job/mock.go
@@ -37,6 +37,7 @@ func NewMock(t zaptest.TestingT, slug, facility string) Mock {
 	}
 
 	mockLog := log.Test(t, "job.Mock")
+
 	return Mock{
 		Logger: mockLog.With("mock", true, "slug", slug, "arch", arch, "uefi", uefi),
 		hardware: &packet.HardwareCacher{
@@ -59,6 +60,7 @@ func NewMockFromDiscovery(d packet.Discovery, mac net.HardwareAddr) Mock {
 	mockLog, _ := log.Init("job.Mock")
 	j := Job{Logger: mockLog, mac: mac}
 	j.setup(d)
+
 	return Mock(j)
 }
 
@@ -223,6 +225,7 @@ func MakeHardwareWithInstance() (*packet.DiscoveryCacher, []packet.MACAddr, stri
 			},
 		},
 	}
+
 	return d, []packet.MACAddr{macIPMI, mac0, mac1, mac2, mac3}, instanceId
 }
 
@@ -247,5 +250,6 @@ func MakeHardwareWithoutInstance() (*packet.DiscoveryCacher, packet.MACAddr) {
 			},
 		},
 	}
+
 	return d, mac
 }

--- a/job/modes.go
+++ b/job/modes.go
@@ -29,6 +29,7 @@ func (m Mode) Slug() string {
 	if s, ok := modeSlugs[m]; ok {
 		return s
 	}
+
 	return "unknown"
 }
 
@@ -45,6 +46,7 @@ func (m Mode) String() string {
 	if s, ok := modeStrings[m]; ok {
 		return s
 	}
+
 	return "(unknown mode)"
 }
 
@@ -53,6 +55,7 @@ var modesBySlug = func() map[string]Mode {
 	for mode, slug := range modeSlugs {
 		modes[slug] = mode
 	}
+
 	return modes
 }()
 

--- a/job/rsa.go
+++ b/job/rsa.go
@@ -43,6 +43,7 @@ func decryptPassword(b []byte) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "decrypt submitted password")
 	}
+
 	return string(pass), nil
 }
 
@@ -51,6 +52,7 @@ func ServePublicKey(w http.ResponseWriter, req *http.Request) {
 	case "GET", "HEAD":
 		w.WriteHeader(http.StatusOK)
 		w.Write(rsaKeypair.pub)
+
 		return
 	default:
 		w.Header().Set("Allow", "GET, HEAD")

--- a/packet/client.go
+++ b/packet/client.go
@@ -122,6 +122,7 @@ func NewMockClient(baseURL *url.URL, workflowClient tw.WorkflowServiceClient) *C
 	c := &http.Client{
 		Transport: t,
 	}
+
 	return &Client{
 		http:           c,
 		workflowClient: workflowClient,
@@ -137,6 +138,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "submit http request")
 	}
+
 	return unmarshalResponse(res, v)
 }
 
@@ -145,6 +147,7 @@ func (c *Client) Get(ref string, v interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "setup GET request")
 	}
+
 	return c.Do(req, v)
 }
 
@@ -156,6 +159,7 @@ func (c *Client) Patch(ref, mime string, body io.Reader, v interface{}) error {
 	if mime != "" {
 		req.Header.Set("Content-Type", mime)
 	}
+
 	return c.Do(req, v)
 }
 
@@ -167,6 +171,7 @@ func (c *Client) Post(ref, mime string, body io.Reader, v interface{}) error {
 	if mime != "" {
 		req.Header.Set("Content-Type", mime)
 	}
+
 	return c.Do(req, v)
 }
 
@@ -192,6 +197,7 @@ func unmarshalResponse(res *http.Response, result interface{}) error {
 			StatusCode: res.StatusCode,
 		}
 		e.unmarshalErrors(res.Body)
+
 		return errors.Wrap(e, "unmarshalling response")
 	}
 

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -86,6 +86,7 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 		b := []byte(resp.JSON)
 		if string(b) != "" {
 			metrics.CacherCacheHits.With(labels).Inc()
+
 			return NewDiscovery(b)
 		} else {
 			return c.ReportDiscovery(mac, giaddr, circuitID)
@@ -114,6 +115,7 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 
 		if string(b) != "{}" {
 			metrics.CacherCacheHits.With(labels).Inc()
+
 			return NewDiscovery(b)
 		}
 
@@ -125,6 +127,7 @@ func (c *Client) DiscoverHardwareFromDHCP(mac net.HardwareAddr, giaddr net.IP, c
 				return v, nil
 			}
 		}
+
 		return nil, errors.Errorf("no entry for MAC %q in standalone data", mac.String())
 	default:
 		return nil, errors.New("unknown DATA_MODEL_VERSION")
@@ -167,6 +170,7 @@ func (c *Client) ReportDiscovery(mac net.HardwareAddr, giaddr net.IP, circuitID 
 	if err := c.Post("/staff/cacher/hardware-discovery", mimeJSON, bytes.NewReader(b), &res); err != nil {
 		return nil, err
 	}
+
 	return &res, nil
 }
 
@@ -244,6 +248,7 @@ func (c *Client) GetInstanceIDFromIP(dip net.IP) (string, error) {
 	if d.Instance() == nil {
 		return "", nil
 	}
+
 	return d.Instance().ID, nil
 }
 
@@ -264,6 +269,7 @@ func (c *Client) PostHardwareEvent(id string, body io.Reader) (string, error) {
 	if err := c.Post("/hardware/"+id+"/events", mimeJSON, body, &res); err != nil {
 		return "", err
 	}
+
 	return res.ID, nil
 }
 func (c *Client) PostHardwarePhoneHome(id string) error {
@@ -279,6 +285,7 @@ func (c *Client) PostHardwareProblem(id HardwareID, body io.Reader) (string, err
 	if err := c.Post("/hardware/"+id.String()+"/problems", mimeJSON, body, &res); err != nil {
 		return "", err
 	}
+
 	return res.ID, nil
 }
 
@@ -292,6 +299,7 @@ func (c *Client) PostInstanceEvent(id string, body io.Reader) (string, error) {
 	if err := c.Post("/devices/"+id+"/events", mimeJSON, body, &res); err != nil {
 		return "", err
 	}
+
 	return res.ID, nil
 }
 func (c *Client) PostInstanceFail(id string, body io.Reader) error {

--- a/packet/endpoints_test.go
+++ b/packet/endpoints_test.go
@@ -84,6 +84,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 			if test.err != nil || test.code != 0 {
 				assert.Error(t, err)
 				assert.Nil(t, d)
+
 				return
 			}
 
@@ -131,6 +132,7 @@ func TestGetWorkflowsFromTink(t *testing.T) {
 			w, err := c.GetWorkflowsFromTink(test.hwID)
 			if test.err != nil {
 				assert.Error(t, err)
+
 				return
 			}
 			assert.Equal(t, w, test.wcl)

--- a/packet/errors.go
+++ b/packet/errors.go
@@ -14,6 +14,7 @@ func IsNotExist(err error) bool {
 	if e, ok := err.(*httpError); ok && e.StatusCode == http.StatusNotFound {
 		return true
 	}
+
 	return false
 }
 
@@ -33,6 +34,7 @@ func (e *httpError) Error() string {
 	for _, err := range e.Errors {
 		errs = append(errs, err.Error())
 	}
+
 	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, strings.Join(errs, "; "))
 }
 
@@ -47,6 +49,7 @@ func (e *httpError) unmarshalErrors(r io.Reader) {
 	}
 	if err := json.NewDecoder(r).Decode(&v); err != nil {
 		e.Errors = []error{errors.Wrap(err, "unmarshalling errors body")}
+
 		return
 	}
 	if n := len(v.Errors); n > 0 {

--- a/packet/models.go
+++ b/packet/models.go
@@ -88,6 +88,7 @@ func NewDiscovery(b []byte) (Discovery, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal json for discovery")
 		}
+
 		return d, nil
 	case "1":
 		d := &DiscoveryTinkerbellV1{}
@@ -95,6 +96,7 @@ func NewDiscovery(b []byte) (Discovery, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal json for discovery")
 		}
+
 		return d, nil
 	default:
 		return nil, errors.New("unknown DATA_MODEL_VERSION")
@@ -145,6 +147,7 @@ func (i *Instance) FindIP(pred func(IP) bool) *IP {
 			return &ip
 		}
 	}
+
 	return nil
 }
 
@@ -169,8 +172,10 @@ func (i *Instance) ServicesVersion() ServicesVersion {
 		if err != nil {
 			return ServicesVersion{}
 		}
+
 		return sv
 	}
+
 	return ServicesVersion{}
 }
 
@@ -239,6 +244,7 @@ func (p *Port) MAC() net.HardwareAddr {
 	if p.Data.MAC != nil && *p.Data.MAC != ZeroMAC {
 		return p.Data.MAC.HardwareAddr()
 	}
+
 	return nil
 }
 

--- a/packet/models_cacher.go
+++ b/packet/models_cacher.go
@@ -45,6 +45,7 @@ type HardwareCacher struct {
 
 func (d DiscoveryCacher) Hardware() Hardware {
 	var h Hardware = d.HardwareCacher
+
 	return h
 }
 
@@ -63,8 +64,10 @@ func (d DiscoveryCacher) LeaseTime(mac net.HardwareAddr) time.Duration {
 func (d DiscoveryCacher) MAC() net.HardwareAddr {
 	if d.mac == nil {
 		mac := d.PrimaryDataMAC()
+
 		return mac.HardwareAddr()
 	}
+
 	return d.mac
 }
 
@@ -74,6 +77,7 @@ func (d DiscoveryCacher) MacType(mac string) string {
 			return string(port.Type)
 		}
 	}
+
 	return "NOTFOUND"
 }
 
@@ -82,8 +86,10 @@ func (d DiscoveryCacher) MacIsType(mac string, portType string) bool {
 		if port.MAC().String() != mac {
 			continue
 		}
+
 		return string(port.Type) == portType
 	}
+
 	return false
 }
 
@@ -102,6 +108,7 @@ func (d DiscoveryCacher) Mode() string {
 	if d.DiscoveredIP(mac.String()) != nil {
 		return "discovered"
 	}
+
 	return ""
 }
 
@@ -123,6 +130,7 @@ func (d DiscoveryCacher) GetIP(mac net.HardwareAddr) IP {
 	if ip != nil {
 		return *ip
 	}
+
 	return IP{}
 }
 
@@ -148,6 +156,7 @@ func (d DiscoveryCacher) InstanceIP(mac string) *IP {
 			return ip
 		}
 	}
+
 	return nil
 }
 
@@ -159,6 +168,7 @@ func (d DiscoveryCacher) HardwareIP(mac string) *IP {
 	if d.PrimaryDataMAC().HardwareAddr().String() != mac {
 		return nil
 	}
+
 	return d.hardwareIP()
 }
 
@@ -172,8 +182,10 @@ func (d DiscoveryCacher) hardwareIP() *IP {
 		if ip.Public {
 			continue
 		}
+
 		return &ip
 	}
+
 	return nil
 }
 
@@ -182,6 +194,7 @@ func (d DiscoveryCacher) ManagementIP(mac string) *IP {
 	if d.MacIsType(mac, "ipmi") && d.Name != "" {
 		return &d.IPMI
 	}
+
 	return nil
 }
 
@@ -190,6 +203,7 @@ func (d DiscoveryCacher) DiscoveredIP(mac string) *IP {
 	if d.MacIsType(mac, "ipmi") && d.Name == "" {
 		return &d.IPMI
 	}
+
 	return nil
 }
 
@@ -202,6 +216,7 @@ func (d DiscoveryCacher) PrimaryDataMAC() MACAddr {
 		}
 		if port.Name == "eth0" {
 			mac = *port.Data.MAC
+
 			break
 		}
 		if port.MAC().String() < mac.String() {
@@ -212,6 +227,7 @@ func (d DiscoveryCacher) PrimaryDataMAC() MACAddr {
 	if mac.IsOnes() {
 		return ZeroMAC
 	}
+
 	return mac
 }
 
@@ -222,6 +238,7 @@ func (d DiscoveryCacher) ManagementMAC() MACAddr {
 			return *port.Data.MAC
 		}
 	}
+
 	return ZeroMAC
 }
 
@@ -254,6 +271,7 @@ func (d *DiscoveryCacher) SetMAC(mac net.HardwareAddr) {
 
 func (h *HardwareCacher) Management() (address, netmask, gateway net.IP) {
 	ip := h.IPMI
+
 	return ip.Address, ip.Netmask, ip.Gateway
 }
 
@@ -268,6 +286,7 @@ func (h HardwareCacher) Interfaces() []Port {
 	if len(ports) == 0 {
 		return nil
 	}
+
 	return ports
 }
 
@@ -355,6 +374,7 @@ func (h *HardwareCacher) OperatingSystem() *OperatingSystem {
 	if i.OSV == (*OperatingSystem)(nil) {
 		i.OSV = &OperatingSystem{}
 	}
+
 	return i.OSV
 }
 
@@ -362,5 +382,6 @@ func (h *HardwareCacher) instance() *Instance {
 	if h.Instance == nil {
 		h.Instance = &Instance{}
 	}
+
 	return h.Instance
 }

--- a/packet/models_standalone.go
+++ b/packet/models_standalone.go
@@ -68,6 +68,7 @@ func (ds DiscoverStandalone) DnsServers(mac net.HardwareAddr) []net.IP {
 	for i, v := range iface.DHCP.NameServers {
 		out[i] = net.ParseIP(v)
 	}
+
 	return out
 }
 
@@ -82,6 +83,7 @@ func (ds DiscoverStandalone) Hostname() (string, error) {
 
 func (ds DiscoverStandalone) Hardware() Hardware {
 	var h Hardware = ds.HardwareStandalone
+
 	return h
 }
 
@@ -118,6 +120,7 @@ func (hs HardwareStandalone) HardwareIPs() []IP {
 	for i, v := range hs.Network.Interfaces {
 		out[i] = v.DHCP.IP
 	}
+
 	return out
 }
 

--- a/packet/models_tinkerbell.go
+++ b/packet/models_tinkerbell.go
@@ -36,11 +36,13 @@ func (d DiscoveryTinkerbellV1) LeaseTime(mac net.HardwareAddr) time.Duration {
 		return conf.DHCPLeaseTime
 	}
 	duration, _ := time.ParseDuration(fmt.Sprintf("%ds", leaseTime))
+
 	return duration
 }
 
 func (d DiscoveryTinkerbellV1) Hardware() Hardware {
 	var h Hardware = d.HardwareTinkerbellV1
+
 	return h
 }
 
@@ -49,6 +51,7 @@ func (d DiscoveryTinkerbellV1) DnsServers(mac net.HardwareAddr) []net.IP {
 	if len(dnsServers) == 0 {
 		return conf.DNSServers
 	}
+
 	return conf.ParseIPv4s(strings.Join(dnsServers, ","))
 }
 
@@ -83,6 +86,7 @@ func (n Network) InterfaceByMac(mac net.HardwareAddr) NetworkInterface {
 			return i
 		}
 	}
+
 	return NetworkInterface{}
 }
 
@@ -94,6 +98,7 @@ func (n Network) InterfaceByIp(ip net.IP) NetworkInterface {
 			return i
 		}
 	}
+
 	return NetworkInterface{}
 }
 
@@ -107,6 +112,7 @@ func (d DiscoveryTinkerbellV1) Hostname() (string, error) {
 	if d.Instance() == nil {
 		return "", nil
 	}
+
 	return d.Instance().Hostname, nil
 }
 
@@ -180,6 +186,7 @@ func (h HardwareTinkerbellV1) HardwareUEFI(mac net.HardwareAddr) bool {
 func (h HardwareTinkerbellV1) Interfaces() []Port {
 	// TODO: to be updated
 	var ports []Port
+
 	return ports
 }
 
@@ -200,6 +207,7 @@ func (h *HardwareTinkerbellV1) OperatingSystem() *OperatingSystem {
 	if i.OS == nil {
 		i.OS = &OperatingSystem{}
 	}
+
 	return i.OS
 }
 
@@ -207,5 +215,6 @@ func (h *HardwareTinkerbellV1) instance() *Instance {
 	if h.Metadata.Instance == nil {
 		h.Metadata.Instance = &Instance{}
 	}
+
 	return h.Metadata.Instance
 }

--- a/packet/util.go
+++ b/packet/util.go
@@ -44,6 +44,7 @@ func (m *MACAddr) UnmarshalText(text []byte) error {
 		return errors.Wrap(err, "parsing mac address")
 	}
 	copy(m[:], mac)
+
 	return nil
 }
 

--- a/syslog/message.go
+++ b/syslog/message.go
@@ -113,6 +113,7 @@ func (m *message) String() string {
 	}
 
 	fields = append(fields, fmt.Sprintf("msg=%q", msgCleanup.Replace(string(m.msg))))
+
 	return strings.Join(fields, " ")
 }
 
@@ -145,6 +146,7 @@ func (m *message) parse() bool {
 	if !m.parseHeader() {
 		return false
 	}
+
 	return m.parseStructuredData()
 }
 
@@ -167,6 +169,7 @@ func (m *message) parseHeader() bool {
 func (m *message) parseStructuredData() bool {
 	if len(m.msg) >= 2 && m.msg[0] == '-' && m.msg[1] == ' ' {
 		m.msg = m.msg[2:]
+
 		return true
 	}
 
@@ -219,13 +222,16 @@ func (m *message) parseLegacyTag() {
 		}
 		if c == '[' {
 			m.app, b = b[:i], b[i:]
+
 			goto parsePid
 		}
 		m.app, b = b[:i], b[i:]
+
 		goto trimColon
 	}
 	m.app = nil
 	m.procid = nil
+
 	return
 
 parsePid:
@@ -249,6 +255,7 @@ func (m *message) parsePriority() bool {
 		if c == '>' {
 			m.priority = pri
 			m.msg = m.buf[1+i+1 : m.size]
+
 			return true
 		}
 		if c < '0' || c > '9' {
@@ -256,6 +263,7 @@ func (m *message) parsePriority() bool {
 		}
 		pri = pri*10 + c - '0'
 	}
+
 	return false
 }
 
@@ -276,6 +284,7 @@ func (m *message) parseTimestamp(b []byte) bool {
 		return false
 	}
 	m.time = t
+
 	return true
 }
 
@@ -290,6 +299,7 @@ func (m *message) parseVersion() bool {
 		return false // we only support version 1
 	}
 	m.msg = m.msg[2:]
+
 	return true
 }
 
@@ -322,5 +332,6 @@ func ignoreNil(b []byte) []byte {
 	if len(b) == 1 && b[0] == '-' {
 		return nil
 	}
+
 	return b
 }

--- a/syslog/receiver.go
+++ b/syslog/receiver.go
@@ -91,9 +91,11 @@ func (r *Receiver) run() {
 			err = errors.Wrap(err, "error reading udp message")
 			if ne, ok := err.(net.Error); ok && ne.Temporary() {
 				sysloglog.Error(err)
+
 				continue
 			}
 			r.err = err
+
 			return
 		}
 		msg.time = time.Now().UTC()

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -44,6 +44,7 @@ func Open(mac net.HardwareAddr, filename, client string) (*tftpTransfer, error) 
 	if !ok {
 		err := errors.Wrap(os.ErrNotExist, "unknown file")
 		l.With("event", "open", "error", err).Info()
+
 		return nil, err
 	}
 
@@ -54,6 +55,7 @@ func Open(mac net.HardwareAddr, filename, client string) (*tftpTransfer, error) 
 	}
 
 	t.With("event", "open").Debug()
+
 	return t, nil
 }
 
@@ -64,12 +66,14 @@ func (t *tftpTransfer) Close() error {
 	t.With("event", "close", "duration", d, "unread", n).Info()
 
 	t.unread = nil
+
 	return nil
 }
 
 func (t *tftpTransfer) Read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		t.With("event", "read", "read", 0, "unread", len(t.unread)).Info()
+
 		return
 	}
 
@@ -81,6 +85,7 @@ func (t *tftpTransfer) Read(p []byte) (n int, err error) {
 	}
 
 	t.With("event", "read", "read", n, "unread", len(t.unread)).Debug()
+
 	return
 }
 


### PR DESCRIPTION
## Description

Goal is to turn on all golanglint-ci linters.
This fixes "return with no blank line before (nlreturn)".
This check is enabled via `golangci-lint run --disable-all --enable nlreturn`

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
