### PR TITLE
Removing extra code specific to setting serial output for specific pl…

### DIFF
--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -204,17 +204,12 @@ func (i installer) kernelParams(ctx context.Context, action, _ string, j job.Job
 
 	var console string
 	if j.IsARM() {
+		// default serial console to ttyAMA0 for ARM.
 		console = "ttyAMA0"
-		if j.PlanSlug() == "baremetal_hua" {
-			console = "ttyS0"
-		}
 	} else {
 		s.Args("console=tty0")
-		if j.PlanSlug() == "d1p.optane.x86" || j.PlanSlug() == "d1f.optane.x86" || j.PlanSlug() == "w3amd.75xx24c.256.4320" {
-			console = "ttyS0"
-		} else {
-			console = "ttyS1"
-		}
+		// default serial console to ttyS1 for all other hardware.
+		console = "ttyS1"
 	}
 	s.Args("console=" + console + ",115200")
 }


### PR DESCRIPTION
…ans as plans do not map to specific hardware.

## Description

Plans do not match specifically to hardware and are causing some hardware to fail provisioning because of specific serial settings.

## How are existing users impacted? What migration steps/scripts do we need?

None

