### PR TITLE
Increase syslog buffer size, fix key/value mapping:

### DIFF
--- a/syslog/message.go
+++ b/syslog/message.go
@@ -53,7 +53,7 @@ const (
 )
 
 type message struct {
-	buf  [1024]byte
+	buf  [2048]byte
 	size int
 	time time.Time
 	host net.IP

--- a/syslog/receiver.go
+++ b/syslog/receiver.go
@@ -149,9 +149,9 @@ func (r *Receiver) runParser() {
 			structured := parse(m)
 			sl := r.Logger.WithValues("msg", structured)
 			if m.Severity() == DEBUG {
-				sl.V(1).Info("msg", "msg", m)
+				sl.V(1).Info("msg")
 			} else {
-				sl.Info("msg", "msg", m)
+				sl.Info("msg")
 			}
 		} else {
 			r.Logger.V(1).Info("msg", "msg", m)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The current syslog buffer size of 1024 was not enough to capture log messages from tink-worker. Also fixed the output of logs to not overwrite the structure key "msg".

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
