### PR TITLE
Allow extra kernel args, set via cli flag:

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -347,7 +347,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	fs.StringVar(&cfg.logLevel, "log-level", "info", "log level.")
 	fs.StringVar(&cfg.dhcpAddr, "dhcp-addr", conf.BOOTPBind, "IP and port to listen on for DHCP.")
 	fs.StringVar(&cfg.syslogAddr, "syslog-addr", conf.SyslogBind, "IP and port to listen on for syslog messages.")
-	fs.StringVar(&cfg.extraKernelArgs, "extra-kernel-args", "", "Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for the default iPXE installer.")
+	fs.StringVar(&cfg.extraKernelArgs, "extra-kernel-args", "", "Extra set of kernel args (k=v k=v) that are appended to the kernel cmdline when booting via iPXE.")
 
 	return &ffcli.Command{
 		Name:       name,

--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -347,7 +347,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	fs.StringVar(&cfg.logLevel, "log-level", "info", "log level.")
 	fs.StringVar(&cfg.dhcpAddr, "dhcp-addr", conf.BOOTPBind, "IP and port to listen on for DHCP.")
 	fs.StringVar(&cfg.syslogAddr, "syslog-addr", conf.SyslogBind, "IP and port to listen on for syslog messages.")
-	fs.StringVar(&cfg.extraKernelArgs, "extra-kernel-args", "", "Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for OSIE.")
+	fs.StringVar(&cfg.extraKernelArgs, "extra-kernel-args", "", "Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for the default iPXE installer.")
 
 	return &ffcli.Command{
 		Name:       name,

--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -79,6 +79,8 @@ type config struct {
 	syslogAddr string
 	// loglevel is the log level for boots
 	logLevel string
+	// extraKernelArgs are key=value pairs to be added as kernel commandline to the kernel in iPXE for OSIE
+	extraKernelArgs string
 }
 
 func main() {
@@ -205,7 +207,7 @@ func main() {
 	mainlog.With("addr", cfg.dhcpAddr).Info("serving dhcp")
 	go dhcpServer.ServeDHCP(cfg.dhcpAddr, nextServer, ipxeBaseURL, bootsBaseURL)
 	mainlog.With("addr", cfg.httpAddr).Info("serving http")
-	go httpServer.ServeHTTP(registerInstallers(), cfg.httpAddr, ipxePattern, ipxeHandler)
+	go httpServer.ServeHTTP(cfg.registerInstallers(), cfg.httpAddr, ipxePattern, ipxeHandler)
 
 	<-ctx.Done()
 	mainlog.Info("boots shutting down")
@@ -345,6 +347,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	fs.StringVar(&cfg.logLevel, "log-level", "info", "log level.")
 	fs.StringVar(&cfg.dhcpAddr, "dhcp-addr", conf.BOOTPBind, "IP and port to listen on for DHCP.")
 	fs.StringVar(&cfg.syslogAddr, "syslog-addr", conf.SyslogBind, "IP and port to listen on for syslog messages.")
+	fs.StringVar(&cfg.extraKernelArgs, "extra-kernel-args", "", "Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for OSIE.")
 
 	return &ffcli.Command{
 		Name:       name,
@@ -357,7 +360,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	}
 }
 
-func registerInstallers() job.Installers {
+func (cf *config) registerInstallers() job.Installers {
 	// register installers
 	i := job.NewInstallers()
 	// register coreos/flatcar
@@ -375,7 +378,7 @@ func registerInstallers() job.Installers {
 	o := osie.Installer{}
 	i.RegisterDistro("discovery", o.Discover())
 	// register osie as default
-	d := osie.Installer{}
+	d := osie.Installer{ExtraKernelArgs: cf.extraKernelArgs}
 	i.RegisterDefaultInstaller(d.DefaultHandler())
 	// register rancher
 	r := rancher.Installer{}

--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -70,6 +70,7 @@ func TestCustomUsageFunc(t *testing.T) {
 
 FLAGS
   -dhcp-addr              IP and port to listen on for DHCP. (default "%v:67")
+  -extra-kernel-args      Extra set of kernel args (k=v,k=v) that are appended to the kernel in iPXE for OSIE.
   -http-addr              local IP and port to listen on for the serving iPXE binaries and files via HTTP. (default "%[1]v:80")
   -ipxe-enable-http       enable serving iPXE binaries via HTTP. (default "true")
   -ipxe-enable-tftp       enable serving iPXE binaries via TFTP. (default "true")

--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -70,7 +70,7 @@ func TestCustomUsageFunc(t *testing.T) {
 
 FLAGS
   -dhcp-addr              IP and port to listen on for DHCP. (default "%v:67")
-  -extra-kernel-args      Extra set of kernel args (k=v,k=v) that are appended to the kernel in iPXE for OSIE.
+  -extra-kernel-args      Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for the default iPXE installer.
   -http-addr              local IP and port to listen on for the serving iPXE binaries and files via HTTP. (default "%[1]v:80")
   -ipxe-enable-http       enable serving iPXE binaries via HTTP. (default "true")
   -ipxe-enable-tftp       enable serving iPXE binaries via TFTP. (default "true")

--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -70,7 +70,7 @@ func TestCustomUsageFunc(t *testing.T) {
 
 FLAGS
   -dhcp-addr              IP and port to listen on for DHCP. (default "%v:67")
-  -extra-kernel-args      Extra set of kernel args (k=v k=v) that are appended to the kernel in iPXE for the default iPXE installer.
+  -extra-kernel-args      Extra set of kernel args (k=v k=v) that are appended to the kernel cmdline when booting via iPXE.
   -http-addr              local IP and port to listen on for the serving iPXE binaries and files via HTTP. (default "%[1]v:80")
   -ipxe-enable-http       enable serving iPXE binaries via HTTP. (default "true")
   -ipxe-enable-tftp       enable serving iPXE binaries via TFTP. (default "true")


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows operators to set any necessary and needed kernel commandline args to the default installer; OSIE. This makes custom kernel args a first class option instead of the current model to overload the "facility" field in the backend data.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
