### PR TITLE
installers: apply bootdrive hint for w plans

### DIFF
--- a/installers/vmware/kickstart-esxi.go
+++ b/installers/vmware/kickstart-esxi.go
@@ -388,6 +388,9 @@ func determineDisk(j job.Job) string {
 	if j.BootDriveHint() != "" && strings.HasPrefix(j.PlanSlug(), "s") {
 		return "--firstdisk=" + j.BootDriveHint()
 	}
+	if j.BootDriveHint() != "" && strings.HasPrefix(j.PlanSlug(), "w") {
+		return "--firstdisk=" + j.BootDriveHint()
+	}
 	switch j.PlanSlug() {
 	case "c1.small.x86",
 		"s1.large.x86",

--- a/installers/vmware/kickstart_script_test.go
+++ b/installers/vmware/kickstart_script_test.go
@@ -56,6 +56,9 @@ func TestScriptKickstart(t *testing.T) {
 									if driveHint != "" && strings.HasPrefix(typ, "s") {
 										disk = "--firstdisk=" + driveHint
 									}
+									if driveHint != "" && strings.HasPrefix(typ, "w") {
+										disk = "--firstdisk=" + driveHint
+									}
 
 									var w strings.Builder
 									genKickstart(m.Job(), &w)


### PR DESCRIPTION
Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Lets use the the BootDriveHint method for plans which start with `w` as well

## Why is this needed

Picking the wrong disk has negative impacts on provisioning

## How Has This Been Tested?

Just theory

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 