### PR TITLE
osie installer: use ttyS0 as console for w3amd.75xx24c.256.4320.x86

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -151,7 +151,7 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 		}
 	} else {
 		s.Args("console=tty0")
-		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" {
+		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" || j.PlanSlug() == "w3amd.75xx24c.256.4320.x86" {
 			console = "ttyS0"
 		} else {
 			console = "ttyS1"


### PR DESCRIPTION
The BIOS on these servers restrict console support to COM0.