### PR TITLE
Fix panic: http: multiple registrations for /hardware-components:

### DIFF
--- a/cmd/boots/http.go
+++ b/cmd/boots/http.go
@@ -97,7 +97,6 @@ func ServeHTTP(i job.Installers) {
 			mainlog.Error(err)
 		}
 	}))
-	mux.HandleFunc("/hardware-components", serveHardware)
 
 	var httpHandlers = make(map[string]http.HandlerFunc)
 	// register coreos/flatcar endpoints


### PR DESCRIPTION
## Description

This duplicate was missed during a rebase of the main branch.

## Why is this needed

Boots panics at runtime

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
