### PR TITLE
Remove kernel parameter ip=dhcp in auto.ipxe:

### DIFF
--- a/ipxe/script/auto_test.go
+++ b/ipxe/script/auto_test.go
@@ -33,7 +33,7 @@ echo Loading the Tinkerbell Hook iPXE script...
 set arch x86_64
 set download-url http://location:8080/to/kernel/and/initrd
 
-kernel ${download-url}/vmlinuz-${arch} ip=dhcp tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet \
+kernel ${download-url}/vmlinuz-${arch} tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet \
 facility=onprem syslog_host=1.2.3.4 grpc_authority=1.2.3.4:42113 tinkerbell_tls=false worker_id=3c:ec:ef:4c:4f:54 hw_addr=3c:ec:ef:4c:4f:54 \
 modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 

--- a/ipxe/script/hook.go
+++ b/ipxe/script/hook.go
@@ -11,7 +11,7 @@ echo Debug TraceID: {{ .TraceID }}
 set arch {{ .Arch }}
 set download-url {{ .DownloadURL }}
 
-kernel ${download-url}/vmlinuz-${arch} {{- if ne .VLANID "" }} vlan_id={{ .VLANID }} {{- else }} ip=dhcp {{- end }} {{- range .ExtraKernelParams}} {{.}} {{- end}} \
+kernel ${download-url}/vmlinuz-${arch} {{- if ne .VLANID "" }} vlan_id={{ .VLANID }} {{- end }} {{- range .ExtraKernelParams}} {{.}} {{- end}} \
 facility={{ .Facility }} syslog_host={{ .SyslogHost }} grpc_authority={{ .TinkGRPCAuthority }} tinkerbell_tls={{ .TinkerbellTLS }} worker_id={{ .WorkerID }} hw_addr={{ .HWAddr }} \
 modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When a machine had multiple interfaces that weren't all plugged in, this would cause significant delay in booting into Hook.

If necessary, this value can be added back in via the `-extra-kernel-args` cli flag.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
