### PR TITLE
when firstDisk is empty, we shouldn't set it equal to anything

### DIFF
--- a/installers/vmware/kickstart.go
+++ b/installers/vmware/kickstart.go
@@ -41,7 +41,11 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted {{ rootpw . }}
 # The install media is in the CD-ROM drive
+{{- if (firstDisk .) }}
 install --firstdisk={{ firstDisk . }} --overwritevmfs
+{{- else }}
+install --firstdisk --overwritevmfs
+{{- end }}
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device={{ vmnic . }}
 reboot

--- a/installers/vmware/testdata/ks_.txt
+++ b/installers/vmware/testdata/ks_.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk= --overwritevmfs
+install --firstdisk --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot


### PR DESCRIPTION
When running an install where firstdisk results in an empty string, we need to not include the `=` as the installer fails.
![image](https://user-images.githubusercontent.com/15132496/136993690-3061a23c-33bf-4b55-969d-044562a2ac4b.png)
