### PR TITLE
Change from "packet" to "metal"

### DIFF
--- a/installers/coreos/ipxe_script_test.go
+++ b/installers/coreos/ipxe_script_test.go
@@ -31,7 +31,7 @@ func TestScript(t *testing.T) {
 				s.Echo("Tinkerbell Boots iPXE")
 				s.Set("iface", "eth0").Or("shell")
 				s.Set("tinkerbell", "http://127.0.0.1")
-				s.Set("ipxe_cloud_config", "packet")
+				s.Set("ipxe_cloud_config", "metal")
 				i := Installer{}
 				bs := i.BootScript()(context.Background(), m.Job(), s)
 				got := string(bs.Bytes())
@@ -48,7 +48,7 @@ var type2Script = map[string]string{
 	"baremetal_0": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -64,7 +64,7 @@ boot
 	"baremetal_1": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -80,7 +80,7 @@ boot
 	"baremetal_2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -96,7 +96,7 @@ boot
 	"baremetal_3": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -112,7 +112,7 @@ boot
 	"baremetal_2a": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -128,7 +128,7 @@ boot
 	"baremetal_2a2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -144,7 +144,7 @@ boot
 	"baremetal_hua": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system

--- a/installers/custom_ipxe/ipxe_script_test.go
+++ b/installers/custom_ipxe/ipxe_script_test.go
@@ -29,7 +29,7 @@ func TestScript(t *testing.T) {
 			s.Echo("Tinkerbell Boots iPXE")
 			s.Set("iface", "eth0").Or("shell")
 			s.Set("tinkerbell", "http://127.0.0.1")
-			s.Set("ipxe_cloud_config", "packet")
+			s.Set("ipxe_cloud_config", "metal")
 			ci := Installer{}
 			bs := ci.BootScript()(context.Background(), m.Job(), s)
 			got := string(bs.Bytes())
@@ -44,7 +44,7 @@ var type2Script = map[string]string{
 	"baremetal_0": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -59,7 +59,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_1": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -74,7 +74,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -89,7 +89,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_3": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -104,7 +104,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_2a": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -119,7 +119,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_2a2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -134,7 +134,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_2a4": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -149,7 +149,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_2a5": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -164,7 +164,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"baremetal_hua": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -179,7 +179,7 @@ chain --autofree http://127.0.0.1/fake_ipxe_url
 	"c2.large.arm": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system

--- a/installers/nixos/ipxe_script_test.go
+++ b/installers/nixos/ipxe_script_test.go
@@ -42,7 +42,7 @@ func TestScript(t *testing.T) {
 			s.Echo("Tinkerbell Boots iPXE")
 			s.Set("iface", "eth0").Or("shell")
 			s.Set("tinkerbell", "http://127.0.0.1")
-			s.Set("ipxe_cloud_config", "packet")
+			s.Set("ipxe_cloud_config", "metal")
 			n := Installer{Paths: oshwToInitPath}
 			bs := n.BootScript()(context.Background(), m.Job(), s)
 			got := string(bs.Bytes())
@@ -57,7 +57,7 @@ var type2Script = map[string]string{
 	"17_03/t1.small.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -73,7 +73,7 @@ boot
 	"17_03/c1.small.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -89,7 +89,7 @@ boot
 	"17_03/m1.xlarge.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -105,7 +105,7 @@ boot
 	"17_03/c1.xlarge.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -121,7 +121,7 @@ boot
 	"18_03/t1.small.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -137,7 +137,7 @@ boot
 	"18_03/c1.small.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -153,7 +153,7 @@ boot
 	"18_03/c2.medium.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -169,7 +169,7 @@ boot
 	"18_03/m1.xlarge.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -185,7 +185,7 @@ boot
 	"18_03/m2.xlarge.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -201,7 +201,7 @@ boot
 	"18_03/c1.xlarge.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -217,7 +217,7 @@ boot
 	"18_03/c1.large.arm": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -233,7 +233,7 @@ boot
 	"18_03/s1.large.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -249,7 +249,7 @@ boot
 	"18_03/x1.small.x86": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -265,13 +265,13 @@ boot
 	"18_03/xx.nano.s390": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 shell
 `,
 	"20_09/c3.small.x86:nix-store-path-masquerading-as-version": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system

--- a/installers/osie/ipxe_script_test.go
+++ b/installers/osie/ipxe_script_test.go
@@ -57,7 +57,7 @@ func TestScript(t *testing.T) {
 					s.Set("iface", "eth0").Or("shell")
 					s.Set("tinkerbell", "http://127.0.0.1")
 					s.Set("syslog_host", "127.0.0.1")
-					s.Set("ipxe_cloud_config", "packet")
+					s.Set("ipxe_cloud_config", "metal")
 					o := Installer{}
 					ctx := context.Background()
 					var bs ipxe.Script
@@ -109,7 +109,7 @@ var prefaces = map[string]string{
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
 set syslog_host 127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 set action %s
 set state %s
 set arch %s
@@ -121,7 +121,7 @@ set base-url http://install.ewr1.packet.net/misc/osie/current
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
 set syslog_host 127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -139,7 +139,7 @@ set bootdevmac %s
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
 set syslog_host 127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 set action %s
 set state %s
 set arch %s

--- a/installers/rancher/ipxe_script_test.go
+++ b/installers/rancher/ipxe_script_test.go
@@ -27,7 +27,7 @@ func TestScript(t *testing.T) {
 			s.Echo("Tinkerbell Boots iPXE")
 			s.Set("iface", "eth0").Or("shell")
 			s.Set("tinkerbell", "http://127.0.0.1")
-			s.Set("ipxe_cloud_config", "packet")
+			s.Set("ipxe_cloud_config", "metal")
 			r := Installer{}
 			bs := r.BootScript()(context.Background(), m.Job(), s)
 			got := string(bs.Bytes())
@@ -42,7 +42,7 @@ var type2Script = map[string]string{
 	"baremetal_0": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -58,7 +58,7 @@ boot
 	"baremetal_1": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -74,7 +74,7 @@ boot
 	"baremetal_2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -90,7 +90,7 @@ boot
 	"baremetal_3": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -106,7 +106,7 @@ boot
 	"baremetal_2a": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -122,7 +122,7 @@ boot
 	"baremetal_2a2": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system
@@ -138,7 +138,7 @@ boot
 	"baremetal_hua": `echo Tinkerbell Boots iPXE
 set iface eth0 || shell
 set tinkerbell http://127.0.0.1
-set ipxe_cloud_config packet
+set ipxe_cloud_config metal
 
 params
 param body Device connected to DHCP system

--- a/job/ipxe.go
+++ b/job/ipxe.go
@@ -68,7 +68,7 @@ func (j Job) serveBootScript(ctx context.Context, w http.ResponseWriter, name st
 	s.Set("iface", j.InterfaceName(0)).Or("shell")
 	s.Set("tinkerbell", "http://"+conf.PublicFQDN)
 	s.Set("syslog_host", conf.PublicSyslogFQDN)
-	s.Set("ipxe_cloud_config", "packet")
+	s.Set("ipxe_cloud_config", "metal")
 
 	s.Echo("Tinkerbell Boots iPXE")
 


### PR DESCRIPTION
## Description

Change ipxe_cloud_config from "packet" to "metal" to match the change made in https://github.com/netbootxyz/netboot.xyz/pull/1076.

## Why is this needed

Fixes: #

## How Has This Been Tested?

`make test` and will be tested in one production facility to see that netbooting works without applying a work-around via the IDRAC console.

## How are existing users impacted? What migration steps/scripts do we need?

Fixes a problem where c3.medium Dell hardware does not configure the serial console correctly on netboot.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
