### PR TITLE
kickstart esxi: Remove the -s option from wget

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -231,17 +231,10 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q $kickstartfburl; then
-		wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
-		echo "========Begin execution of supplemental firstboot kickstart"
-		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
-		echo "========End execution of supplemental firstboot kickstart"
-	else
-		echo "ERROR: Custom kickstart firstboot URL is NOT accessible!"
-		exit 1
-	fi
-else
-	echo "Skipping supplemental kickstart firstboot URL"
+	wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
+	echo "========Begin execution of supplemental firstboot kickstart"
+	chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
+	echo "========End execution of supplemental firstboot kickstart"
 fi
 
 # Kickstart firstboot supplemental shell commands
@@ -308,18 +301,13 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
-        echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-        if wget -q $kickstartpiurl; then
-                wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
-                echo "========Begin execution of supplemental postinstall kickstart"
-                chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
-                echo "========End execution of supplemental postinstall kickstart"
-        else
-                echo "ERROR: Custom kickstart postinstall URL is NOT accessible!"
-                exit 1
-        fi
+	echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
+	wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
+	echo "========Begin execution of supplemental postinstall kickstart"
+	chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
+	echo "========End execution of supplemental postinstall kickstart"
 else
-        echo "Skipping supplemental kickstart postinstall URL"
+	echo "Skipping supplemental kickstart postinstall URL"
 fi
 
 # Kickstart postinstall supplemental shell commands

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -231,10 +231,16 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
-	echo "========Begin execution of supplemental firstboot kickstart"
-	chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
-	echo "========End execution of supplemental firstboot kickstart"
+	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh
+		echo "========Begin execution of supplemental firstboot kickstart"
+		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
+		echo "========End execution of supplemental firstboot kickstart"
+	else
+		echo "ERROR: Custom kickstart firstboot URL '$kickstartfburl' is NOT accessible!"
+		exit 1
+	fi
+else
+	echo "Skipping supplemental kickstart firstboot URL"
 fi
 
 # Kickstart firstboot supplemental shell commands

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -231,7 +231,7 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q -s $kickstartfburl; then
+	if wget -q $kickstartfburl; then
 		wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
 		echo "========Begin execution of supplemental firstboot kickstart"
 		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
@@ -309,7 +309,7 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
         echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-        if wget -q -s $kickstartpiurl; then
+        if wget -q $kickstartpiurl; then
                 wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
                 echo "========Begin execution of supplemental postinstall kickstart"
                 chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -231,7 +231,7 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh
+	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh; then
 		echo "========Begin execution of supplemental firstboot kickstart"
 		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
 		echo "========End execution of supplemental firstboot kickstart"
@@ -308,7 +308,7 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
 	echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh
+	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh; then
 		echo "========Begin execution of supplemental postinstall kickstart"
 		chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
 		echo "========End execution of supplemental postinstall kickstart"

--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -302,10 +302,14 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
 	echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-	wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
-	echo "========Begin execution of supplemental postinstall kickstart"
-	chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
-	echo "========End execution of supplemental postinstall kickstart"
+	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh
+		echo "========Begin execution of supplemental postinstall kickstart"
+		chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
+		echo "========End execution of supplemental postinstall kickstart"
+	else
+		echo "ERROR: Custom kickstart postinstall URL '$kickstartpiurl' is NOT accessible!"
+		exit 1
+	fi
 else
 	echo "Skipping supplemental kickstart postinstall URL"
 fi

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -197,7 +197,7 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q -s $kickstartfburl; then
+	if wget -q $kickstartfburl; then
 		wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
 		echo "========Begin execution of supplemental firstboot kickstart"
 		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
@@ -275,7 +275,7 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
         echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-        if wget -q -s $kickstartpiurl; then
+        if wget -q $kickstartpiurl; then
                 wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
                 echo "========Begin execution of supplemental postinstall kickstart"
                 chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -197,10 +197,14 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
-	echo "========Begin execution of supplemental firstboot kickstart"
-	chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
-	echo "========End execution of supplemental firstboot kickstart"
+	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh
+		echo "========Begin execution of supplemental firstboot kickstart"
+		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
+		echo "========End execution of supplemental firstboot kickstart"
+	else
+		echo "ERROR: Custom kickstart firstboot URL '$kickstartfburl' is NOT accessible!"
+		exit 1
+	fi
 else
 	echo "Skipping supplemental kickstart firstboot URL"
 fi
@@ -269,13 +273,17 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
-        echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-	wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
-	echo "========Begin execution of supplemental postinstall kickstart"
-	chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
-	echo "========End execution of supplemental postinstall kickstart"
+	echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
+	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh
+		echo "========Begin execution of supplemental postinstall kickstart"
+		chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
+		echo "========End execution of supplemental postinstall kickstart"
+	else
+		echo "ERROR: Custom kickstart postinstall URL '$kickstartpiurl' is NOT accessible!"
+		exit 1
+	fi
 else
-        echo "Skipping supplemental kickstart postinstall URL"
+	echo "Skipping supplemental kickstart postinstall URL"
 fi
 
 # Kickstart postinstall supplemental shell commands

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -197,15 +197,10 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q $kickstartfburl; then
-		wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
-		echo "========Begin execution of supplemental firstboot kickstart"
-		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
-		echo "========End execution of supplemental firstboot kickstart"
-	else
-		echo "ERROR: Custom kickstart firstboot URL is NOT accessible!"
-		exit 1
-	fi
+	wget -q $kickstartfburl -O /tmp/ks-firstboot-sup.sh
+	echo "========Begin execution of supplemental firstboot kickstart"
+	chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
+	echo "========End execution of supplemental firstboot kickstart"
 else
 	echo "Skipping supplemental kickstart firstboot URL"
 fi
@@ -275,15 +270,10 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
         echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-        if wget -q $kickstartpiurl; then
-                wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
-                echo "========Begin execution of supplemental postinstall kickstart"
-                chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
-                echo "========End execution of supplemental postinstall kickstart"
-        else
-                echo "ERROR: Custom kickstart postinstall URL is NOT accessible!"
-                exit 1
-        fi
+	wget -q $kickstartpiurl -O /tmp/ks-postinstall-sup.sh
+	echo "========Begin execution of supplemental postinstall kickstart"
+	chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
+	echo "========End execution of supplemental postinstall kickstart"
 else
         echo "Skipping supplemental kickstart postinstall URL"
 fi

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -197,7 +197,7 @@ fi
 # Kickstart firstboot supplemental config URL
 if [ "$kickstartfburl" != "null" ]; then
 	echo "Using supplemental kickstart firstboot URL: $kickstartfburl"
-	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh
+	if wget -q "$kickstartfburl" -O /tmp/ks-firstboot-sup.sh; then
 		echo "========Begin execution of supplemental firstboot kickstart"
 		chmod +x /tmp/ks-firstboot-sup.sh && /tmp/ks-firstboot-sup.sh
 		echo "========End execution of supplemental firstboot kickstart"
@@ -274,7 +274,7 @@ kickstartpishellcmd=$(custom_data "['kickstart']['postinstall_shell_cmd']")
 # Kickstart postinstall supplemental config URL
 if [ "$kickstartpiurl" != "null" ]; then
 	echo "Using supplemental kickstart postinstall URL: $kickstartpiurl"
-	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh
+	if wget -q "$kickstartpiurl" -O /tmp/ks-postinstall-sup.sh; then
 		echo "========Begin execution of supplemental postinstall kickstart"
 		chmod +x /tmp/ks-postinstall-sup.sh && /tmp/ks-postinstall-sup.sh
 		echo "========End execution of supplemental postinstall kickstart"


### PR DESCRIPTION
## Description

The VMware installer was previously relying on wget's "-s" or spider option to determine whether or not a particular URL was accessible while handling the customdata portion of the kickstart. This option is not valid on the version of wget which ships with current closed-source ESXi installers.

## Why is this needed

This change fixes a bug related to the customdata logic responsible for executing the kickstart postinstall scripts and kickstart firstboot install scripts provided via customdata.

Fixes: #

## How Has This Been Tested?
CI testing


## How are existing users impacted? What migration steps/scripts do we need?

Fixes customdata bug and unblocks further VMware VCF configuration.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
