### PR TITLE
Disambiguate ipxe HTTP URLs from other boots URLs

### DIFF
--- a/cmd/boots/dhcp.go
+++ b/cmd/boots/dhcp.go
@@ -26,10 +26,10 @@ import (
 func ServeDHCP(addr string, nextServer net.IP, ipxeBaseURL string, bootsBaseURL string) {
 	poolSize := env.Int("BOOTS_DHCP_WORKERS", runtime.GOMAXPROCS(0)/2)
 	handler := dhcpHandler{
-		pool:           workerpool.New(poolSize),
-		nextServer:     nextServer,
-		ipxeBaseURL:    ipxeBaseURL,
-		bootsBaseURL:   bootsBaseURL,
+		pool:         workerpool.New(poolSize),
+		nextServer:   nextServer,
+		ipxeBaseURL:  ipxeBaseURL,
+		bootsBaseURL: bootsBaseURL,
 	}
 	defer handler.pool.Stop()
 
@@ -44,10 +44,10 @@ func ServeDHCP(addr string, nextServer net.IP, ipxeBaseURL string, bootsBaseURL 
 }
 
 type dhcpHandler struct {
-	pool           *workerpool.WorkerPool
-	nextServer     net.IP
-	ipxeBaseURL    string
-	bootsBaseURL   string
+	pool         *workerpool.WorkerPool
+	nextServer   net.IP
+	ipxeBaseURL  string
+	bootsBaseURL string
 }
 
 func (d dhcpHandler) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) {

--- a/cmd/boots/dhcp.go
+++ b/cmd/boots/dhcp.go
@@ -23,12 +23,13 @@ import (
 // ServeDHCP starts the DHCP server.
 // It takes the next server address (nextServer) for serving iPXE binaries via TFTP
 // and an IP:Port (httpServerFQDN) for serving iPXE binaries via HTTP.
-func ServeDHCP(addr string, nextServer net.IP, httpServerFQDN string) {
+func ServeDHCP(addr string, nextServer net.IP, ipxeBaseURL string, bootsBaseURL string) {
 	poolSize := env.Int("BOOTS_DHCP_WORKERS", runtime.GOMAXPROCS(0)/2)
 	handler := dhcpHandler{
 		pool:           workerpool.New(poolSize),
 		nextServer:     nextServer,
-		httpServerFQDN: httpServerFQDN,
+		ipxeBaseURL:    ipxeBaseURL,
+		bootsBaseURL:   bootsBaseURL,
 	}
 	defer handler.pool.Stop()
 
@@ -45,7 +46,8 @@ func ServeDHCP(addr string, nextServer net.IP, httpServerFQDN string) {
 type dhcpHandler struct {
 	pool           *workerpool.WorkerPool
 	nextServer     net.IP
-	httpServerFQDN string
+	ipxeBaseURL    string
+	bootsBaseURL   string
 }
 
 func (d dhcpHandler) ServeDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) {
@@ -99,7 +101,8 @@ func (d dhcpHandler) serveDHCP(w dhcp4.ReplyWriter, req *dhcp4.Packet) {
 		return
 	}
 	span.End()
-	j.HTTPServerFQDN = d.httpServerFQDN
+	j.IpxeBaseURL = d.ipxeBaseURL
+	j.BootsBaseURL = d.bootsBaseURL
 	j.NextServer = d.nextServer
 
 	go func() {

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -165,6 +165,7 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 	} else {
 		isHTTPClient = true
 		filename = "auto.ipxe"
+		j.HTTPServerFQDN = conf.PublicFQDN
 	}
 
 	if filename == "" {
@@ -174,5 +175,5 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 		return
 	}
 
-	dhcp.SetFilename(rep, filename, j.NextServer, isHTTPClient, conf.PublicFQDN)
+	dhcp.SetFilename(rep, filename, j.NextServer, isHTTPClient, j.HTTPServerFQDN)
 }

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -7,7 +7,6 @@ import (
 
 	dhcp4 "github.com/packethost/dhcp4-go"
 	"github.com/pkg/errors"
-	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/dhcp"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/packet"
@@ -139,7 +138,9 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 	}
 
 	var filename string
+	httpPrefix := j.BootsBaseURL
 	if !isTinkerbellIPXE {
+		httpPrefix = j.IpxeBaseURL
 		if j.PArch() == "hua" || j.PArch() == "2a2" {
 			filename = "snp.efi"
 		} else if isARM {
@@ -165,7 +166,6 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 	} else {
 		isHTTPClient = true
 		filename = "auto.ipxe"
-		j.HTTPServerFQDN = conf.PublicFQDN
 	}
 
 	if filename == "" {
@@ -175,5 +175,5 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 		return
 	}
 
-	dhcp.SetFilename(rep, filename, j.NextServer, isHTTPClient, j.HTTPServerFQDN)
+	dhcp.SetFilename(rep, filename, j.NextServer, isHTTPClient, httpPrefix)
 }

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -87,9 +87,9 @@ func TestSetPXEFilename(t *testing.T) {
 					PlanSlug: "baremetal_" + tt.plan,
 					Instance: instance,
 				},
-				instance:       instance,
-				NextServer:     conf.PublicIPv4,
-				IpxeBaseURL: conf.PublicFQDN + "/ipxe",
+				instance:     instance,
+				NextServer:   conf.PublicIPv4,
+				IpxeBaseURL:  conf.PublicFQDN + "/ipxe",
 				BootsBaseURL: conf.PublicFQDN,
 			}
 			rep := dhcp4.NewPacket(42)

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -54,7 +54,7 @@ func TestSetPXEFilename(t *testing.T) {
 			uefi: true, filename: "ipxe.efi"},
 		{name: "x86 uefi http client",
 			uefi: true, allowPXE: true, httpClient: true,
-			filename: "http://" + conf.PublicFQDN + "/ipxe.efi"},
+			filename: "http://" + conf.PublicFQDN + "/ipxe/ipxe.efi"},
 		{name: "all defaults",
 			filename: "undionly.kpxe"},
 		{name: "packet iPXE",
@@ -89,7 +89,8 @@ func TestSetPXEFilename(t *testing.T) {
 				},
 				instance:       instance,
 				NextServer:     conf.PublicIPv4,
-				HTTPServerFQDN: conf.PublicFQDN,
+				IpxeBaseURL: conf.PublicFQDN + "/ipxe",
+				BootsBaseURL: conf.PublicFQDN,
 			}
 			rep := dhcp4.NewPacket(42)
 			j.setPXEFilename(&rep, tt.packet, tt.arm, tt.uefi, tt.httpClient)

--- a/job/job.go
+++ b/job/job.go
@@ -47,7 +47,8 @@ type Job struct {
 	hardware       packet.Hardware
 	instance       *packet.Instance
 	NextServer     net.IP
-	HTTPServerFQDN string
+	IpxeBaseURL    string
+	BootsBaseURL   string
 }
 
 type Installers struct {

--- a/job/job.go
+++ b/job/job.go
@@ -39,16 +39,16 @@ func SetProvisionerEngineName(engineName string) {
 // Job holds per request data
 type Job struct {
 	log.Logger
-	mac            net.HardwareAddr
-	ip             net.IP
-	start          time.Time
-	mode           Mode
-	dhcp           dhcp.Config
-	hardware       packet.Hardware
-	instance       *packet.Instance
-	NextServer     net.IP
-	IpxeBaseURL    string
-	BootsBaseURL   string
+	mac          net.HardwareAddr
+	ip           net.IP
+	start        time.Time
+	mode         Mode
+	dhcp         dhcp.Config
+	hardware     packet.Hardware
+	instance     *packet.Instance
+	NextServer   net.IP
+	IpxeBaseURL  string
+	BootsBaseURL string
 }
 
 type Installers struct {


### PR DESCRIPTION
## Description

With the splitting out of ipxedust, the goal is for boots to be able to send DHCP responses
that point to a separate ipxedust server. The code didn't fully make that distinction
all the way down to the DHCP responses.

## Why is this needed

Reverts #246 
Fixes the issue identified in #246

## How Has This Been Tested?

- [ ] In a sandbox
- [x] In EM Production

## How are existing users impacted? What migration steps/scripts do we need?

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
