### PR TITLE
Make local registry and nginx optional

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -99,14 +99,30 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 
 	if j.CanWorkflow() {
 		buildWorkerParams()
-		s.Args("docker_registry=" + dockerRegistry)
+		if len(dockerRegistry) > 0 {
+			s.Args("docker_registry=" + dockerRegistry)
+		}
+		if len(registryUsername) > 0 {
+			s.Args("registry_username=" + registryUsername)
+			s.Args("registry_password=" + registryPassword)
+		}
+		if len(registryCertUrl) > 0 {
+			s.Args("registry_cert_url=" + registryCertUrl)
+		}
+		if len(registryCertRequired) > 0 {
+			s.Args("registry_cert_required=" + registryCertRequired)
+		}
+		if len(useAbsoluteImageURI) > 0 {
+			s.Args("use_absolute_image_uri=" + useAbsoluteImageURI)
+		}
 		s.Args("grpc_authority=" + grpcAuthority)
 		s.Args("grpc_cert_url=" + grpcCertURL)
 		s.Args("instance_id=" + j.InstanceID())
-		s.Args("registry_username=" + registryUsername)
-		s.Args("registry_password=" + registryPassword)
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID().String())
+		if len(tinkWorkerImage) > 0 {
+			s.Args("tink_worker_image=" + tinkWorkerImage)
+		}
 	}
 
 	s.Args("packet_bootdev_mac=${bootdevmac}")
@@ -188,6 +204,9 @@ func isCustomOSIE(j job.Job) bool {
 
 // osieBaseURL returns the value of Custom OSIE Service Version or just /current
 func osieBaseURL(j job.Job) string {
+	if osiePathOverride != "" {
+		return osiePathOverride
+	}
 	if u := j.OSIEBaseURL(); u != "" {
 		return u
 	}

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -14,11 +14,17 @@ const (
 )
 
 var (
-	osieURL                            = mustBuildOSIEURL().String()
-	mirrorBaseURL                      = conf.MirrorBaseUrl
-	dockerRegistry                     string
-	grpcAuthority, grpcCertURL         string
-	registryUsername, registryPassword string
+	osieURL                    = mustBuildOSIEURL().String()
+	osiePathOverride           = getOSIEPathOverride()
+	mirrorBaseURL              = conf.MirrorBaseUrl
+	dockerRegistry             string
+	grpcAuthority, grpcCertURL string
+	registryUsername           string
+	registryPassword           string
+	registryCertUrl            string		
+	registryCertRequired       string		
+	tinkWorkerImage            string
+	useAbsoluteImageURI  string
 )
 
 func buildOSIEURL() (*url.URL, error) {
@@ -42,6 +48,22 @@ func buildOSIEURL() (*url.URL, error) {
 	return u, nil
 }
 
+func getOSIEPathOverride() string {
+	base, err := url.Parse(conf.MirrorBaseUrl)
+	if err != nil {
+		panic(errors.Wrap(err, "parsing MirrorBaseUrl"))
+	}
+	if s, ok := os.LookupEnv("OSIE_PATH_OVERRIDE"); ok {
+		u, err := base.Parse(s)
+		if err != nil {
+			panic(errors.Wrapf(err, "invalid OSIE_PATH_OVERRIDE: %s", s))
+		}
+
+		return u.String() 
+	}
+	return ""
+}
+
 func mustBuildOSIEURL() *url.URL {
 	u, err := buildOSIEURL()
 	if err != nil {
@@ -52,11 +74,15 @@ func mustBuildOSIEURL() *url.URL {
 }
 
 func buildWorkerParams() {
-	dockerRegistry = getParam("DOCKER_REGISTRY")
+	dockerRegistry = os.Getenv("DOCKER_REGISTRY")
 	grpcAuthority = getParam("TINKERBELL_GRPC_AUTHORITY")
 	grpcCertURL = getParam("TINKERBELL_CERT_URL")
-	registryUsername = getParam("REGISTRY_USERNAME")
-	registryPassword = getParam("REGISTRY_PASSWORD")
+	registryUsername = os.Getenv("REGISTRY_USERNAME")
+	registryPassword = os.Getenv("REGISTRY_PASSWORD")
+	registryCertUrl = os.Getenv("REGISTRY_CERT_URL")
+	registryCertRequired = os.Getenv("REGISTRY_CERT_REQUIRED")
+	tinkWorkerImage = os.Getenv("TINK_WORKER_IMAGE")
+	useAbsoluteImageURI = os.Getenv("USE_ABSOLUTE_IMAGE_URI")
 }
 
 func getParam(key string) string {


### PR DESCRIPTION
* Add environment variables for
	- OSIE path override
        - Custom URL for registry CA certificate
        - tink-worker image:tag and path
	- Registry certificate required
	- Template action image absolute path URIs
  These environment variables allow
	- Bypassing the requirement for OSIE artifacts to be under
          predefined paths
	- Specifying custom URL for downloading CA certificate for
          the registry, which can be passed on to Hook for tink-docker
	  setup
	- Specifying custom tink-worker image:tag and path, which can
	  be passed to hook for tink-worker image pull
	- Specifying whether a registry certificate is required and needs
	  to be downloaded from either the default path hosted under
	  workflow directory on MIRROR_HOST webserver or from one specified
	  via custom path mentioned above
	- Specifying whether to consider the action image URIs specified in
	  the template as absolute paths and skip prepending registry to
          these
* Make registry username/password optional to allow for public registry
  pulls

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
