### PR TITLE
Upgrade ScottGarman from triage to push role

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,6 +11,8 @@ collaborators:
     permission: push
   - username: rgl
     permission: push
+  - username: ScottGarman
+    permission: push
   - username: tobert
     permission: push
   - username: tstromberg
@@ -21,8 +23,6 @@ collaborators:
   - username: displague
     permission: triage
   - username: mikemrm
-    permission: triage
-  - username: ScottGarman
     permission: triage
 
   # Note: `permission` is only valid on organization-owned repositories.


### PR DESCRIPTION
As work is ramping up to thin out/eliminate the Equinix Metal specific OS installers from the Boots codebase, I will likely be heavily involved in code review. This will allow my PR approvals to unblock merges.