### PR TITLE
Add ESXi 7.0U2a as separate alternative to 7.0.0

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -137,6 +137,7 @@ func registerInstallers() job.Installers {
 	i.RegisterSlug("vmware_esxi_6_5", v.BootScriptVmwareEsxi65())
 	i.RegisterSlug("vmware_esxi_6_7", v.BootScriptVmwareEsxi67())
 	i.RegisterSlug("vmware_esxi_7_0", v.BootScriptVmwareEsxi70())
+	i.RegisterSlug("vmware_esxi_7_0U2a", v.BootScriptVmwareEsxi70U2a())
 	i.RegisterSlug("vmware_esxi_6_5_vcf", v.BootScriptVmwareEsxi65())
 	i.RegisterSlug("vmware_esxi_6_7_vcf", v.BootScriptVmwareEsxi67())
 	i.RegisterSlug("vmware_esxi_7_0_vcf", v.BootScriptVmwareEsxi70())

--- a/installers/vmware/kickstart_test.go
+++ b/installers/vmware/kickstart_test.go
@@ -55,7 +55,7 @@ func TestFirstDisk(t *testing.T) {
 
 func TestScriptKickstart(t *testing.T) {
 	manufacturers := []string{"supermicro", "dell"}
-	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0"}
+	versions := []string{"vmware_esxi_6_0", "vmware_esxi_6_5", "vmware_esxi_6_7", "vmware_esxi_7_0", "vmware_esxi_7_0U2a"}
 
 	diskConfigs := []struct {
 		slug    string

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -55,6 +55,12 @@ func (i Installer) BootScriptVmwareEsxi70() job.BootScript {
 	}
 }
 
+func (i Installer) BootScriptVmwareEsxi70U2a() job.BootScript {
+	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
+		return script(j, s, "/vmware/esxi-7.0U2a")
+	}
+}
+
 func script(j job.Job, s ipxe.Script, basePath string) ipxe.Script {
 	s.DHCP()
 	s.PhoneHome("provisioning.104.01")


### PR DESCRIPTION
## Description

This adds ESXi 7.0U2a as an alternative to 7.0.0 since there typically can only be one major version or ESXi associated with an OS slug at a time.

## Why is this needed

This specific version is needed as a requirement for certain Equinix Metal customers.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
Testing manually using custom iPXE


## How are existing users impacted? What migration steps/scripts do we need?

Unblocks Equinix Metal customer requirement.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
