### PR TITLE
Fix regression from data-model refactor

### DIFF
--- a/client/cacher/hardware_finder.go
+++ b/client/cacher/hardware_finder.go
@@ -1,6 +1,7 @@
 package cacher
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -8,7 +9,9 @@ import (
 	cacherClient "github.com/packethost/cacher/client"
 	"github.com/packethost/cacher/protos/cacher"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tinkerbell/boots/client"
+	"github.com/tinkerbell/boots/metrics"
 )
 
 // HardwareFinder is a type that can discover hardware from a cacher client.
@@ -64,4 +67,42 @@ func (f *HardwareFinder) ByMAC(ctx context.Context, mac net.HardwareAddr, _ net.
 	}
 
 	return d, nil
+}
+
+// GetDiscoveryFromEM is called when Cacher returns an empty response for the MAC address.
+// It does a POST to the Packet API /staff/cacher/hardware-discovery endpoint.
+// This was split out from DiscoverHardwareFromDHCP to make the control flow easier to understand.
+func GetDiscoveryFromEM(ctx context.Context, reporter client.Reporter, mac net.HardwareAddr, giaddr net.IP, circuitID string) (client.Discoverer, error) {
+	if giaddr == nil {
+		return nil, errors.New("missing MAC address")
+	}
+
+	labels := prometheus.Labels{"from": "dhcp"}
+	metrics.HardwareDiscovers.With(labels).Inc()
+	metrics.DiscoversInProgress.With(labels).Inc()
+	defer metrics.DiscoversInProgress.With(labels).Dec()
+	discoverTimer := prometheus.NewTimer(metrics.DiscoverDuration.With(labels))
+	defer discoverTimer.ObserveDuration()
+
+	req := struct {
+		MAC       string `json:"mac"`
+		GIADDR    string `json:"giaddr,omitempty"`
+		CIRCUITID string `json:"circuit_id,omitempty"`
+	}{
+		MAC:       mac.String(),
+		GIADDR:    giaddr.String(),
+		CIRCUITID: circuitID,
+	}
+
+	b, err := json.Marshal(&req)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshalling api discovery")
+	}
+
+	res := &DiscoveryCacher{}
+	if err := reporter.Post(ctx, "/staff/cacher/hardware-discovery", "application/json", bytes.NewReader(b), res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/client/cacher/hardware_finder.go
+++ b/client/cacher/hardware_finder.go
@@ -16,17 +16,18 @@ import (
 
 // HardwareFinder is a type that can discover hardware from a cacher client.
 type HardwareFinder struct {
-	cc cacher.CacherClient
+	cc       cacher.CacherClient
+	reporter client.Reporter
 }
 
 // NewHardwareFinder returns a github.com/packethost/cacher/client Finder.
-func NewHardwareFinder(facility string) (*HardwareFinder, error) {
+func NewHardwareFinder(facility string, reporter client.Reporter) (*HardwareFinder, error) {
 	cc, err := cacherClient.New(facility)
 	if err != nil {
 		return nil, errors.Wrap(err, "connect to cacher")
 	}
 
-	return &HardwareFinder{cc}, nil
+	return &HardwareFinder{cc, reporter}, nil
 }
 
 // ByIP returns a Discoverer for a particular IP.

--- a/client/cacher/hardware_finder_test.go
+++ b/client/cacher/hardware_finder_test.go
@@ -56,7 +56,7 @@ func TestByIP(t *testing.T) {
 			cc := mockcacher.NewMockCacherClient(mockCtrl)
 			cc.EXPECT().ByIP(context.Background(), &cacher.GetRequest{IP: ip.String()}).Times(1).Return(tc.resp, tc.respErr)
 
-			cf := HardwareFinder{cc}
+			cf := HardwareFinder{cc, nil}
 			d, err := cf.ByIP(context.Background(), ip)
 
 			if err != nil {
@@ -128,7 +128,7 @@ func TestByMAC(t *testing.T) {
 			cc := mockcacher.NewMockCacherClient(mockCtrl)
 			cc.EXPECT().ByMAC(context.Background(), &cacher.GetRequest{MAC: mac.String()}).Times(1).Return(tc.resp, tc.respErr)
 
-			cf := HardwareFinder{cc}
+			cf := HardwareFinder{cc, nil}
 			d, err := cf.ByMAC(context.Background(), mac, nil, "")
 
 			if err != nil {

--- a/client/noop_reporter.go
+++ b/client/noop_reporter.go
@@ -51,6 +51,10 @@ func (c *noOpReporter) UpdateInstance(ctx context.Context, id string, body io.Re
 	return nil
 }
 
+func (c *noOpReporter) Post(ctx context.Context, ref, mime string, body io.Reader, v interface{}) error {
+	return nil
+}
+
 // NewNoOpReporter returns a reporter that does nothing. This is used for the
 // Tinkerbell and standalone backends.
 func NewNoOpReporter(logger log.Logger) Reporter {

--- a/client/reporter.go
+++ b/client/reporter.go
@@ -17,4 +17,6 @@ type Reporter interface {
 	PostInstanceFail(ctx context.Context, id string, body io.Reader) error
 	PostInstancePassword(ctx context.Context, id, pass string) error
 	UpdateInstance(ctx context.Context, id string, body io.Reader) error
+
+	Post(ctx context.Context, ref, mime string, body io.Reader, v interface{}) error
 }

--- a/cmd/boots/main.go
+++ b/cmd/boots/main.go
@@ -118,7 +118,7 @@ func main() {
 	if err != nil {
 		mainlog.Fatal(err)
 	}
-	workflowFinder, finder, err := getFinders(l, cfg)
+	workflowFinder, finder, err := getFinders(l, cfg, reporter)
 	if err != nil {
 		mainlog.Fatal(err)
 	}
@@ -221,14 +221,14 @@ func main() {
 	}
 }
 
-func getFinders(l log.Logger, c *config) (client.WorkflowFinder, client.HardwareFinder, error) {
+func getFinders(l log.Logger, c *config, reporter client.Reporter) (client.WorkflowFinder, client.HardwareFinder, error) {
 	var hf client.HardwareFinder
 	var wf client.WorkflowFinder = &client.NoOpWorkflowFinder{}
 	var err error
 
 	switch os.Getenv("DATA_MODEL_VERSION") {
 	case "":
-		hf, err = cacher.NewHardwareFinder(os.Getenv("FACILITY_CODE"))
+		hf, err = cacher.NewHardwareFinder(os.Getenv("FACILITY_CODE"), reporter)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
## Description

An EM specific regression popped up due to #255 where `GetDiscoveryFromEM` isn't being called anymore (color me surprised thats all we noticed :smile:). This fixes it and adds some tests for the fallback behavior.

## Why is this needed

Reinstates the cacher mode behavior of falling back to trying to fetch some data from EMAPI.

## How Has This Been Tested?

Unit tests. Ran against cacher/emapi using sandbox.

## How are existing users impacted? What migration steps/scripts do we need?

No more missing fallback for EM.
