### PR TITLE
vmware installer: Use vendor services url to download OS images

### DIFF
--- a/installers/vmware/ipxe_script_test.go
+++ b/installers/vmware/ipxe_script_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
+	"github.com/tinkerbell/boots/conf"
 	"github.com/tinkerbell/boots/ipxe"
 	"github.com/tinkerbell/boots/job"
 )
@@ -78,7 +79,7 @@ param type provisioning.104.01
 imgfetch ${tinkerbell}/phone-home##params
 imgfree
 
-set base-url http://install.ewr1.packet.net/vmware/%s
+set base-url ` + conf.OsieVendorServicesURL + `/vmware/%s
 kernel ${base-url}/mboot.c32 -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `},
@@ -98,7 +99,7 @@ param type provisioning.104.01
 imgfetch ${tinkerbell}/phone-home##params
 imgfree
 
-set base-url http://install.ewr1.packet.net/vmware/%s
+set base-url ` + conf.OsieVendorServicesURL + `/vmware/%s
 kernel ${base-url}/efi/boot/bootx64.efi -c ${base-url}/boot.cfg ks=${tinkerbell}/vmware/ks-esxi.cfg netdevice=00:00:ba:dd:be:ef ksdevice=00:00:ba:dd:be:ef
 boot
 `,

--- a/installers/vmware/main.go
+++ b/installers/vmware/main.go
@@ -52,7 +52,7 @@ func (i installer) BootScript(slug string) job.BootScript {
 
 func script(j job.Job, s *ipxe.Script, basePath string) {
 	s.PhoneHome("provisioning.104.01")
-	s.Set("base-url", conf.MirrorBaseURL+"/vmware/"+basePath)
+	s.Set("base-url", conf.OsieVendorServicesURL+"/vmware/"+basePath)
 	if j.IsUEFI() {
 		s.Kernel("${base-url}/efi/boot/bootx64.efi -c ${base-url}/boot.cfg")
 	} else {


### PR DESCRIPTION
This is part of an ongoing effort to consolidate the sources of OS images, and uses a base url from the Boots environment to be a bit less hard-coded.