### PR TITLE
CLI flag to allow overriding of OSIE path

### DIFF
--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -86,6 +86,9 @@ type config struct {
 	kubeAPI string
 	// kubeNamespace is an override for the namespace the kubernetes client will watch.
 	kubeNamespace string
+	// osiePathOverride allows a completely custom path/URL to be specified for OSIE/Hook images
+	// This will bypass the hardcoded path appending of 'misc/osie/current' to the path
+	osiePathOverride string
 }
 
 func main() {
@@ -375,6 +378,7 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	fs.StringVar(&cfg.kubeconfig, "kubeconfig", "", "The Kubernetes config file location. Only applies if DATA_MODEL_VERSION=kubernetes.")
 	fs.StringVar(&cfg.kubeAPI, "kubernetes", "", "The Kubernetes API URL, used for in-cluster client construction. Only applies if DATA_MODEL_VERSION=kubernetes.")
 	fs.StringVar(&cfg.kubeNamespace, "kube-namespace", "", "An optional Kubernetes namespace override to query hardware data from.")
+	fs.StringVar(&cfg.osiePathOverride, "osie-path-override", "", "A custom URL for OSIE/Hook images.")
 
 	return &ffcli.Command{
 		Name:       name,
@@ -415,6 +419,7 @@ func (cf *config) registerInstallers() (job.Installers, error) {
 		env.Get("REGISTRY_USERNAME"),
 		env.Get("REGISTRY_PASSWORD"),
 		env.Bool("TINKERBELL_TLS", true),
+		cf.osiePathOverride,
 	)
 	i.RegisterDistro("discovery", o.BootScript("discover"))
 	i.RegisterDefaultInstaller(o.BootScript("default"))

--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -82,6 +82,7 @@ FLAGS
   -kubeconfig             The Kubernetes config file location. Only applies if DATA_MODEL_VERSION=kubernetes.
   -kubernetes             The Kubernetes API URL, used for in-cluster client construction. Only applies if DATA_MODEL_VERSION=kubernetes.
   -log-level              log level. (default "info")
+  -osie-path-override     A custom URL for OSIE/Hook images.
   -syslog-addr            IP and port to listen on for syslog messages. (default "%[1]v:514")
 `, defaultIP)
 	c := &config{}

--- a/installers/osie/ipxe_script_test.go
+++ b/installers/osie/ipxe_script_test.go
@@ -60,7 +60,7 @@ func TestScript(t *testing.T) {
 					s.Set("syslog_host", "127.0.0.1")
 					s.Set("ipxe_cloud_config", "packet")
 
-					Installer("", "", "", "", "", "", true).BootScript(action)(context.Background(), m.Job(), s)
+					Installer("", "", "", "", "", "", true, "").BootScript(action)(context.Background(), m.Job(), s)
 					got := string(s.Bytes())
 
 					arch := "aarch64"


### PR DESCRIPTION
Add CLI flag for overriding OSIE path

If an OSIE download path URL is specified via this fkag, OSIE_PATH and
MIRROR_HOST variables that are used to build OSIE URL will be ignored.
Hardcoded appending of 'misc/osie' and 'current' directories to the path
will be bypassed.

With the ongoing refactoring efforts, once all this hardcoded appending 
of paths is cleaned up, this flag can be removed/modified.


Signed-off-by: Pooja Trivedi <tripooja@amazon.com>

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
