### PR TITLE
switch to handling rescue with the default installer

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -314,11 +314,10 @@ func registerInstallers() job.Installers {
 	i.RegisterDistro("nixos", n.BootScript())
 	// register osie
 	o := osie.Installer{}
-	i.RegisterDistro("alpine", o.Rescue())
 	i.RegisterDistro("discovery", o.Discover())
 	// register osie as default
 	d := osie.Installer{}
-	i.RegisterDefaultInstaller(d.Install())
+	i.RegisterDefaultInstaller(d.DefaultHandler())
 	// register rancher
 	r := rancher.Installer{}
 	i.RegisterDistro("rancher", r.BootScript())

--- a/installers/osie/ipxe_script_test.go
+++ b/installers/osie/ipxe_script_test.go
@@ -66,9 +66,9 @@ func TestScript(t *testing.T) {
 					var bs ipxe.Script
 					switch action {
 					case "rescue":
-						bs = o.Rescue()(ctx, m.Job(), s)
+						bs = o.rescue()(ctx, m.Job(), s)
 					case "install":
-						bs = o.Install()(ctx, m.Job(), s)
+						bs = o.install()(ctx, m.Job(), s)
 					case "discover":
 						bs = o.Discover()(ctx, m.Job(), s)
 					}

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -12,6 +12,16 @@ import (
 
 type Installer struct{}
 
+func (i Installer) DefaultHandler() job.BootScript {
+	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
+		if j.Rescue() {
+			return i.Rescue()(ctx, j, s)
+		}
+
+		return i.Install()(ctx, j, s)
+	}
+}
+
 func (i Installer) Rescue() job.BootScript {
 	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
 		s.Set("action", "rescue")

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -12,17 +12,21 @@ import (
 
 type Installer struct{}
 
+// DefaultHandler determines the ipxe boot script to be returned.
+// If the job has an instance with Rescue true, the rescue boot script is returned.
+// Otherwise the installation boot script is returned.
 func (i Installer) DefaultHandler() job.BootScript {
 	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
 		if j.Rescue() {
-			return i.Rescue()(ctx, j, s)
+			return i.rescue()(ctx, j, s)
 		}
 
-		return i.Install()(ctx, j, s)
+		return i.install()(ctx, j, s)
 	}
 }
 
-func (i Installer) Rescue() job.BootScript {
+// rescue generates the ipxe boot script for booting into osie in rescue mode
+func (i Installer) rescue() job.BootScript {
 	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
 		s.Set("action", "rescue")
 		s.Set("state", j.HardwareState())
@@ -31,7 +35,8 @@ func (i Installer) Rescue() job.BootScript {
 	}
 }
 
-func (i Installer) Install() job.BootScript {
+// install generates the ipxe boot script for booting into the osie installer
+func (i Installer) install() job.BootScript {
 	return func(ctx context.Context, j job.Job, s ipxe.Script) ipxe.Script {
 		typ := "provisioning.104.01"
 		if j.HardwareState() == "deprovisioning" {

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -71,6 +71,14 @@ func (j Job) InstanceID() string {
 	return ""
 }
 
+func (j Job) Rescue() bool {
+	if i := j.instance; i != nil {
+		return i.Rescue
+	}
+
+	return false
+}
+
 // UserData returns instance.UserData
 func (j Job) UserData() string {
 	if i := j.instance; i != nil {


### PR DESCRIPTION
## Description

An override for `alpine` was defined that forced any alpine distro to trigger the rescue environment.

This isn't great logic as Alpine is a true OS and may want to be provisioned.

This changes the default installer to detect whether Rescue was requested and trigger the rescue path when enabled.

## Why is this needed

To cleanup old logic that doesn't make sense and allow for an Alpine OS to properly boot to the default installer.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
