### PR TITLE
Add a namespace for the cluster client

### DIFF
--- a/client/kubernetes/cluster.go
+++ b/client/kubernetes/cluster.go
@@ -26,7 +26,7 @@ const (
 // * Workflows by worker address
 //
 // Callers must instantiate the client-side cache by calling Start() before use.
-func NewCluster(config *rest.Config) (cluster.Cluster, error) {
+func NewCluster(config *rest.Config, namespace string) (cluster.Cluster, error) {
 	runtimescheme := runtime.NewScheme()
 
 	err := clientgoscheme.AddToScheme(runtimescheme)
@@ -41,6 +41,7 @@ func NewCluster(config *rest.Config) (cluster.Cluster, error) {
 
 	c, err := cluster.New(config, func(o *cluster.Options) {
 		o.Scheme = runtimescheme
+		o.Namespace = namespace
 	})
 	if err != nil {
 		return nil, err

--- a/client/kubernetes/hardware_finder.go
+++ b/client/kubernetes/hardware_finder.go
@@ -46,7 +46,7 @@ func NewFinder(logger log.Logger, k8sAPI, kubeconfig, kubeNamespace string) (*Fi
 		return nil, err
 	}
 
-	cluster, err := NewCluster(config)
+	cluster, err := NewCluster(config, kubeNamespace)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/client/kubernetes/hardware_finder.go
+++ b/client/kubernetes/hardware_finder.go
@@ -27,7 +27,7 @@ type Finder struct {
 //
 // Callers must instantiate the client-side cache by calling Start() before use.
 func NewFinder(logger log.Logger, k8sAPI, kubeconfig, kubeNamespace string) (*Finder, error) {
-	// TODO(moadqassem): Maybe use the tinkerbell kubecleint instead of using this cluster client similar to hegel.
+	// TODO(moadqassem): Maybe use the tinkerbell kubeclient instead of using this cluster client similar to hegel.
 	ccfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: kubeconfig,
@@ -42,12 +42,7 @@ func NewFinder(logger log.Logger, k8sAPI, kubeconfig, kubeNamespace string) (*Fi
 		},
 	)
 
-	config, err := ccfg.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	cluster, err := NewCluster(config, kubeNamespace)
+	cluster, err := NewCluster(ccfg)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/client/kubernetes/hardware_finder.go
+++ b/client/kubernetes/hardware_finder.go
@@ -27,6 +27,7 @@ type Finder struct {
 //
 // Callers must instantiate the client-side cache by calling Start() before use.
 func NewFinder(logger log.Logger, k8sAPI, kubeconfig, kubeNamespace string) (*Finder, error) {
+	// TODO(moadqassem): Maybe use the tinkerbell kubecleint instead of using this cluster client similar to hegel.
 	ccfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: kubeconfig,


### PR DESCRIPTION
## Description
Currently, the kube client for boots needs a cluster role permission to fetch Hardware and Workflow CRs, even if the resources and the client are namespaced. This will lead to extending boots rbac to cluster role instead of using namespaced roles. It seems that, the current client creation doesn't scope the client to a namespace(the rest config type that is returned doesn't have a context, thus there will be no Namespace scoped anywhere in the client).     
<!--- Please describe what this PR is going to change -->

## Why is this needed
Enabling kube client operation on Namespaced scoped resources
<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran against a live cluster and the indexer succeeded to list the needed resources. 

## How are existing users impacted? What migration steps/scripts do we need?
They are not as they can pass whatever rbacs they like, based on their setup. 
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
