### PR TITLE
installers: remove f3 plan specific tty

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -141,7 +141,7 @@ func kernelParams(action, state string, j job.Job, s ipxe.Script) ipxe.Script {
 		}
 	} else {
 		s.Args("console=tty0")
-		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" || j.PlanSlug() == "f3.medium.x86" || j.PlanSlug() == "f3.large.x86" {
+		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" {
 			console = "ttyS0"
 		} else {
 			console = "ttyS1"


### PR DESCRIPTION
Found a method to ensure those plans were on ttyS1 and so we won't need 
to adjust to ttyS0 anymore.

Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Remove plan specific actions for console tty settings

## Why is this needed

More defaults and less Metal specific things is good

## How Has This Been Tested?

Just in theory

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 