### PR TITLE
unify AllowPXE so checks are consistent

### DIFF
--- a/cmd/boots/http.go
+++ b/cmd/boots/http.go
@@ -158,7 +158,7 @@ func (h *jobHandler) serveJobFile(w http.ResponseWriter, req *http.Request) {
 	// 2. the network.interfaces[].netboot.allow_pxe value, in the tink server hardware record, equal to true
 	// This allows serving custom ipxe scripts, starting up into OSIE or other installation environments
 	// without a tink workflow present.
-	if !j.AllowPxe() {
+	if !j.AllowPXE() {
 		w.WriteHeader(http.StatusNotFound)
 		mainlog.With("client", req.RemoteAddr).Info("the hardware data for this machine, or lack there of, does not allow it to pxe; allow_pxe: false")
 

--- a/job/dhcp_test.go
+++ b/job/dhcp_test.go
@@ -158,7 +158,7 @@ func TestAllowPXE(t *testing.T) {
 					AllowPXE: tt.instance,
 				},
 			}
-			got := j.isPXEAllowed()
+			got := j.AllowPXE()
 			if got != tt.want {
 				t.Fatalf("unexpected return, want: %t, got %t", tt.want, got)
 			}

--- a/job/job.go
+++ b/job/job.go
@@ -80,8 +80,15 @@ func NewInstallers() Installers {
 
 // AllowPxe returns the value from the hardware data
 // in tink server defined at network.interfaces[].netboot.allow_pxe.
-func (j Job) AllowPxe() bool {
-	return j.hardware.HardwareAllowPXE(j.mac)
+func (j Job) AllowPXE() bool {
+	if j.hardware.HardwareAllowPXE(j.mac) {
+		return true
+	}
+	if j.InstanceID() == "" {
+		return false
+	}
+
+	return j.instance.AllowPXE
 }
 
 // ProvisionerEngineName returns the current provisioning engine name


### PR DESCRIPTION
## Description

isPXEAllowed is checked in most locations internally to determine if
dhcp should hand off the ipxe image etc.

isPXEAllowed checks both the hardware and instance for whether it's
allowed to pxe.

AllowPXE on the other hand is used only for returning the auto.ipxe
script and only checks if the hardware is allowed to pxe.

This inconsistency allows dhcp to provide the ipxe image but then the
ipxe image fails to load the script if the instance AllowPXE is true
while hardware AllowPXE is false.

This change makes the AllowPXE check consistent everywhere.

## Why is this needed

Simplifies PXE checks

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
