### PR TITLE
Abstract Packet client

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	client                *packet.Client
+	client                packet.Client
 	apiBaseURL            = env.URL("API_BASE_URL", "https://api.packet.net")
 	provisionerEngineName = env.Get("PROVISIONER_ENGINE_NAME", "packet")
 

--- a/job/job.go
+++ b/job/job.go
@@ -16,11 +16,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var client *packet.Client
+var client packet.Client
 var provisionerEngineName string
 
 // SetClient sets the client used to interact with the api.
-func SetClient(c *packet.Client) {
+func SetClient(c packet.Client) {
 	client = c
 }
 

--- a/packet/endpoints.go
+++ b/packet/endpoints.go
@@ -35,7 +35,7 @@ type ComponentsResponse struct {
 }
 
 // GetWorkflowsFromTink fetches the list of workflows from tink
-func (c *Client) GetWorkflowsFromTink(ctx context.Context, hwID HardwareID) (result *tw.WorkflowContextList, err error) {
+func (c *client) GetWorkflowsFromTink(ctx context.Context, hwID HardwareID) (result *tw.WorkflowContextList, err error) {
 	if hwID == "" {
 		return result, errors.New("missing hardware id")
 	}
@@ -57,7 +57,7 @@ func (c *Client) GetWorkflowsFromTink(ctx context.Context, hwID HardwareID) (res
 	return result, nil
 }
 
-func (c *Client) DiscoverHardwareFromDHCP(ctx context.Context, mac net.HardwareAddr, giaddr net.IP, circuitID string) (Discovery, error) {
+func (c *client) DiscoverHardwareFromDHCP(ctx context.Context, mac net.HardwareAddr, giaddr net.IP, circuitID string) (Discovery, error) {
 	if mac == nil {
 		return nil, errors.New("missing MAC address")
 	}
@@ -139,7 +139,7 @@ func (c *Client) DiscoverHardwareFromDHCP(ctx context.Context, mac net.HardwareA
 // endpoint.
 // This was split out from DiscoverHardwareFromDHCP to make the control flow
 // easier to understand.
-func (c *Client) ReportDiscovery(ctx context.Context, mac net.HardwareAddr, giaddr net.IP, circuitID string) (Discovery, error) {
+func (c *client) ReportDiscovery(ctx context.Context, mac net.HardwareAddr, giaddr net.IP, circuitID string) (Discovery, error) {
 	if giaddr == nil {
 		return nil, errors.New("missing MAC address")
 	}
@@ -174,7 +174,7 @@ func (c *Client) ReportDiscovery(ctx context.Context, mac net.HardwareAddr, giad
 	return &res, nil
 }
 
-func (c *Client) DiscoverHardwareFromIP(ctx context.Context, ip net.IP) (Discovery, error) {
+func (c *client) DiscoverHardwareFromIP(ctx context.Context, ip net.IP) (Discovery, error) {
 	if ip.String() == net.IPv4zero.String() {
 		return nil, errors.New("missing ip address")
 	}
@@ -240,7 +240,7 @@ func (c *Client) DiscoverHardwareFromIP(ctx context.Context, ip net.IP) (Discove
 }
 
 // GetDeviceIDFromIP Looks up a device (instance) in cacher via ByIP
-func (c *Client) GetInstanceIDFromIP(ctx context.Context, dip net.IP) (string, error) {
+func (c *client) GetInstanceIDFromIP(ctx context.Context, dip net.IP) (string, error) {
 	d, err := c.DiscoverHardwareFromIP(ctx, dip)
 	if err != nil {
 		return "", err
@@ -253,7 +253,7 @@ func (c *Client) GetInstanceIDFromIP(ctx context.Context, dip net.IP) (string, e
 }
 
 // PostHardwareComponent - POSTs a HardwareComponent to the API
-func (c *Client) PostHardwareComponent(ctx context.Context, hardwareID HardwareID, body io.Reader) (*ComponentsResponse, error) {
+func (c *client) PostHardwareComponent(ctx context.Context, hardwareID HardwareID, body io.Reader) (*ComponentsResponse, error) {
 	var response ComponentsResponse
 
 	if err := c.Post(ctx, "/hardware/"+hardwareID.String()+"/components", mimeJSON, body, &response); err != nil {
@@ -262,7 +262,7 @@ func (c *Client) PostHardwareComponent(ctx context.Context, hardwareID HardwareI
 
 	return &response, nil
 }
-func (c *Client) PostHardwareEvent(ctx context.Context, id string, body io.Reader) (string, error) {
+func (c *client) PostHardwareEvent(ctx context.Context, id string, body io.Reader) (string, error) {
 	var res struct {
 		ID string `json:"id"`
 	}
@@ -272,13 +272,13 @@ func (c *Client) PostHardwareEvent(ctx context.Context, id string, body io.Reade
 
 	return res.ID, nil
 }
-func (c *Client) PostHardwarePhoneHome(ctx context.Context, id string) error {
+func (c *client) PostHardwarePhoneHome(ctx context.Context, id string) error {
 	return c.Post(ctx, "/hardware/"+id+"/phone-home", "", nil, nil)
 }
-func (c *Client) PostHardwareFail(ctx context.Context, id string, body io.Reader) error {
+func (c *client) PostHardwareFail(ctx context.Context, id string, body io.Reader) error {
 	return c.Post(ctx, "/hardware/"+id+"/fail", mimeJSON, body, nil)
 }
-func (c *Client) PostHardwareProblem(ctx context.Context, id HardwareID, body io.Reader) (string, error) {
+func (c *client) PostHardwareProblem(ctx context.Context, id HardwareID, body io.Reader) (string, error) {
 	var res struct {
 		ID string `json:"id"`
 	}
@@ -289,10 +289,10 @@ func (c *Client) PostHardwareProblem(ctx context.Context, id HardwareID, body io
 	return res.ID, nil
 }
 
-func (c *Client) PostInstancePhoneHome(ctx context.Context, id string) error {
+func (c *client) PostInstancePhoneHome(ctx context.Context, id string) error {
 	return c.Post(ctx, "/devices/"+id+"/phone-home", "", nil, nil)
 }
-func (c *Client) PostInstanceEvent(ctx context.Context, id string, body io.Reader) (string, error) {
+func (c *client) PostInstanceEvent(ctx context.Context, id string, body io.Reader) (string, error) {
 	var res struct {
 		ID string `json:"id"`
 	}
@@ -302,10 +302,10 @@ func (c *Client) PostInstanceEvent(ctx context.Context, id string, body io.Reade
 
 	return res.ID, nil
 }
-func (c *Client) PostInstanceFail(ctx context.Context, id string, body io.Reader) error {
+func (c *client) PostInstanceFail(ctx context.Context, id string, body io.Reader) error {
 	return c.Post(ctx, "/devices/"+id+"/fail", mimeJSON, body, nil)
 }
-func (c *Client) PostInstancePassword(ctx context.Context, id, pass string) error {
+func (c *client) PostInstancePassword(ctx context.Context, id, pass string) error {
 	var req = struct {
 		Password string `json:"password"`
 	}{
@@ -319,6 +319,6 @@ func (c *Client) PostInstancePassword(ctx context.Context, id, pass string) erro
 
 	return c.Post(ctx, "/devices/"+id+"/password", mimeJSON, bytes.NewReader(b), nil)
 }
-func (c *Client) UpdateInstance(ctx context.Context, id string, body io.Reader) error {
+func (c *client) UpdateInstance(ctx context.Context, id string, body io.Reader) error {
 	return c.Patch(ctx, "/devices/"+id, mimeJSON, body, nil)
 }

--- a/packet/endpoints_test.go
+++ b/packet/endpoints_test.go
@@ -75,7 +75,7 @@ func TestDiscoverHardwareFromDHCP(t *testing.T) {
 			cMock := cacherMock.NewMockCacherClient(ctrl)
 			cMock.EXPECT().ByMAC(gomock.Any(), gomock.Any()).Return(&cacher.Hardware{JSON: test.gResponse}, test.err)
 
-			c := &Client{
+			c := &client{
 				baseURL:        u,
 				http:           s.Client(),
 				hardwareClient: cMock,


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Refactor `packet.Client` to an interface

## Why is this needed

This codifies the calls boots makes to backends. This is prep work for tinkerbell/proposals#46

Fixes: 
N/A

## How Has This Been Tested?
```
$ make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
ok  	github.com/tinkerbell/boots/cmd/boots	0.107s	coverage: 12.0% of statements
ok  	github.com/tinkerbell/boots/conf	0.034s	coverage: 50.0% of statements
?   	github.com/tinkerbell/boots/dhcp	[no test files]
?   	github.com/tinkerbell/boots/files/ignition	[no test files]
?   	github.com/tinkerbell/boots/files/tarball	[no test files]
?   	github.com/tinkerbell/boots/files/unit	[no test files]
?   	github.com/tinkerbell/boots/httplog	[no test files]
?   	github.com/tinkerbell/boots/installers	[no test files]
ok  	github.com/tinkerbell/boots/installers/coreos	0.587s	coverage: 44.4% of statements
ok  	github.com/tinkerbell/boots/installers/custom_ipxe	0.393s	coverage: 100.0% of statements
ok  	github.com/tinkerbell/boots/installers/nixos	0.555s	coverage: 95.7% of statements
ok  	github.com/tinkerbell/boots/installers/osie	0.849s	coverage: 69.4% of statements
ok  	github.com/tinkerbell/boots/installers/rancher	0.286s	coverage: 100.0% of statements
ok  	github.com/tinkerbell/boots/installers/vmware	1.277s	coverage: 60.3% of statements
?   	github.com/tinkerbell/boots/ipxe	[no test files]
ok  	github.com/tinkerbell/boots/job	0.076s	coverage: 32.5% of statements
?   	github.com/tinkerbell/boots/metrics	[no test files]
ok  	github.com/tinkerbell/boots/packet	0.080s	coverage: 43.0% of statements
?   	github.com/tinkerbell/boots/packet/mock_cacher	[no test files]
?   	github.com/tinkerbell/boots/packet/mock_workflow	[no test files]
?   	github.com/tinkerbell/boots/syslog	[no test files]
?   	github.com/tinkerbell/boots/tftp	[no test files]
```

## How are existing users impacted? What migration steps/scripts do we need?

No change to existing user flow

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
