### PR TITLE
Don't add kernel arg `ip=dhcp` for tagged vlans:

### DIFF
--- a/installers/osie/ipxe_script_test.go
+++ b/installers/osie/ipxe_script_test.go
@@ -146,12 +146,12 @@ var action2Plan2Body = map[string]map[string]string{
 
 var discoverBodies = map[string]string{
 	"c3.small.x86": `
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
 	"c3.large.arm": `
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 initrd=initramfs-${arch} console=ttyAMA0,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 initrd=initramfs-${arch} console=ttyAMA0,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
@@ -160,19 +160,19 @@ boot
 var installBodies = map[string]string{
 	"c3.small.x86": `
 set base-url http://install.` + facility + `.packet.net/misc/osie/current
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt plan=c3.small.x86 manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt plan=c3.small.x86 manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
 	"c3.large.arm": `
 set base-url http://install.` + facility + `.packet.net/misc/osie/current
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 plan=c3.large.arm manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=ttyAMA0,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 plan=c3.large.arm manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=ttyAMA0,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
 	"custom-osie": `
 set base-url http://install.` + facility + `.packet.net/misc/osie/osie-v18.08.13.00
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=ewr1 intel_iommu=on iommu=pt plan=custom-osie manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=ewr1 intel_iommu=on iommu=pt plan=custom-osie manufacturer=supermicro slug=ubuntu_16_04 initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
@@ -180,12 +180,12 @@ boot
 
 var rescueBodies = map[string]string{
 	"c3.small.x86": `
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,
 	"c3.large.arm": `
-kernel ${base-url}/vmlinuz-${arch} ip=dhcp modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 initrd=initramfs-${arch} console=ttyAMA0,115200
+kernel ${base-url}/vmlinuz-${arch} modules=loop,squashfs,sd-mod,usb-storage tinkerbell=${tinkerbell} syslog_host=${syslog_host} osie_vendors_url=https://localhost ip=dhcp packet_base_url=${base-url} facility=` + facility + ` iommu.passthrough=1 initrd=initramfs-${arch} console=ttyAMA0,115200
 initrd ${base-url}/initramfs-${arch}
 boot
 `,

--- a/installers/osie/main.go
+++ b/installers/osie/main.go
@@ -23,7 +23,6 @@ type installer struct {
 // Installer instantiates a new osie installer.
 func Installer(dataModelVersion, tinkGRPCAuth, extraKernelArgs, registry, registryUsername, registryPassword string, tinkTLS bool, osiePathOverride string, dynamicIPXEVars [][]string) job.BootScripter {
 	defaultParams := []string{
-		"ip=dhcp",
 		"modules=loop,squashfs,sd-mod,usb-storage",
 		"tinkerbell=${tinkerbell}",
 		"syslog_host=${syslog_host}",
@@ -144,6 +143,9 @@ func (i installer) kernelParams(ctx context.Context, action, _ string, j job.Job
 
 	if j.VLANID() != "" {
 		s.Args("vlan_id=" + j.VLANID())
+		s.Args("hw_addr=${mac}")
+	} else {
+		s.Args("ip=dhcp")
 	}
 
 	if j.CanWorkflow() {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When tagged VLANs are enabled `ip=dhcp` in the kernel will always fail as the vlan interface hasn't been created yet. It also has to timeout before moving on and add significant delay to Hook's boot up time. The kernel arg `hw_addr` has been added to help in creation of the tagged interface.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
