### PR TITLE
Expose ipxedust script patching feature

### DIFF
--- a/cmd/boots/main_test.go
+++ b/cmd/boots/main_test.go
@@ -160,6 +160,7 @@ FLAGS
   -ipxe-enable-tftp       enable serving iPXE binaries via TFTP. (default "true")
   -ipxe-remote-http-addr  remote IP and port where iPXE binaries are served via HTTP. Overrides -http-addr for iPXE binaries only.
   -ipxe-remote-tftp-addr  remote IP where iPXE binaries are served via TFTP. Overrides -tftp-addr.
+  -ipxe-script-patch      iPXE script fragment to patch into served iPXE binaries served via TFTP and HTTP
   -ipxe-tftp-addr         local IP and port to listen on for serving iPXE binaries via TFTP (port must be 69). (default "0.0.0.0:69")
   -ipxe-tftp-timeout      local iPXE TFTP server requests timeout. (default "5s")
   -ipxe-vars              additional variable definitions to include in all iPXE installer scripts. Separate multiple var definitions with spaces, e.g. 'var1=val1 var2=val2'.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35
 	github.com/stretchr/testify v1.8.0
-	github.com/tinkerbell/ipxedust v0.0.0-20230118215055-b00d1b371ddf
+	github.com/tinkerbell/ipxedust v0.0.0-20230210031627-6cd69ece53f3
 	github.com/tinkerbell/tink v0.7.1-0.20220916173048-e3975fbcf4e1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.29.0
 	go.opentelemetry.io/otel v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -667,8 +667,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tinkerbell/ipxedust v0.0.0-20230118215055-b00d1b371ddf h1:Q7OkknxWEEIEbEcx7hT5+8FcKkOldiZ6P/NfkSysc7g=
-github.com/tinkerbell/ipxedust v0.0.0-20230118215055-b00d1b371ddf/go.mod h1:4TMjBQjpeLxfOb09nOf1RYiVRr1z5ZVw8eDuf6Pu5hw=
+github.com/tinkerbell/ipxedust v0.0.0-20230210031627-6cd69ece53f3 h1:DQT7al3vvIy9tKDm5jg2ewLJyXCibgHJEdHRGqaTEK0=
+github.com/tinkerbell/ipxedust v0.0.0-20230210031627-6cd69ece53f3/go.mod h1:4TMjBQjpeLxfOb09nOf1RYiVRr1z5ZVw8eDuf6Pu5hw=
 github.com/tinkerbell/tink v0.7.1-0.20220916173048-e3975fbcf4e1 h1:K0bl3z+Lj7quCv0axvJo6sWc0ZW5u3pyZ+wG8jh3BPo=
 github.com/tinkerbell/tink v0.7.1-0.20220916173048-e3975fbcf4e1/go.mod h1:bfAkSH7J/QQYIyqZRR6IQp8w78aac6l8Z2Lws5uXz6A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
## Description

Update ipxedust and exposes the binary patching functionality added in https://github.com/tinkerbell/ipxedust/pull/63

## Why is this needed

New feature

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
