### PR TITLE
Remove iSCSI and IQN config

### DIFF
--- a/installers/vmware/kickstart.go
+++ b/installers/vmware/kickstart.go
@@ -66,11 +66,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_.txt
+++ b/installers/vmware/testdata/ks_.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_KXG50ZNV256G_TOSHIBA,vmw_ahci.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_hint.txt
+++ b/installers/vmware/testdata/ks_hint.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,lsi_msgpt3,vmw_ahci.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_lsi_mr3,vmw_ahci.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci,lsi_mr3,lsi_msgpt3.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/ks_vmw_ahci.txt
+++ b/installers/vmware/testdata/ks_vmw_ahci.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys

--- a/installers/vmware/testdata/vmware_base.txt
+++ b/installers/vmware/testdata/vmware_base.txt
@@ -24,11 +24,6 @@ vim-cmd hostsvc/start_esx_shell
 # Add private network interface
 esxcli network vswitch standard portgroup add --portgroup-name='Private Network' --vswitch-name=vSwitch0
 esxcli network ip interface add --interface-name=vmk1 --portgroup-name='Private Network'
-# Set the iSCSI IQN
-iqn=$(cat /tmp/metadata | python -c "import sys, json; print(json.load(sys.stdin)['iqn'])")
-esxcli iscsi software set --enabled=true
-esxcli iscsi adapter set -A vmhba64 -n $iqn
-esxcli iscsi networkportal add -n vmk1 -A vmhba64
 # Configure IP addresses statically from metadata using python
 cat >> /tmp/netcfg.py <<EOF
 import sys


### PR DESCRIPTION
## Description
This PR removes the additional iSCSI and IQN config that was previously required to support a specific third-party storage provider which has since been decommissioned.

## Why is this needed

The base level iSCSI config interferes with VMware ESXi users who are using their own iSCSI storage solutions.

Fixes: #

## How Has This Been Tested?
Testing via CI


## How are existing users impacted? What migration steps/scripts do we need?
Fixes a customer issue relating to iSCSI storage.
Requires a customer notification before deployment.


## Checklist:

I have:

- [X ] updated the documentation and/or roadmap (if required)
- [X ] added unit or e2e tests
- [X] provided instructions on how to upgrade
