### PR TITLE
Fix server panics

### DIFF
--- a/cmd/boots/http.go
+++ b/cmd/boots/http.go
@@ -69,7 +69,7 @@ type jobHandler struct {
 // OpenTelemetry. Optionally configures X-Forwarded-For support.
 func (s *BootsHTTPServer) ServeHTTP(i job.Installers, addr string, ipxePattern string, ipxeHandler func(http.ResponseWriter, *http.Request)) {
 	mux := http.NewServeMux()
-	jh := jobHandler{i: i}
+	jh := jobHandler{i: i, jobManager: s.jobManager}
 	mux.Handle(otelFuncWrapper("/", jh.serveJobFile))
 	if ipxeHandler != nil {
 		mux.Handle(otelFuncWrapper(ipxePattern, ipxeHandler))

--- a/job/job.go
+++ b/job/job.go
@@ -100,6 +100,7 @@ func (c *Creator) CreateFromDHCP(ctx context.Context, mac net.HardwareAddr, giad
 		start:                 time.Now(),
 		reporter:              c.reporter,
 		provisionerEngineName: c.provisionerEngineName,
+		Logger:                c.logger,
 	}
 	d, err := c.finder.ByMAC(ctx, mac, giaddr, circuitID)
 	if err != nil {
@@ -137,6 +138,7 @@ func (c *Creator) CreateFromIP(ctx context.Context, ip net.IP) (context.Context,
 		start:                 time.Now(),
 		reporter:              c.reporter,
 		provisionerEngineName: c.provisionerEngineName,
+		Logger:                c.logger,
 	}
 
 	c.logger.With("ip", ip).Info("discovering from ip")


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Set jobManager for HTTP server:
This fixes nil pointer dereference panic in func `serveJobFile` calling `jobHandler.jobManager.CreateFromRemoteAddr`. This panic was manifest when doing an HTTP Get for auto.ipxe

Also experiencing a nil pointer panic when calling `Job.Logger` in the job package.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
export API_AUTH_TOKEN=none
export API_CONSUMER_TOKEN=none
export DATA_MODEL_VERSION=standalone
export BOOTS_STANDALONE_JSON=./test/standalone-hardware.json
sudo -E go run ./cmd/boots/

curl -v http://<boots ip>/auto.ipxe 
```
```bash
2022/05/02 16:41:21 http: panic serving 192.168.0.240:59216: runtime error: invalid memory address or nil pointer dereference
goroutine 114 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1825 +0xbf
panic({0x1795a00, 0x200e540})
        /usr/local/go/src/runtime/panic.go:844 +0x258
main.(*jobHandler).serveJobFile(0xc0001c0c60, {0x19ba870, 0xc00007c080}, 0xc000298700)
        /Users/jacobwei/repos/tinkerbell/boots/cmd/boots/http.go:150 +0x297
net/http.HandlerFunc.ServeHTTP(0x19bafc0?, {0x19ba870?, 0xc00007c080?}, 0x0?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.WithRouteTag.func1({0x19ba870, 0xc00007c080}, 0xc000298700)
        /Users/jacobwei/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.21.0/handler.go:223 +0x1d8
net/http.HandlerFunc.ServeHTTP(0xc0001281b0?, {0x19ba870?, 0xc00007c080?}, 0xc0005dd698?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0x19bafc0?, {0x19ba870, 0xc00007c080}, 0xc000298700)
        /usr/local/go/src/net/http/server.go:2462 +0x149
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).ServeHTTP(0xc00073e000, {0x19b9940?, 0xc000126228}, 0xc000298200)
        /Users/jacobwei/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.21.0/handler.go:179 +0xaa9
github.com/tinkerbell/boots/httplog.(*Handler).ServeHTTP(0xc00007a0a0, {0x19ba090?, 0xc0004fc0e0}, 0xc000298200)
        /Users/jacobwei/repos/tinkerbell/boots/httplog/httplog.go:33 +0x322
net/http.serverHandler.ServeHTTP({0xc0001c1560?}, {0x19ba090, 0xc0004fc0e0}, 0xc000298200)
        /usr/local/go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc000310140, {0x19bafc0, 0xc00051abd0})
        /usr/local/go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3071 +0x4db
```

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
