### PR TITLE
Drop EMism - PArch

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -29,10 +29,9 @@ func Installer(dataModelVersion, tinkGRPCAuth, extraKernelArgs, registry, regist
 		"ip=dhcp",
 		"modules=loop,squashfs,sd-mod,usb-storage",
 		"alpine_repo=${base-url}/repo-${arch}/main",
-		"modloop=${base-url}/modloop-${parch}",
+		"modloop=${base-url}/modloop-${arch}",
 		"tinkerbell=${tinkerbell}",
 		"syslog_host=${syslog_host}",
-		"parch=${parch}",
 		"packet_action=${action}",
 		"packet_state=${state}",
 		"osie_vendors_url=" + conf.OsieVendorServicesURL,
@@ -140,17 +139,11 @@ func (i installer) discover(ctx context.Context, j job.Job, s *ipxe.Script) {
 
 func (i installer) setBootScript(ctx context.Context, action string, j job.Job, s *ipxe.Script) {
 	s.Set("arch", j.Arch())
-	s.Set("parch", j.PArch())
 	s.Set("bootdevmac", j.PrimaryNIC().String())
 	s.Set("base-url", osieBaseURL(i.osieURL, i.osieFullURLOverride, j))
 	s.Kernel("${base-url}/" + kernelPath(j))
 	i.kernelParams(ctx, action, j.HardwareState(), j, s)
 	s.Initrd("${base-url}/" + initrdPath(j))
-
-	if j.PArch() == "hua" || j.PArch() == "2a2" {
-		// Workaround for Huawei firmware crash
-		s.Sleep(15)
-	}
 
 	s.Boot()
 }
@@ -231,7 +224,7 @@ func kernelPath(j job.Job) string {
 		return path
 	}
 
-	return "vmlinuz-${parch}"
+	return "vmlinuz-${arch}"
 }
 
 func initrdPath(j job.Job) string {
@@ -239,7 +232,7 @@ func initrdPath(j job.Job) string {
 		return path
 	}
 
-	return "initramfs-${parch}"
+	return "initramfs-${arch}"
 }
 
 func isCustomOSIE(j job.Job) bool {

--- a/job/dhcp.go
+++ b/job/dhcp.go
@@ -132,8 +132,6 @@ func (j Job) setPXEFilename(rep *dhcp4.Packet, isTinkerbellIPXE, isARM, isUEFI, 
 	case !isTinkerbellIPXE:
 		httpPrefix = j.IpxeBaseURL
 		switch {
-		case j.PArch() == "hua" || j.PArch() == "2a2":
-			filename = "snp.efi"
 		case isARM:
 			filename = "snp.efi"
 		case isUEFI:

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -61,14 +61,6 @@ func TestSetPXEFilename(t *testing.T) {
 			filename: "undionly.kpxe",
 		},
 		{
-			name: "hua",
-			plan: "hua", filename: "snp.efi",
-		},
-		{
-			name: "2a2",
-			plan: "2a2", filename: "snp.efi",
-		},
-		{
 			name: "arm",
 			arm:  true, filename: "snp.efi",
 		},

--- a/job/helpers.go
+++ b/job/helpers.go
@@ -40,29 +40,6 @@ func (j Job) BootDriveHint() string {
 	return ""
 }
 
-func (j Job) PArch() string {
-	var parch string
-
-	switch j.PlanSlug() {
-	case "baremetal_2a2", "c1.large.arm.xda":
-		parch = "2a2"
-	case "baremetal_2a4":
-		parch = "tx2"
-	case "baremetal_2a5":
-		parch = "qcom"
-	case "baremetal_hua":
-		parch = "hua"
-	case "c2.large.arm", "c2.large.anbox":
-		parch = "amp"
-	}
-
-	if parch != "" {
-		return parch
-	}
-
-	return j.Arch()
-}
-
 func (j Job) InstanceID() string {
 	if i := j.instance; i != nil {
 		return i.ID


### PR DESCRIPTION
## Description

Drops all use of parch.

## Why is this needed

Gets rid of an EMism and makes it so we only ever boot one kernel per cpu arch.

## How Has This Been Tested?

Unit tests and ran in EM. Non-EM was never affected.