### PR TITLE
Add kernel commandline parameter for specifying the tink-worker image:

### DIFF
--- a/cmd/boots/http.go
+++ b/cmd/boots/http.go
@@ -55,15 +55,16 @@ func otelFuncWrapper(route string, h func(w http.ResponseWriter, req *http.Reque
 }
 
 type jobHandler struct {
-	i job.Installers
+	i               job.Installers
+	tinkWorkerImage string
 }
 
 // ServeHTTP sets up all the HTTP routes using a stdlib mux and starts the http
 // server, which will block. App functionality is instrumented in Prometheus and
 // OpenTelemetry. Optionally configures X-Forwarded-For support.
-func ServeHTTP(i job.Installers, addr string, ipxePattern string, ipxeHandler func(http.ResponseWriter, *http.Request)) {
+func ServeHTTP(i job.Installers, addr, tinkWorkerImage string, ipxePattern string, ipxeHandler func(http.ResponseWriter, *http.Request)) {
 	mux := http.NewServeMux()
-	s := jobHandler{i: i}
+	s := jobHandler{i: i, tinkWorkerImage: tinkWorkerImage}
 	mux.Handle(otelFuncWrapper("/", s.serveJobFile))
 	if ipxeHandler != nil {
 		mux.Handle(otelFuncWrapper(ipxePattern, ipxeHandler))
@@ -148,6 +149,8 @@ func (h *jobHandler) serveJobFile(w http.ResponseWriter, req *http.Request) {
 
 		return
 	}
+	// set Tink Worker image location
+	j.TinkWorkerImage = h.tinkWorkerImage
 	// This gates serving PXE file by
 	// 1. the existence of a hardware record in tink server
 	// AND

--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -76,6 +76,8 @@ type config struct {
 	syslogAddr string
 	// loglevel is the log level for boots
 	logLevel string
+	// tinkWorkerImage is used in kernel command line parameters to define where the Tink worker image is located.
+	tinkWorkerImage string
 }
 
 func main() {
@@ -196,7 +198,7 @@ func main() {
 	mainlog.With("addr", cfg.dhcpAddr).Info("serving dhcp")
 	go ServeDHCP(cfg.dhcpAddr, nextServer, ipxeBaseURL, bootsBaseURL)
 	mainlog.With("addr", cfg.httpAddr).Info("serving http")
-	go ServeHTTP(registerInstallers(), cfg.httpAddr, ipxePattern, ipxeHandler)
+	go ServeHTTP(registerInstallers(), cfg.httpAddr, cfg.tinkWorkerImage, ipxePattern, ipxeHandler)
 
 	<-ctx.Done()
 	mainlog.Info("boots shutting down")
@@ -286,6 +288,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	fs.StringVar(&cfg.logLevel, "log-level", "info", "log level.")
 	fs.StringVar(&cfg.dhcpAddr, "dhcp-addr", conf.BOOTPBind, "IP and port to listen on for DHCP.")
 	fs.StringVar(&cfg.syslogAddr, "syslog-addr", conf.SyslogBind, "IP and port to listen on for syslog messages.")
+	fs.StringVar(&cfg.tinkWorkerImage, "tink-worker-image", "quay.io/tinkerbell/tink:latest", "Tink worker image for use as kernel commandline parameter.")
 
 	return &ffcli.Command{
 		Name:       name,

--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -26,6 +26,7 @@ func TestParser(t *testing.T) {
 		httpAddr:           "192.168.2.225:8080",
 		dhcpAddr:           "0.0.0.0:67",
 		syslogAddr:         "0.0.0.0:514",
+		tinkWorkerImage:    "quay.io/tinkerbell/tink:latest",
 		logLevel:           "info",
 	}
 	got := &config{}
@@ -79,6 +80,7 @@ FLAGS
   -ipxe-tftp-timeout      local iPXE TFTP server requests timeout. (default "5s")
   -log-level              log level. (default "info")
   -syslog-addr            IP and port to listen on for syslog messages. (default "%[1]v:514")
+  -tink-worker-image      Tink worker image for use as kernel commandline parameter. (default "quay.io/tinkerbell/tink:latest")
 `, defaultIP)
 	c := &config{}
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -128,6 +128,9 @@ func kernelParams(ctx context.Context, action, state string, j job.Job, s ipxe.S
 		}
 		s.Args("packet_base_url=" + workflowBaseURL())
 		s.Args("worker_id=" + j.HardwareID().String())
+		if j.TinkWorkerImage != "" {
+			s.Args("tink_worker_image=" + j.TinkWorkerImage)
+		}
 	}
 
 	s.Args("packet_bootdev_mac=${bootdevmac}")

--- a/job/job.go
+++ b/job/job.go
@@ -49,6 +49,8 @@ type Job struct {
 	NextServer   net.IP
 	IpxeBaseURL  string
 	BootsBaseURL string
+	// TinkWorkerImage is used in kernel command line parameters to define where the Tink worker image is located.
+	TinkWorkerImage string
 }
 
 type Installers struct {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows flexibility from where to pull the tink worker container image. This will be needed if the env var `DOCKER_REGISTRY` is not specified.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
