### PR TITLE
Split docker build and push into different steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: compile binaries
         run: nix-shell --run 'make crosscompile'
 
-      - name: Docker Image Tag for Sha
+      - name: Figure out Docker Tags
         id: docker-image-tag
         run: |
           echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
@@ -64,6 +64,17 @@ jobs:
           context: ./
           file: ./Dockerfile
           cache-from: type=registry,ref=quay.io/tinkerbell/boots:latest
-          push: ${{ startsWith(github.ref, 'refs/heads/main') }}
-          tags: ${{ steps.docker-image-tag.outputs.tags }}
           platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker-image-tag.outputs.tags }}
+
+      # looks just like Build Docker Images except with push:true and this will only run for builds for main
+      - name: Push Docker Images
+        uses: docker/build-push-action@v3
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        with:
+          context: ./
+          file: ./Dockerfile
+          cache-from: type=registry,ref=quay.io/tinkerbell/boots:latest
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker-image-tag.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           lfs: true
 
       - name: Install nix
-        uses: cachix/install-nix-action@v17
+        uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
@@ -31,7 +31,7 @@ jobs:
         run: nix-shell --run 'go get -t ./... && go mod tidy'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Generate all files
         run: nix-shell --run 'make -j1 gen'
@@ -51,7 +51,7 @@ jobs:
           echo ::set-output name=tags::quay.io/tinkerbell/boots:latest,quay.io/tinkerbell/boots:sha-${GITHUB_SHA::8}
 
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         with:
           registry: quay.io
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build Docker Images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate Release Notes
         run: |
           release_notes=$(gh api repos/{owner}/{repo}/releases/generate-notes -F tag_name=${{ github.ref }} --jq .body)
@@ -25,7 +25,7 @@ jobs:
 
       - name: Docker manager metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false


### PR DESCRIPTION
## Description

Split container build and push to different steps to avoid confusion.

## Why is this needed

We recently tried deploy a tag that was never pushed to quay because we didn't notice it was for a PR and not for a build off of main. It seems like a good idea to avoid having to go digging into the build's output and try to figure out if it was actually pushed or not.

## How Has This Been Tested?

CI.
