### PR TITLE
Enable PCI Pass-through and IOMMU as a default kernel parameter

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -119,6 +119,8 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 	switch j.PlanSlug() {
 	case "c2.large.arm", "c2.large.anbox":
 		s.Args("iommu.passthrough=1")
+        default:
+                s.Args("intel_iommu=on amd_iommu=on iommu=pt")
 	}
 
 	if action == "install" {

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -117,10 +117,10 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 	s.Args("facility=" + j.FacilityCode())
 
 	switch j.PlanSlug() {
-	case "c2.large.arm", "c2.large.anbox":
+	case "c2.large.arm", "c2.large.anbox", "c3.large.arm":
 		s.Args("iommu.passthrough=1")
-        default:
-                s.Args("intel_iommu=on amd_iommu=on iommu=pt")
+	default:
+		s.Args("intel_iommu=on iommu=pt")
 	}
 
 	if action == "install" {


### PR DESCRIPTION
## Description

Enabled PCI Pass-through mode and enables the IOMMU by default

## Why is this needed

Needed to enable ISO support

## How are existing users impacted? What migration steps/scripts do we need?

No expected user impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
