### PR TITLE
support esxi 7.0.1+ root password hash changes

### DIFF
--- a/client/instance.go
+++ b/client/instance.go
@@ -33,6 +33,10 @@ type Instance struct {
 	// Only returned in the first 24 hours of a provision
 	PasswordHash string `json:"password_hash,omitempty"`
 
+	// CustomData is an additional JSON field included in metadata
+	// Typically in the format of map[string]interface{}, however this format is not required.
+	CustomData interface{} `json:"customdata,omitempty"`
+
 	Tags []string `json:"tags,omitempty"`
 	// Project
 	SSHKeys []string `json:"ssh_keys,omitempty"`

--- a/installers/vmware/testdata/ks_.txt
+++ b/installers/vmware/testdata/ks_.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_hint.txt
+++ b/installers/vmware/testdata/ks_hint.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/ks_vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -135,16 +135,10 @@ custom_data () {
         fi
 }
 
-set_root_pw() {
-	echo "Setting rootpw"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-}
-
 ## TODO: Consider validating customdata, but maybe the API is a better place for that
 
 sshset=$(custom_data "['sshd']['enabled']")
 sshpwauth=$(custom_data "['sshd']['pwauth']")
-rootpwcrypt=$(custom_data "['rootpwcrypt']")
 esxishellset=$(custom_data "['esxishell']['enabled']")
 kickstartfburl=$(custom_data "['kickstart']['firstboot_url']")
 kickstartfbshell=$(custom_data "['kickstart']['firstboot_shell']")
@@ -184,14 +178,6 @@ elif [ "$esxishellset" == "false" ]; then
 	vim-cmd hostsvc/stop_esx_shell
 else
 	echo "Skipping ESXishell config"
-fi
-
-# Custom root pass
-if [ "$rootpwcrypt" != "null" ]; then
-	echo "Using custom root pass"
-	set_root_pw "$rootpwcrypt" /etc/shadow
-else
-	echo "Skipping custom root pass"
 fi
 
 # Kickstart firstboot supplemental config URL

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -119,6 +119,15 @@ func (j Job) PasswordHash() string {
 	return j.instance.PasswordHash
 }
 
+// CustomData returns instance.CustomData.
+func (j Job) CustomData() interface{} {
+	if i := j.instance; i != nil && i.CustomData != nil {
+		return i.CustomData
+	}
+
+	return nil
+}
+
 func (j Job) OperatingSystem() *client.OperatingSystem {
 	if i := j.instance; i != nil {
 		if i.Rescue {

--- a/job/mock.go
+++ b/job/mock.go
@@ -132,6 +132,10 @@ func (m *Mock) SetPassword(string) {
 	m.instance.PasswordHash = "insecure"
 }
 
+func (m *Mock) SetCustomData(data interface{}) {
+	m.instance.CustomData = data
+}
+
 func (m *Mock) SetState(state string) {
 	hp := m.hardware
 	h, ok := hp.(*cacher.HardwareCacher)


### PR DESCRIPTION
## Description

The password on an instance is typically a generated password.
For VMWare an alternative password hash can be provided via the
instance's customdata field.

Previously the method for utilizing that override required manipulating the shadow file.
This method is no longer supported by vmware, as the shadow file is generated based off a database value.

The correct way to set the root password is through the kickstart file.
We already were setting the generated password, so we could simply add
the necessary logic to check for an overwritten password instead.

## Why is this needed

The previous hack of editing /etc/shadow no longer works as that file is overwritten at startup.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
