### PR TITLE
Enable CI & push to registry for forks

### DIFF
--- a/.github/actions/build-test-push/action.yml
+++ b/.github/actions/build-test-push/action.yml
@@ -1,0 +1,117 @@
+name: Build and Test and Push
+description: Build and test all the things, push images at the end (maybe).
+inputs:
+  registry:
+    description: OCI registry to push to
+    default: quay.io
+  namespace:
+    description: Organization/user to use as the namespace for container image
+    default: tinkerbell
+  username:
+    description: Username used to log against the registry
+  password:
+    description: Password or personal access token used to log against the registry
+runs:
+  using: composite
+  steps:
+    - name: Setup Dynamic Env
+      shell: bash
+      run: |
+        PUSH=false
+        set +x # ensure we don't leak creds (even though github would hide it)
+        if [[ -n ${OCI_USERNAME:-} ]] && [[ -n ${OCI_PASSWORD:-} ]]; then
+          PUSH=true
+        fi
+
+        {
+          echo "MAKEFLAGS=-j$(nproc)"
+          echo "OCI_REGISTRY=${OCI_REGISTRY:-quay.io}"
+          echo "OCI_REGISTRY_NS=${OCI_REGISTRY_NS:-tinkerbell}"
+          echo "PUSH=$PUSH"
+        } | tee -a $GITHUB_ENV
+      env:
+        OCI_USERNAME: ${{ inputs.username }}
+        OCI_PASSWORD: ${{ inputs.password }}
+        OCI_REGISTRY: ${{ inputs.registry }}
+        OCI_REGISTRY_NS: ${{ inputs.namespace }}
+
+    - name: Install nix
+      uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Fetch Nix Derivations
+      shell: bash
+      run: nix-shell --command true
+
+    - name: Fetch Go Packages
+      shell: bash
+      run: nix-shell --run 'go get ./... && go get -t ./... && make tools'
+
+    - name: Generate all files
+      shell: bash
+      run: nix-shell --run 'make gen'
+
+    - name: goimports
+      shell: bash
+      run: ./bin/goimports -d . | (! grep .)
+
+    - name: go vet
+      shell: bash
+      run: nix-shell --run 'go mod tidy && go vet ./...'
+
+    # This will catch any modifcations from go mod tidy above, this is hacky and needs to go away when boots gets lint-install'ed
+    - name: Non Go formatters and linters
+      shell: bash
+      run: ./.github/actions/build-test-push/ci-non-go.sh
+
+    - name: golangci-lint brought to you by Nix
+      shell: bash
+      run: nix-shell --run 'golangci-lint run -v'
+
+    - name: go test
+      shell: bash
+      run: nix-shell --run 'go test -v ./... -gcflags=-l'
+
+    - name: go test coverage
+      shell: bash
+      run: nix-shell --run 'go test -coverprofile=coverage.txt ./... -gcflags=-l'
+
+    - name: upload codecov
+      shell: bash
+      run: bash <(curl -s https://codecov.io/bash)
+
+    - name: compile binaries
+      shell: bash
+      run: nix-shell --run 'make crosscompile'
+
+    - name: Docker Image Tags
+      id: gen-tags
+      shell: bash
+      run: |
+        TAGS="${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:sha-$(git log -1 --pretty=%h)"
+        if ${{ startsWith(github.ref, 'refs/heads/main') }}; then
+          TAGS="$TAGS,${TAGS%%:sha*}:latest"
+        fi
+        echo ::set-output "name=tags::$TAGS"
+
+    - name: Login to Registry
+      uses: docker/login-action@v1
+      if: env.PUSH == 'true'
+      with:
+        registry: ${{ env.OCI_REGISTRY}}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Push to Registry
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        cache-from: type=registry,ref=${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:latest
+        push: ${{ env.PUSH == 'true' }}
+        tags: ${{ steps.gen-tags.outputs.tags }}
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64

--- a/.github/actions/build-test-push/ci-non-go.sh
+++ b/.github/actions/build-test-push/ci-non-go.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../../shell.nix
+#shellcheck shell=bash
+
+set -eux
+
+failed=0
+
+if ! git ls-files '*.md' '*.yaml' '*.yml' | xargs prettier --list-different --write; then
+	failed=1
+fi
+
+if ! shfmt -f . | xargs shfmt -l -d; then
+	failed=1
+fi
+
+if ! shfmt -f . | xargs shellcheck; then
+	failed=1
+fi
+
+if ! nixfmt shell.nix; then
+	failed=1
+fi
+
+if ! git diff | (! grep .); then
+	failed=1
+fi
+
+exit "$failed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Fetch Go Packages
         run: nix-shell --run 'go get ./... && go get -t ./... && make tools'
 
-      - name: Non Go formatters and linters
-        run: ./.github/workflows/ci-non-go.sh
-
       - name: Generate all files
         run: nix-shell --run 'make gen'
 
@@ -42,6 +39,10 @@ jobs:
       - name: go vet
         run: |
           nix-shell --run 'go mod tidy && go vet ./...'
+
+      # This will catch any modifcations from go mod tidy above, this is hacky and needs to go away when boots gets lint-install'ed
+      - name: Non Go formatters and linters
+        run: ./.github/workflows/ci-non-go.sh
 
       - name: golangci-lint brought to you by Nix
         run: nix-shell --run 'golangci-lint run -v'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,117 +4,36 @@ on:
   pull_request:
 
 jobs:
-  get-runner:
-    runs-on: [ubuntu-latest]
-    outputs:
-      runner: ${{ steps.get-runner.outputs.runner }}
-    steps:
-      - name: Get Runner
-        id: get-runner
-        run: |
-          if [[ "${{ github.event.repository.owner.login }}" == "tinkerbell" ]]; then
-            echo "using self-hosted"
-            echo ::set-output name=runner::self-hosted,X64
-          else
-            echo "using github-hosted"
-            echo ::set-output name=runner::ubuntu-latest
-          fi
-
-  validation:
-    needs: [get-runner]
-    runs-on: ${{ needs.get-runner.outputs.runner }}
+  validation-for-tinkerbell:
+    if: github.event.repository.owner.loging == 'tinkerbell'
+    runs-on: [self-hosted, X64]
     env:
       CGO_ENABLED: 0
     steps:
-      - name: Setup Dynamic Env
-        run: |
-          PUSH=false
-          set +x # ensure we don't leak creds (even though github would hide it)
-          if [[ -n ${OCI_USERNAME:-} ]] && [[ -n ${OCI_PASSWORD:-} ]]; then
-            PUSH=true
-          fi
-
-          {
-            echo "MAKEFLAGS=-j$(nproc)"
-            echo "OCI_REGISTRY=${OCI_REGISTRY:-quay.io}"
-            echo "OCI_REGISTRY_NS=${OCI_REGISTRY_NS:-tinkerbell}"
-            echo "PUSH=$PUSH"
-          } | tee -a $GITHUB_ENV
-        env:
-          OCI_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
-          OCI_PASSWORD: ${{ secrets.OCI_REGISTRY_PASSWORD }}
-          OCI_REGISTRY: ${{ secrets.OCI_REGISTRY }}
-          OCI_REGISTRY_NS: ${{ secrets.OCI_REGISTRY_NS }}
-
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install nix
-        uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
+      - name: validate
+        uses: ./.github/actions/build-test-push
         with:
-          nix_path: nixpkgs=channel:nixpkgs-unstable
+          registry: quay.io
+          namespace: tinkerbell
+          username: ${{ secrets.OCI_USERNAME }}
+          password: ${{ secrets.OCI_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+  validation-for-forks:
+    if: github.event.repository.owner.loging != 'tinkerbell'
+    runs-on: [ubuntu-latest]
+    env:
+      CGO_ENABLED: 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      - name: Fetch Nix Derivations
-        run: nix-shell --command true
-
-      - name: Fetch Go Packages
-        run: nix-shell --run 'go get ./... && go get -t ./... && make tools'
-
-      - name: Generate all files
-        run: nix-shell --run 'make gen'
-
-      - name: goimports
-        run: ./bin/goimports -d . | (! grep .)
-
-      - name: go vet
-        run: |
-          nix-shell --run 'go mod tidy && go vet ./...'
-
-      # This will catch any modifcations from go mod tidy above, this is hacky and needs to go away when boots gets lint-install'ed
-      - name: Non Go formatters and linters
-        run: ./.github/workflows/ci-non-go.sh
-
-      - name: golangci-lint brought to you by Nix
-        run: nix-shell --run 'golangci-lint run -v'
-
-      - name: go test
-        run: nix-shell --run 'go test -v ./... -gcflags=-l'
-
-      - name: go test coverage
-        run: nix-shell --run 'go test -coverprofile=coverage.txt ./... -gcflags=-l'
-
-      - name: upload codecov
-        run: bash <(curl -s https://codecov.io/bash)
-
-      - name: compile binaries
-        run: nix-shell --run 'make crosscompile'
-
-      - name: Docker Image Tags
-        id: gen-tags
-        run: |
-          TAGS="${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:sha-$(git log -1 --pretty=%h)"
-          if ${{ startsWith(github.ref, 'refs/heads/main') }}; then
-            TAGS="$TAGS,${TAGS%%:sha*}:latest"
-          fi
-          echo ::set-output "name=tags::$TAGS"
-
-      - name: Login to Registry
-        uses: docker/login-action@v1
-        if: env.PUSH == 'true'
+      - name: validate
+        uses: ./.github/actions/build-test-push
         with:
-          registry: ${{ env.OCI_REGISTRY}}
-          username: ${{ secrets.OCI_REGISTRY_USERNAME }}
-          password: ${{ secrets.OCI_REGISTRY_PASSWORD }}
-
-      - name: Push to Registry
-        uses: docker/build-push-action@v2
-        with:
-          context: ./
-          file: ./Dockerfile
-          cache-from: type=registry,ref=${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:latest
-          push: ${{ env.PUSH == 'true' }}
-          tags: ${{ steps.gen-tags.outputs.tags }}
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          registry: ${{ secrets.OCI_REGISTRY }}
+          namespace: ${{ secrets.OCI_REGISTRY_NS }}
+          username: ${{ secrets.OCI_USERNAME }}
+          password: ${{ secrets.OCI_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Fetch Nix Derivations
+        run: nix-shell --command true
+
+      - name: Fetch Go Packages
+        run: nix-shell --run 'go get ./... && go get -t ./... && make tools'
+
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
-
 
       - name: Generate all files
         run: nix-shell --run 'make gen'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
           echo "MAKEFLAGS=-j$(nproc)" | tee $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          lfs: true
       - name: Install nix
         uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,23 @@ jobs:
     steps:
       - name: Setup Dynamic Env
         run: |
-          echo "MAKEFLAGS=-j$(nproc)" | tee $GITHUB_ENV
+          PUSH=false
+          set +x # ensure we don't leak creds (even though github would hide it)
+          if [[ -n ${OCI_USERNAME:-} ]] && [[ -n ${OCI_PASSWORD:-} ]]; then
+            PUSH=true
+          fi
+
+          {
+            echo "MAKEFLAGS=-j$(nproc)"
+            echo "OCI_REGISTRY=${OCI_REGISTRY:-quay.io}"
+            echo "OCI_REGISTRY_NS=${OCI_REGISTRY_NS:-tinkerbell}"
+            echo "PUSH=$PUSH"
+          } | tee -a $GITHUB_ENV
+        env:
+          OCI_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          OCI_PASSWORD: ${{ secrets.OCI_REGISTRY_PASSWORD }}
+          OCI_REGISTRY: ${{ secrets.OCI_REGISTRY }}
+          OCI_REGISTRY_NS: ${{ secrets.OCI_REGISTRY_NS }}
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -76,25 +92,29 @@ jobs:
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'
 
-      - name: Docker Image Tag for Sha
-        id: docker-image-tag
+      - name: Docker Image Tags
+        id: gen-tags
         run: |
-          echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
+          TAGS="${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:sha-$(git log -1 --pretty=%h)"
+          if ${{ startsWith(github.ref, 'refs/heads/main') }}; then
+            TAGS="$TAGS,${TAGS%%:sha*}:latest"
+          fi
+          echo ::set-output "name=tags::$TAGS"
 
-      - name: Login to quay.io
+      - name: Login to Registry
         uses: docker/login-action@v1
-        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        if: env.PUSH == 'true'
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: ${{ env.OCI_REGISTRY}}
+          username: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          password: ${{ secrets.OCI_REGISTRY_PASSWORD }}
 
-      - name: quay.io/tinkerbell/boots
+      - name: Push to Registry
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfile
-          cache-from: type=registry,ref=quay.io/tinkerbell/boots:latest
-          push: ${{ startsWith(github.ref, 'refs/heads/main') }}
-          tags: ${{ steps.docker-image-tag.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.OCI_REGISTRY }}/${{ env.OCI_REGISTRY_NS }}/boots:latest
+          push: ${{ env.PUSH == 'true' }}
+          tags: ${{ steps.gen-tags.outputs.tags }}
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         run: nix-shell --run 'make gen'
 
       - name: goimports
-        run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+        run: ./bin/goimports -d . | (! grep .)
 
       - name: go vet
         run: go mod tidy && go vet ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,40 +12,55 @@ jobs:
       - name: Setup Dynamic Env
         run: |
           echo "MAKEFLAGS=-j$(nproc)" | tee $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install nix
         uses: cachix/install-nix-action@018abf956a0a15673dae4932ae26f0f071ac0944
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.16.3"
+
       - name: Generate all files
         run: nix-shell --run 'make gen'
+
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+
       - name: go vet
         run: go mod tidy && go vet ./...
+
       - name: golangci-lint brought to you by Nix
         run: nix-shell --run 'GOROOT= golangci-lint run -v'
+
       - name: go test
         run: go test -v ./... -gcflags=-l
+
       - name: go test coverage
         run: go test -coverprofile=coverage.txt ./... -gcflags=-l
+
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
+
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'
+
       - name: Docker Image Tag for Sha
         id: docker-image-tag
         run: |
           echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
+
       - name: Login to quay.io
         uses: docker/login-action@v1
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
@@ -53,6 +68,7 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: quay.io/tinkerbell/boots
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,25 @@ on:
   pull_request:
 
 jobs:
+  get-runner:
+    runs-on: [ubuntu-latest]
+    outputs:
+      runner: ${{ steps.get-runner.outputs.runner }}
+    steps:
+      - name: Get Runner
+        id: get-runner
+        run: |
+          if [[ "${{ github.event.repository.owner.login }}" == "tinkerbell" ]]; then
+            echo "using self-hosted"
+            echo ::set-output name=runner::self-hosted,X64
+          else
+            echo "using github-hosted"
+            echo ::set-output name=runner::ubuntu-latest
+          fi
+
   validation:
-    runs-on: [self-hosted, X64]
+    needs: [get-runner]
+    runs-on: ${{ needs.get-runner.outputs.runner }}
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,6 @@ jobs:
       - name: Non Go formatters and linters
         run: ./.github/workflows/ci-non-go.sh
 
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.16.3"
 
       - name: Generate all files
         run: nix-shell --run 'make gen'
@@ -39,16 +35,17 @@ jobs:
         run: ./bin/goimports -d . | (! grep .)
 
       - name: go vet
-        run: go mod tidy && go vet ./...
+        run: |
+          nix-shell --run 'go mod tidy && go vet ./...'
 
       - name: golangci-lint brought to you by Nix
-        run: nix-shell --run 'GOROOT= golangci-lint run -v'
+        run: nix-shell --run 'golangci-lint run -v'
 
       - name: go test
-        run: go test -v ./... -gcflags=-l
+        run: nix-shell --run 'go test -v ./... -gcflags=-l'
 
       - name: go test coverage
-        run: go test -coverprofile=coverage.txt ./... -gcflags=-l
+        run: nix-shell --run 'go test -coverprofile=coverage.txt ./... -gcflags=-l'
 
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,7 @@ golangci-lint: ## Run golangci-lint
 
 validate-local: vet coverage goimports golangci-lint ## Runs all the same validations and tests that run in CI
 
+tools: $(toolsBins) ## Builds go based tools out of tools.go
+
 help: ## Print this help
 	@grep --no-filename -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/:.*##/·/' | sort | column -ts '·' -c 120

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: help
 boots: cmd/boots/boots ## Compile boots for host OS and Architecture
 
 crosscompile: $(crossbinaries) ## Compile boots for all architectures
-	
+
 gen: $(generated_go_files) ## Generate go generate'd files
 
 IMAGE_TAG ?= boots:latest

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tinkerbell/ipxedust v0.0.0-20220106182341-d4f6c38cecdd h1:QnZU7MqsrPjqaE0Zp9qrVwqghomFeZ5AIDlWlf6R1sI=
-github.com/tinkerbell/ipxedust v0.0.0-20220106182341-d4f6c38cecdd/go.mod h1:WgjBPZVkWlD6RS+Pq9TmXpf62xW28UQr+ayrOd+znCo=
 github.com/tinkerbell/ipxedust v0.0.0-20220115003831-1c488c3b00ae h1:PrEh1FSUH8JxTHSW9RB5qLx0KXLfs6F42LlLfAic+v0=
 github.com/tinkerbell/ipxedust v0.0.0-20220115003831-1c488c3b00ae/go.mod h1:WgjBPZVkWlD6RS+Pq9TmXpf62xW28UQr+ayrOd+znCo=
 github.com/tinkerbell/tink v0.0.0-20201109122352-0e8e57332303 h1:R371mpGgSgSAcfcAtnAFrwtJTNXGu99Q3EGhQJCJPZQ=

--- a/rules.mk
+++ b/rules.mk
@@ -40,8 +40,9 @@ endif
 toolsBins := $(addprefix bin/,$(notdir $(shell grep '^\s*_' tools.go | awk -F'"' '{print $$2}')))
 
 # installs cli tools defined in tools.go
+$(toolsBins): CMD=$(shell awk -F'"' '/$(@F)/{print $$2}' tools.go | tr -d '\n')
 $(toolsBins): go.sum tools.go
-	go install $$(awk -F'"' '/$(@F)/{print $$2}' tools.go)
+	go install $(CMD)
 
 generated_go_files := \
 	packet/mock_cacher/cacher_mock.go \

--- a/rules.mk
+++ b/rules.mk
@@ -42,13 +42,13 @@ toolsBins := $(addprefix bin/,$(notdir $(shell grep '^\s*_' tools.go | awk -F'"'
 # installs cli tools defined in tools.go
 $(toolsBins): go.sum tools.go
 	go install $$(awk -F'"' '/$(@F)/{print $$2}' tools.go)
-	
+
 generated_go_files := \
 	packet/mock_cacher/cacher_mock.go \
 	packet/mock_workflow/workflow_mock.go \
 	syslog/facility_string.go \
 	syslog/severity_string.go \
-	
+
 .PHONY: $(generated_go_files)
 
 # go generate


### PR DESCRIPTION
## Description

Enable using our GitHub Actions workflows from forks.

## Why is this needed

I was developing a couple of changes to boots and trying it out in production along with @ScottGarman. The code lived in my fork and the images were being pushed up to my personal quay repository. At one point I committed a fix and left for the day, but forgot to manually build the image and push. This left @ScottGarman stuck and needing to work around my lack of push. Why must I manually push when GitHub can do it for me?

I've been after this for a while now but failed because I was trying to push the "merged" code GitHub creates for the pull_request events. This happens in the target repository's context and thus secrets are not present for PRs from forks. I had some ideas to get around this by using the `pull_request_target` event but that ran against some lack of features in `buildx` and I burned out on that effort. This is a nice compromise though. Since the build happens for the `push` event, this actually takes place from the source's context and can use the secrets for the fork if present. If branches are kept up to date with upstream's `main` then that is just as good as the `pull_request`'s fake-merge.

## How Has This Been Tested?

Tested from my fork :tada:! https://github.com/mmlb/tinkerbell-boots/actions?query=branch%3Aenable-push-to-registry-for-forks

## How are existing users impacted? What migration steps/scripts do we need?

Allows for testing of code using "upstream test procedure" before opening PRs for forks.
Allows for pushing to a container image registry from a fork if secrets are defined, which makes for easier dev testing.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
