### PR TITLE
fix vmware firstboot disk

### DIFF
--- a/installers/vmware/kickstart.go
+++ b/installers/vmware/kickstart.go
@@ -2,6 +2,7 @@ package vmware
 
 import (
 	"io"
+	"math"
 	"net/http"
 	"text/template"
 
@@ -386,7 +387,8 @@ func rootpw(j job.Job) string {
 func firstDisk(j job.Job) string {
 	// Always respect the boot drive hint if one is provided
 	if hint := j.BootDriveHint(); hint != "" {
-		return hint
+		// Truncating hint to 16 characters to match VMware kickstart limitation.
+		return hint[:int(math.Min(16, float64(len(hint))))]
 	}
 
 	return equinixPlanDisk(j.PlanSlug(), j.PlanVersionSlug())

--- a/installers/vmware/kickstart.go
+++ b/installers/vmware/kickstart.go
@@ -42,7 +42,7 @@ vmaccepteula
 rootpw --iscrypted {{ rootpw . }}
 # The install media is in the CD-ROM drive
 {{- if (firstDisk .) }}
-install --firstdisk={{ firstDisk . }} --overwritevmfs
+install --firstdisk="{{ firstDisk . }}" --overwritevmfs
 {{- else }}
 install --firstdisk --overwritevmfs
 {{- end }}

--- a/installers/vmware/kickstart_test.go
+++ b/installers/vmware/kickstart_test.go
@@ -40,6 +40,7 @@ func TestFirstDisk(t *testing.T) {
 		{slug: "x1.small.x86", hint: "hint", want: "hint"},
 		{slug: "arbitrary_name", hint: "hint", want: "hint"},
 		{slug: "x2.xlarge.x86", hint: "hint", want: "hint"},
+		{slug: "n3.xlarge.x86", hint: "KXG60ZNV256G TOSHIBA", want: "KXG60ZNV256G TOS"},
 	}
 
 	for _, tc := range tests {

--- a/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=KXG50ZNV256G_TOSHIBA,vmw_ahci --overwritevmfs
+install --firstdisk="KXG50ZNV256G_TOSHIBA,vmw_ahci" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot

--- a/installers/vmware/testdata/ks_hint.txt
+++ b/installers/vmware/testdata/ks_hint.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=hint --overwritevmfs
+install --firstdisk="hint" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot

--- a/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=lsi_mr3,lsi_msgpt3,vmw_ahci --overwritevmfs
+install --firstdisk="lsi_mr3,lsi_msgpt3,vmw_ahci" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot

--- a/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=lsi_mr3,vmw_ahci --overwritevmfs
+install --firstdisk="lsi_mr3,vmw_ahci" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot

--- a/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=vmw_ahci,lsi_mr3,lsi_msgpt3 --overwritevmfs
+install --firstdisk="vmw_ahci,lsi_mr3,lsi_msgpt3" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot

--- a/installers/vmware/testdata/ks_vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci.txt
@@ -4,7 +4,7 @@ vmaccepteula
 # Set the root password for the DCUI and Tech Support Mode
 rootpw --iscrypted insecure
 # The install media is in the CD-ROM drive
-install --firstdisk=vmw_ahci --overwritevmfs
+install --firstdisk="vmw_ahci" --overwritevmfs
 # Set the network to DHCP on the proper network adapter based on its type
 network --bootproto=dhcp --device=00:00:ba:dd:be:ef
 reboot


### PR DESCRIPTION
## Description

A first disk hint may have a space which would break the option.

Additionally, vmware truncates the model version to 16 characters.

## Why is this needed

The drive reported model may contain a space which if provided as a hint would break this command.

If the model in the hint is longer than 16 characters we need to truncate to match vmware expectation.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
