### PR TITLE
flatcar installer: Use vendor services url to download OS images

### DIFF
--- a/installers/flatcar/installer.go
+++ b/installers/flatcar/installer.go
@@ -10,8 +10,8 @@ import (
 
 func getInstallOpts(j job.Job, channel, facilityCode string) string {
 	base := map[bool]string{
-		true:  "http://install." + facilityCode + ".packet.net/flatcar/arm64-usr/" + channel,
-		false: "http://install." + facilityCode + ".packet.net/flatcar/amd64-usr/" + channel,
+		true:  conf.OsieVendorServicesURL + "/flatcar/arm64-usr/" + channel,
+		false: conf.OsieVendorServicesURL + "/flatcar/amd64-usr/" + channel,
 	}
 	args := []string{
 		"-V current",

--- a/installers/flatcar/installer_test.go
+++ b/installers/flatcar/installer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/installers/flatcar/files/ignition"
 	"github.com/tinkerbell/boots/job"
 )
@@ -59,7 +60,7 @@ var baseEnd = []string{
 
 var Exec = []string{
 	`ExecStart=/usr/bin/curl --retry 10 -H "Content-Type: application/json" -X POST -d '{"type":"provisioning.106"}' ${phone_home_url}`,
-	"ExecStart=/usr/bin/flatcar-install -V current -C alpha -b http://install." + facility + ".packet.net/flatcar/amd64-usr/alpha -o packet -s",
+	"ExecStart=/usr/bin/flatcar-install -V current -C alpha -b " + conf.OsieVendorServicesURL + "/flatcar/amd64-usr/alpha -o packet -s",
 	"ExecStart=/usr/bin/udevadm settle",
 	"ExecStart=/usr/bin/mkdir -p /oemmnt",
 	"ExecStart=/usr/bin/mount /dev/disk/by-label/OEM /oemmnt",

--- a/installers/flatcar/ipxe_script_test.go
+++ b/installers/flatcar/ipxe_script_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
+	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
 )
@@ -61,7 +62,7 @@ param type provisioning.104.01
 imgfetch ${tinkerbell}/phone-home##params
 imgfree
 
-set base-url http://install.` + facility + `.packet.net/misc/tinkerbell
+set base-url ` + conf.OsieVendorServicesURL + `/flatcar
 kernel ${base-url}/flatcar_production_pxe.vmlinuz console=ttyS1,115200n8 console=tty0 vga=773 initrd=flatcar_production_pxe_image.cpio.gz bonding.max_bonds=0 flatcar.autologin flatcar.first_boot=1 flatcar.config.url=${tinkerbell}/flatcar/ignition.json systemd.setenv=phone_home_url=${tinkerbell}/phone-home
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot
@@ -82,7 +83,7 @@ param type provisioning.104.01
 imgfetch ${tinkerbell}/phone-home##params
 imgfree
 
-set base-url http://install.` + facility + `.packet.net/misc/tinkerbell
+set base-url ` + conf.OsieVendorServicesURL + `/flatcar
 kernel ${base-url}/flatcar-arm.vmlinuz console=ttyAMA0,115200 initrd=flatcar-arm.cpio.gz bonding.max_bonds=0 flatcar.autologin flatcar.first_boot=1 flatcar.config.url=${tinkerbell}/flatcar/ignition.json systemd.setenv=phone_home_url=${tinkerbell}/phone-home
 initrd ${base-url}/flatcar-arm.cpio.gz
 boot

--- a/installers/flatcar/main.go
+++ b/installers/flatcar/main.go
@@ -28,7 +28,7 @@ func (i installer) BootScript(string) job.BootScript {
 
 func bootScript(ctx context.Context, j job.Job, s *ipxe.Script) {
 	s.PhoneHome("provisioning.104.01")
-	s.Set("base-url", conf.MirrorBaseURL+"/misc/tinkerbell")
+	s.Set("base-url", conf.OsieVendorServicesURL+"/flatcar")
 	s.Kernel("${base-url}/" + kernelPath(j))
 
 	kernelParams(j, s)


### PR DESCRIPTION
This is part of an ongoing effort to consolidate the sources of OS images, and uses a base url from the Boots environment to be a bit less hard-coded.