### PR TITLE
add support for UEFI HTTP Boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 /cmd/boots/boots
 /cmd/boots/boots-*-*
 coverage.txt
-tftp/ipxe/
+ipxe/ipxe/*.efi
+ipxe/ipxe/*.kpxe
 !deploy/stack/.env
 .vagrant
 deploy/stack/state/webroot/misc/osie/current/*

--- a/cmd/boots/tftp.go
+++ b/cmd/boots/tftp.go
@@ -53,7 +53,10 @@ func (t tftpHandler) ReadFile(c tftp.Conn, filename string) (tftp.ReadCloser, er
 	defer metrics.JobsInProgress.With(labels).Dec()
 
 	ip := tftpClientIP(c.RemoteAddr())
-	filename = path.Base(filename)
+	filename = path.Clean(filename)
+	if path.IsAbs(filename) {
+		filename = filename[1:]
+	}
 	l := mainlog.With("client", ip.String(), "event", "open", "filename", filename)
 
 	// clients can send traceparent over TFTP by appending the traceparent string

--- a/ipxe/dhcp_options.go
+++ b/ipxe/dhcp_options.go
@@ -75,6 +75,7 @@ func IsPacketIPXE(req *dhcp4.Packet) bool {
 	// TODO: make this actually check for iPXE and use ipxe' build system's ability to set name.
 	// This way we could set to something like "Packet iPXE" and then just look for that in the identifier sent in dhcp.
 	// This also means we won't lose ipxe's version number for logging and such.
+	// see https://ipxe.org/appnote/userclass
 	if om := GetEncapsulatedOptions(req); om != nil {
 		if ov, ok := om.GetOption(OptionVersion); ok {
 			return ok && bytes.Equal(ov, packetVersion)

--- a/ipxe/files.go
+++ b/ipxe/files.go
@@ -1,0 +1,9 @@
+package ipxe
+
+import "embed"
+
+//go:embed ipxe/ipxe.efi
+//go:embed ipxe/snp-hua.efi
+//go:embed ipxe/snp-nolacp.efi
+//go:embed ipxe/undionly.kpxe
+var Files embed.FS

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -15,17 +15,18 @@ func TestSetPXEFilename(t *testing.T) {
 	conf.PublicFQDN = "boots-testing.packet.net"
 
 	var setPXEFilenameTests = []struct {
-		name     string
-		hState   string
-		id       string
-		iState   string
-		slug     string
-		plan     string
-		allowPXE bool
-		packet   bool
-		arm      bool
-		uefi     bool
-		filename string
+		name       string
+		hState     string
+		id         string
+		iState     string
+		slug       string
+		plan       string
+		allowPXE   bool
+		httpClient bool
+		packet     bool
+		arm        bool
+		uefi       bool
+		filename   string
 	}{
 		{name: "just in_use",
 			hState: "in_use"},
@@ -39,20 +40,23 @@ func TestSetPXEFilename(t *testing.T) {
 			hState: "in_use", id: "$instance_id", iState: "active", slug: "not_custom_ipxe"},
 		{name: "active custom ipxe",
 			hState: "in_use", id: "$instance_id", iState: "active", slug: "custom_ipxe",
-			filename: "undionly.kpxe"},
+			filename: "ipxe/undionly.kpxe"},
 		{name: "active custom ipxe with allow pxe",
 			hState: "in_use", id: "$instance_id", iState: "active", allowPXE: true,
-			filename: "undionly.kpxe"},
+			filename: "ipxe/undionly.kpxe"},
 		{name: "hua",
-			plan: "hua", filename: "snp-hua.efi"},
+			plan: "hua", filename: "ipxe/snp-hua.efi"},
 		{name: "2a2",
-			plan: "2a2", filename: "snp-hua.efi"},
+			plan: "2a2", filename: "ipxe/snp-hua.efi"},
 		{name: "arm",
-			arm: true, filename: "snp-nolacp.efi"},
+			arm: true, filename: "ipxe/snp-nolacp.efi"},
 		{name: "x86 uefi",
-			uefi: true, filename: "ipxe.efi"},
+			uefi: true, filename: "ipxe/ipxe.efi"},
+		{name: "x86 uefi http client",
+			uefi: true, allowPXE: true, httpClient: true,
+			filename: "http://" + conf.PublicFQDN + "/ipxe/ipxe.efi"},
 		{name: "all defaults",
-			filename: "undionly.kpxe"},
+			filename: "ipxe/undionly.kpxe"},
 		{name: "packet iPXE",
 			packet: true, filename: "/nonexistent"},
 		{name: "packet iPXE PXE allowed",
@@ -87,7 +91,7 @@ func TestSetPXEFilename(t *testing.T) {
 				instance: instance,
 			}
 			rep := dhcp4.NewPacket(42)
-			j.setPXEFilename(&rep, tt.packet, tt.arm, tt.uefi)
+			j.setPXEFilename(&rep, tt.packet, tt.arm, tt.uefi, tt.httpClient)
 			filename := string(bytes.TrimRight(rep.File(), "\x00"))
 
 			if tt.filename != filename {

--- a/job/http.go
+++ b/job/http.go
@@ -21,8 +21,10 @@ func (j Job) ServeFile(w http.ResponseWriter, req *http.Request, i Installers) {
 		return
 	}
 
-	w.WriteHeader(http.StatusNotFound)
-	j.With("file", base).Info("file not found")
+	// serve iPXE to HTTP clients.
+	// NB this must handle HEAD/GET and return Content-Length for odd clients
+	//    like the Seeed Studio Odyssey X86J4105 board.
+	ipxeFilesHandler.ServeHTTP(w, req)
 }
 
 func (j Job) ServePhoneHomeEndpoint(w http.ResponseWriter, req *http.Request) {

--- a/job/job.go
+++ b/job/job.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/dhcp"
+	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/packet"
 	tw "github.com/tinkerbell/tink/protos/workflow"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,8 +19,16 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var joblog log.Logger
+var ipxeFilesHandler http.Handler
 var client packet.Client
 var provisionerEngineName string
+
+func Init(l log.Logger) {
+	joblog = l.Package("http")
+	ipxeFilesHandler = http.FileServer(http.FS(ipxe.Files))
+	initRSA()
+}
 
 // SetClient sets the client used to interact with the api.
 func SetClient(c packet.Client) {

--- a/job/logging.go
+++ b/job/logging.go
@@ -2,16 +2,7 @@ package job
 
 import (
 	"context"
-
-	"github.com/packethost/pkg/log"
 )
-
-var joblog log.Logger
-
-func Init(l log.Logger) {
-	joblog = l.Package("http")
-	initRSA()
-}
 
 func (j Job) Fatal(err error, args ...interface{}) {
 	j.Logger.AddCallerSkip(1).Error(err, args...)

--- a/rules.mk
+++ b/rules.mk
@@ -52,7 +52,7 @@ generated_go_files := \
 .PHONY: $(generated_go_files)
 
 # build all the ipxe binaries
-generated_ipxe_files := tftp/ipxe/ipxe.efi tftp/ipxe/snp-hua.efi tftp/ipxe/snp-nolacp.efi tftp/ipxe/undionly.kpxe tftp/ipxe/snp-hua.efi
+generated_ipxe_files := ipxe/ipxe/ipxe.efi ipxe/ipxe/snp-hua.efi ipxe/ipxe/snp-nolacp.efi ipxe/ipxe/undionly.kpxe ipxe/ipxe/snp-hua.efi
 
 # go generate
 go_generate:
@@ -71,15 +71,15 @@ include ipxev.mk
 ipxeconfigs := $(wildcard ipxe/ipxe/*.h)
 
 # copy ipxe binaries into location available for go embed
-tftp/ipxe/ipxe.efi: ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi
-tftp/ipxe/snp-nolacp.efi: ipxe/ipxe/build/bin-arm64-efi/snp.efi
-tftp/ipxe/undionly.kpxe: ipxe/ipxe/build/bin/undionly.kpxe
-tftp/ipxe/ipxe.efi tftp/ipxe/snp-nolacp.efi tftp/ipxe/undionly.kpxe:
-	mkdir -p tftp/ipxe
+ipxe/ipxe/ipxe.efi: ipxe/ipxe/build/bin-x86_64-efi/ipxe.efi
+ipxe/ipxe/snp-nolacp.efi: ipxe/ipxe/build/bin-arm64-efi/snp.efi
+ipxe/ipxe/undionly.kpxe: ipxe/ipxe/build/bin/undionly.kpxe
+ipxe/ipxe/ipxe.efi ipxe/ipxe/snp-nolacp.efi ipxe/ipxe/undionly.kpxe:
+	mkdir -p ipxe/ipxe
 	cp $^ $@
 
-tftp/ipxe/snp-hua.efi:
-	mkdir -p tftp/ipxe
+ipxe/ipxe/snp-hua.efi:
+	mkdir -p ipxe/ipxe
 # we dont build the snp-hua.efi binary. It's checked into git, so here we just copy it over
 	cp ipxe/bin/snp-hua.efi $@
 

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -1,34 +1,13 @@
 package tftp
 
 import (
-	_ "embed"
 	"io"
 	"net"
-	"os"
 	"time"
 
 	"github.com/packethost/pkg/log"
-	"github.com/pkg/errors"
+	"github.com/tinkerbell/boots/ipxe"
 )
-
-//go:embed ipxe/ipxe.efi
-var ipxeEFI []byte
-
-//go:embed ipxe/undionly.kpxe
-var undionly []byte
-
-//go:embed ipxe/snp-nolacp.efi
-var snpNolacp []byte
-
-//go:embed ipxe/snp-hua.efi
-var snpHua []byte
-
-var tftpFiles = map[string][]byte{
-	"undionly.kpxe":  undionly,
-	"snp-nolacp.efi": snpNolacp,
-	"ipxe.efi":       ipxeEFI,
-	"snp-hua.efi":    snpHua,
-}
 
 type tftpTransfer struct {
 	log.Logger
@@ -40,9 +19,8 @@ type tftpTransfer struct {
 func Open(mac net.HardwareAddr, filename, client string) (*tftpTransfer, error) {
 	l := tftplog.With("mac", mac, "client", client, "filename", filename)
 
-	content, ok := tftpFiles[filename]
-	if !ok {
-		err := errors.Wrap(os.ErrNotExist, "unknown file")
+	content, err := ipxe.Files.ReadFile(filename)
+	if err != nil {
 		l.With("event", "open", "error", err).Info()
 
 		return nil, err


### PR DESCRIPTION
## Description

This adds supports for UEFI HTTP Boot.

## Why is this needed

Fixes: #210 

## How Has This Been Tested?

Tested with:

* [QEMU OVMF (AMD64)](https://github.com/tianocore/tianocore.github.io/wiki/OVMF) (HTTP and TFTP Boot)
* [RPi4-UEFI (ARM64)](https://github.com/pftf/RPi4) (HTTP and TFTP Boot)
* [RPi4-UEFI-iPXE (ARM64)](https://github.com/rgl/rpi4-uefi-ipxe) (HTTP and TFTP Boot)
* [Seeed Studio Odyssey X86J4105 board (AMD64)](https://wiki.seeedstudio.com/ODYSSEY-X86J4105/) (HTTP Boot)
* [HP EliteDesk 800 35W G2 Desktop Mini (AMD64)](https://support.hp.com/us-en/product/hp-elitedesk-800-35w-g2-desktop-mini-pc/7633266) (TFTP Boot)

## How are existing users impacted? What migration steps/scripts do we need?

Should have no impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
