### PR TITLE
Allow registry, registry username and password to be empty strings

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -114,12 +114,18 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 
 	if j.CanWorkflow() {
 		buildWorkerParams()
-		s.Args("docker_registry=" + dockerRegistry)
+		if dockerRegistry != "" {
+			s.Args("docker_registry=" + dockerRegistry)
+		}
 		s.Args("grpc_authority=" + grpcAuthority)
 		s.Args("grpc_cert_url=" + grpcCertURL)
 		s.Args("instance_id=" + j.InstanceID())
-		s.Args("registry_username=" + registryUsername)
-		s.Args("registry_password=" + registryPassword)
+		if registryUsername != "" {
+			s.Args("registry_username=" + registryUsername)
+		}
+		if registryPassword != "" {
+			s.Args("registry_password=" + registryPassword)
+		}
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID().String())
 	}

--- a/installers/osie/mirror.go
+++ b/installers/osie/mirror.go
@@ -52,11 +52,11 @@ func mustBuildOSIEURL() *url.URL {
 }
 
 func buildWorkerParams() {
-	dockerRegistry = getParam("DOCKER_REGISTRY")
+	dockerRegistry = os.Getenv("DOCKER_REGISTRY")
 	grpcAuthority = getParam("TINKERBELL_GRPC_AUTHORITY")
 	grpcCertURL = getParam("TINKERBELL_CERT_URL")
-	registryUsername = getParam("REGISTRY_USERNAME")
-	registryPassword = getParam("REGISTRY_PASSWORD")
+	registryUsername = os.Getenv("REGISTRY_USERNAME")
+	registryPassword = os.Getenv("REGISTRY_PASSWORD")
 }
 
 func getParam(key string) string {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Allow registry, registry username, and password to be empty strings. These values are passed as kernel command line args for OSIE's boot up and then used by Tink worker when it pulls and runs containers. With [this](https://github.com/tinkerbell/tink/pull/607) change to Tink worker, allowing the empty string here provides Tink worker the ability to specify any fully qualified container image in a template. e.g. `docker.io/alpine`, `quay.io/tinkerbell-actions/cexec`, `public.ecr.aws/l0g8r8j6/tinkerbell/pbnj`, etc

This change is backward compatible and shouldn't negatively affect using the Cacher backend.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
