### PR TITLE
removing unnecessary dhcp in vmware ipxe script

### DIFF
--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -47,8 +47,7 @@ func TestScriptPerType(t *testing.T) {
 }
 
 var type2pxe = map[string]string{
-	"baremetal_0": `dhcp
-
+	"baremetal_0": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01
@@ -59,8 +58,7 @@ set base-url http://install.ewr1.packet.net/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,
-	"baremetal_1": `dhcp
-
+	"baremetal_1": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01
@@ -71,8 +69,7 @@ set base-url http://install.ewr1.packet.net/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,
-	"baremetal_2": `dhcp
-
+	"baremetal_2": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01
@@ -83,8 +80,7 @@ set base-url http://install.ewr1.packet.net/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,
-	"baremetal_3": `dhcp
-
+	"baremetal_3": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01
@@ -95,8 +91,7 @@ set base-url http://install.ewr1.packet.net/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,
-	"baremetal_s": `dhcp
-
+	"baremetal_s": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01
@@ -107,8 +102,7 @@ set base-url http://install.ewr1.packet.net/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,
-	"c2.medium.x86": `dhcp
-
+	"c2.medium.x86": `
 params
 param body Device connected to DHCP system
 param type provisioning.104.01

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -62,7 +62,6 @@ func (i Installer) BootScriptVmwareEsxi70U2a() job.BootScript {
 }
 
 func script(j job.Job, s ipxe.Script, basePath string) ipxe.Script {
-	s.DHCP()
 	s.PhoneHome("provisioning.104.01")
 	s.Set("base-url", conf.MirrorBaseUrl+basePath)
 	if j.IsUEFI() {


### PR DESCRIPTION
## Description

This dhcp command is not needed as by this time we've already
loaded auto.ipxe which required networking.

Additionally, no other installer includes this command and slightly
increases provision time.

## Why is this needed

Speed up vmware install.

## How Has This Been Tested?

TBD


## How are existing users impacted? What migration steps/scripts do we need?

No Change


## Checklist:

I have:

- [x] ~updated the documentation and/or roadmap (if required)~
- [x] added unit or e2e tests
- [x] ~provided instructions on how to upgrade~
