### PR TITLE
Revert "Refactor setPXEFilename to be less complicated"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-has nix && use nix
-PATH_add bin
+which nix &>/dev/null && use nix
+unset GOPATH

--- a/ipxe/dhcp_options.go
+++ b/ipxe/dhcp_options.go
@@ -68,18 +68,16 @@ func Setup(rep *dhcp4.Packet) {
 	rep.SetIP(dhcp4.OptionLogServer, conf.PublicSyslogIPv4) // Have iPXE send syslog to me.
 }
 
-// Version we override in our iPXE build so we can differentiate between vendor/nic builtins vs ours (with the features we need/want)
-// see VERSION_PATCH=255 in ./ipxe/ipxe/build.sh:43
-var ouriPXEVersion = []byte{1, 0, 255}
+var packetVersion = []byte{1, 0, 255}
 
-// IsOuriPXE returns bool depending on if the request originated from our custom built/embedded iPXE
-func IsOuriPXE(req *dhcp4.Packet) bool {
+// IsPacketIPXE returns bool depending on if the request originated with packet's ipxe build
+func IsPacketIPXE(req *dhcp4.Packet) bool {
 	// TODO: make this actually check for iPXE and use ipxe' build system's ability to set name.
-	// This way we could set to something like "Boots iPXE" and then just look for that in the identifier sent in dhcp.
+	// This way we could set to something like "Packet iPXE" and then just look for that in the identifier sent in dhcp.
 	// This also means we won't lose ipxe's version number for logging and such.
 	if om := GetEncapsulatedOptions(req); om != nil {
 		if ov, ok := om.GetOption(OptionVersion); ok {
-			return ok && bytes.Equal(ov, ouriPXEVersion)
+			return ok && bytes.Equal(ov, packetVersion)
 		}
 	}
 

--- a/job/hardware.go
+++ b/job/hardware.go
@@ -27,7 +27,7 @@ type ComponentsResponse struct {
 func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 	b, err := readClose(req.Body)
 	if err != nil {
-		j.Logger.Error(errors.Wrap(err, "reading hardware component body"))
+		joblog.Error(errors.Wrap(err, "reading hardware component body"))
 		w.WriteHeader(http.StatusBadRequest)
 
 		return
@@ -36,7 +36,7 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 	var response ComponentsResponse
 
 	if err := json.Unmarshal(b, &response); err != nil {
-		j.Logger.Error(errors.Wrap(err, "parsing hardware component as json"))
+		joblog.Error(errors.Wrap(err, "parsing hardware component as json"))
 		w.WriteHeader(http.StatusBadRequest)
 
 		return
@@ -44,14 +44,14 @@ func (j Job) AddHardware(w http.ResponseWriter, req *http.Request) {
 
 	jsonBody, err := json.Marshal(response)
 	if err != nil {
-		j.Logger.Error(errors.Wrap(err, "marshalling componenents as json"))
+		joblog.Error(errors.Wrap(err, "marshalling componenents as json"))
 		w.WriteHeader(http.StatusBadRequest)
 
 		return
 	}
 
 	if _, err := client.PostHardwareComponent(req.Context(), j.hardware.HardwareID(), bytes.NewReader(jsonBody)); err != nil {
-		j.Logger.Error(errors.Wrap(err, "posting componenents"))
+		joblog.Error(errors.Wrap(err, "posting componenents"))
 		w.WriteHeader(http.StatusBadRequest)
 
 		return

--- a/job/job.go
+++ b/job/job.go
@@ -80,6 +80,8 @@ func HasActiveWorkflow(ctx context.Context, hwID packet.HardwareID) (bool, error
 	}
 	for _, wf := range (*wcl).WorkflowContexts {
 		if wf.CurrentActionState == tw.State_STATE_PENDING || wf.CurrentActionState == tw.State_STATE_RUNNING {
+			joblog.With("workflowID", wf.WorkflowId).Info("found active workflow for hardware")
+
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Reverts tinkerbell/boots#149

Testing this at Equinix Metal appears to not be compatible with some ARM servers. My desire is to revert this and then do some more testings to figure out why.